### PR TITLE
Wrap up existing tests for consumption by automated infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
+CTestTestfile.cmake
 Debug
 Makefile
 Profile
 obj/
 .project
+*.record
+*.replay
 .settings/
+Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,15 @@
 cmake_minimum_required(VERSION 2.6)
 project(rr)
 
+enable_testing()
+set(BUILD_SHARED_LIBS ON)
+
 set(PROJECT_BINARY_DIR ${CMAKE_SOURCE_DIR}/obj)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
 set(rr_VERSION_MAJOR 0)
 set(rr_VERSION_MINOR 1)
-
-SET(BUILD_SHARED_LIBS ON)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g3 -Wall -m32")
 
@@ -46,3 +47,10 @@ target_link_libraries(rr
   pfm
   disasm
 )
+
+# TODO: probably want to manage the tests with the build system to
+# avoid unnecessary rebuilding etc.
+add_test(Tests "${CMAKE_SOURCE_DIR}/src/script/test.sh" "-dir=${CMAKE_SOURCE_DIR}/src/test" "-rr=${EXECUTABLE_OUTPUT_PATH}/rr")
+set_tests_properties(Tests PROPERTIES FAIL_REGULAR_EXPRESSION "FAILED")
+# Why isn't dumping output on failure default ...
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)

--- a/src/script/test.sh
+++ b/src/script/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Usage: test.sh [-dir=test_directory] [-rr=rr_command]"
 echo "Runs rr standard tests."
-echo "Default rr command is 'RecordReplayDebug'"
+echo "Default rr command is 'rr'"
 echo "Default test directory is '../test/'"
 echo "-----------------------------------------------------"
 
@@ -15,7 +15,7 @@ done
 
 # find the rr command, if not given
 if [ -z $rr ]; then
-	rr=RecordReplayDebug
+	rr=rr
 fi
 
 # find the tests dir, if not given
@@ -30,5 +30,3 @@ cd $dir
 for test in *.run; do
 	source $test $rr
 done
-
-

--- a/src/test/alarm.run
+++ b/src/test/alarm.run
@@ -2,6 +2,6 @@ source util.sh
 get_rr_cmd $# $1
 compile alarm
 record alarm
-replay alarm --redirect_output 
+replay alarm
 check alarm
-cleanup 
+cleanup

--- a/src/test/hello.run
+++ b/src/test/hello.run
@@ -2,6 +2,6 @@ source util.sh
 get_rr_cmd $# $1
 compile hello
 record hello
-replay hello --redirect_output 
+replay hello
 check hello
-cleanup 
+cleanup

--- a/src/test/segfault.run
+++ b/src/test/segfault.run
@@ -2,6 +2,6 @@ source util.sh
 get_rr_cmd $# $1
 compile segfault
 record segfault
-replay segfault --redirect_output 
+replay segfault
 check segfault
-cleanup 
+cleanup

--- a/src/test/simple.run
+++ b/src/test/simple.run
@@ -2,6 +2,6 @@ source util.sh
 get_rr_cmd $# $1
 compile simple
 record simple
-replay simple
+replay simple --no_redirect_output
 check simple
-cleanup 
+cleanup

--- a/src/test/threads.run
+++ b/src/test/threads.run
@@ -2,6 +2,6 @@ source util.sh
 get_rr_cmd $# $1
 compile threads -pthread
 record threads
-replay threads --redirect_output
+replay threads
 check threads
-cleanup 
+cleanup

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -42,7 +42,8 @@ function check {
 	fi
 }
 
-# cleanup
+# cleanup.  we intentionally leave .record/.replay files around for
+# developers to reference.
 function cleanup {
 	rm -rf a.out trace_0
 }


### PR DESCRIPTION
creates make test/check targets, and theoretically analogues for IDEs too.

Semantics preserving, just packaging up what's already there.  Also fixes tests that were broken by the --redirect_output => default patch.
