### PR TITLE
Add test for SIGILL, disabled since it's NYI

### DIFF
--- a/src/test/sigill.c
+++ b/src/test/sigill.c
@@ -1,0 +1,11 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	puts("running privileged instruction ...");
+	__asm__ ("ud2");
+	assert("should have terminated!" && 0);
+	return 0;
+}

--- a/src/test/sigill.run.disabled
+++ b/src/test/sigill.run.disabled
@@ -1,0 +1,7 @@
+source util.sh
+get_rr_cmd $# $1
+compile sigill
+record sigill
+replay sigill
+check sigill
+cleanup


### PR DESCRIPTION
Trivial, and not enabled :).
