### PR TITLE
Remove some unused code in replayer.c, split out advance-trace logic, and get warnings to 0

### DIFF
--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -748,8 +748,7 @@ static void process_socketcall(struct context* ctx, int state)
 	exit_syscall_emu(ctx, SYS_socketcall, num_emu_args);
 }
 
-void rep_process_syscall(struct context* ctx, int syscall,
-			 struct flags rr_flags)
+void rep_process_syscall(struct context* ctx, int syscall, int redirect_stdio)
 {
 	const struct syscall_def* def = &syscall_table[syscall];
 	pid_t tid = ctx->child_tid;
@@ -1029,7 +1028,7 @@ void rep_process_syscall(struct context* ctx, int syscall,
 			enter_syscall_emu(ctx, syscall);
 		} else {
 			exit_syscall_emu(ctx, syscall, 0);
-			if (rr_flags.redirect) {
+			if (redirect_stdio) {
 				/* print output intended for
 				 * stdout/stderr */
 				struct user_regs_struct regs;

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -8,6 +8,8 @@
 #include "../share/util.h"
 
 void rep_process_flush(struct context* ctx);
-void rep_process_syscall(struct context* context, int syscall , struct flags rr_flags);
+/* |redirect_stdio| is nonzero if output written to stdout/stderr
+ * during recording should be tee'd during replay, zero otherwise. */
+void rep_process_syscall(struct context* ctx, int syscall, int redirect_stdio);
 
 #endif /* REP_PROCESS_EVENT_H_ */


### PR DESCRIPTION
Straightforward small refactoring, -> automerge.
