### PR TITLE
Handle SECCOMP_OBSELETE event for Ubuntu 12.04 compat (#45)

### DIFF
--- a/src/share/util.c
+++ b/src/share/util.c
@@ -1104,7 +1104,11 @@ int inject_and_execute_syscall(struct context * ctx, struct user_regs_struct * c
 	sys_ptrace_syscall(tid);
 	sys_waitpid(tid, &ctx->status);
 
-	if (GET_PTRACE_EVENT(ctx->status) == PTRACE_EVENT_SECCOMP) {
+	if (GET_PTRACE_EVENT(ctx->status) == PTRACE_EVENT_SECCOMP
+	    /* XXX this is a special case for ubuntu 12.04.  revisit
+	     * this check if an event is added with number 8 (just
+	     * after SECCOMP */
+	    || GET_PTRACE_EVENT(ctx->status) == PTRACE_EVENT_SECCOMP_OBSOLETE) {
 		sys_ptrace_syscall(tid);
 		sys_waitpid(tid, &ctx->status);
 	}

--- a/src/share/wrap_syscalls.c
+++ b/src/share/wrap_syscalls.c
@@ -386,8 +386,7 @@ int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
 	_syscall_post(epoll_wait)
 }
 
-/* TODO: the the socketcall API wrappers prevent firefox from starting
- * up properly. */
+/* TODO: the socketcall API can block, and we need to handle that better. */
 
 #define _copy_socketcall_args(arg0,arg1,arg2,arg3,arg4,arg5) \
 volatile long args[6] = { (long)arg0, (long)arg1, (long)arg2, (long)arg3, (long)arg4, (long)arg5 };
@@ -609,15 +608,17 @@ if (ret == 0) {										\
 }													\
 _syscall_post(call)
 
-int fstat(int fd, struct stat *buf){
+/* TODO: the stat API can block, and we need to handle that better. */
+
+int fstat_(int fd, struct stat *buf){
 	_stat(fstat64,fd,buf);
 }
 
-int lstat(const char *path, struct stat *buf) {
+int lstat_(const char *path, struct stat *buf) {
 	_stat(lstat64,path,buf);
 }
 
-int stat(const char *path, struct stat *buf){
+int stat_(const char *path, struct stat *buf){
 	_stat(stat64,path,buf);
 }
 


### PR DESCRIPTION
Firefox 24 hits this event during recording and aborts.  With this patch recording works again.

@rocallahan or @nimrodpar, would either of you care to take a look at this?  This is an area of the code I still feel a bit uncomfortable with.  In particular, I don't know how to write a test for this behavior.  I'm surprised the existing thread test doesn't hit it.
