### PR TITLE
Initial support for reading registers and memory.

### DIFF
--- a/src/share/ipc.c
+++ b/src/share/ipc.c
@@ -296,9 +296,12 @@ void* read_child_data_tid(pid_t tid, size_t size, long int addr)
 	return data;
 }
 
-size_t checked_pread(struct context *ctx, void *buf, size_t size,off_t offset) {
+ssize_t checked_pread(struct context *ctx, void *buf, size_t size,off_t offset) {
 	errno = 0;
-	size_t read = pread(ctx->child_mem_fd, buf, size, offset);
+	ssize_t read = pread(ctx->child_mem_fd, buf, size, offset);
+	if (read < 0) {
+		return read;
+	}
 
 	// for some reason reading from the child process requires to re-open the fd
 	// who knows why??

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -13,7 +13,7 @@ long read_child_data_word(pid_t pid, void* addr);
 void* read_child_data(struct context *ctx, size_t size, uintptr_t addr);
 void read_child_usr(struct context *ctx, void *dest, void *src, size_t size);
 void* read_child_data_checked(struct context *ctx, ssize_t size, uintptr_t addr, ssize_t *read_bytes);
-size_t checked_pread(struct context *ctx, void *buf, size_t size,off_t offset);
+ssize_t checked_pread(struct context *ctx, void *buf, size_t size,off_t offset);
 void memcpy_child(struct context *ctx, void *dest, void *src, int size);
 
 void write_child_code(pid_t pid, void* addr, long code);

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -228,7 +228,20 @@ void sys_ptrace_sysemu_singlestep(pid_t pid, int sig)
 	sys_ptrace(PTRACE_SYSEMU_SINGLESTEP, pid, 0, (void*)sig);
 }
 
+int sys_ptrace_peekdata(pid_t pid, long addr, long* value)
+{
+	long ret;
 
+	assert(0 == (addr & (sizeof(void*) - 1)));
+
+	errno = 0;
+	ret = ptrace(PTRACE_PEEKDATA, pid, addr, 0);
+	if (-1 == ret && errno) {
+		return -1;
+	}
+	*value = ret;
+	return 0;
+}
 
 unsigned long sys_ptrace_getmsg(pid_t pid)
 {
@@ -407,12 +420,8 @@ void* sys_malloc_zero(int size)
 
 void sys_free(void** ptr)
 {
-	if (*ptr == NULL) {
-		log_err("Failed to free memory at %p -- bailing out",*ptr);
-		sys_exit();
-	}
 	free(*ptr);
-	*ptr = 0;
+	*ptr = NULL;
 }
 
 void sys_setpgid(pid_t pid, pid_t pgid)

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -37,6 +37,8 @@ void sys_ptrace_sysemu_singlestep(pid_t pid, int sig);
 void sys_ptrace_traceme();
 void sys_ptrace_cont(pid_t pid);
 void sys_ptrace_syscall_sig(pid_t pid, int sig);
+/* Return zero on success, -1 on error. */
+int sys_ptrace_peekdata(pid_t pid, long addr, long* value);
 unsigned long sys_ptrace_getmsg(pid_t pid);
 void sys_ptrace_getsiginfo(pid_t pid, siginfo_t* sig);
 void sys_ptrace_detatch(pid_t pid);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -22,6 +22,9 @@
 #define PTRACE_EVENT_SECCOMP			7 // ubuntu 12.10 and future kernels
 #endif
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
 char* get_inst(pid_t pid, int eip_offset, int* opcode_size);
 bool is_write_mem_instruction(pid_t pid, int eip_offset, int* opcode_size);
 void emulate_child_inst(struct context * ctx, int eip_offset);


### PR DESCRIPTION
Memory reading is currently disabled, because gdb is requesting reads of
addresses that we can't read, and it gets upset when the read fails.  TODO.
