### PR TITLE
Fix computation of extracted string length

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -276,7 +276,7 @@ int main(int argc, char* argv[], char** envp)
 
 	// optional seccomp filter flag
 	if  (flag_index < argc && strncmp("--filter_lib=", argv[flag_index], sizeof("--filter_lib=") - 1) == 0) {
-		__rr_flags.filter_lib_path = sys_malloc(strlen(argv[flag_index]) - sizeof("--filter_lib=") + 1);
+		__rr_flags.filter_lib_path = sys_malloc(strlen(argv[flag_index]) - (sizeof("--filter_lib=") - 1) + 1);
 		sscanf(argv[flag_index],"--filter_lib=%s",__rr_flags.filter_lib_path);
 		flag_index++;
 	}


### PR DESCRIPTION
This was causing the assertion failure seen in #14.  (Aside: I want to start a discussion of C vs. C++ here in a bit .. ;).)
