### PR TITLE
Put framework for new control flow in place.

### DIFF
--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -3,13 +3,13 @@
 #ifndef REP_PROCESS_EVENT_H_
 #define REP_PROCESS_EVENT_H_
 
-#include "../share/types.h"
-#include "../share/trace.h"
-#include "../share/util.h"
+struct context;
+struct rep_trace_step;
 
 void rep_process_flush(struct context* ctx);
 /* |redirect_stdio| is nonzero if output written to stdout/stderr
  * during recording should be tee'd during replay, zero otherwise. */
-void rep_process_syscall(struct context* ctx, int syscall, int redirect_stdio);
+void rep_process_syscall(struct context* ctx, int redirect_stdio,
+			 struct rep_trace_step* step);
 
 #endif /* REP_PROCESS_EVENT_H_ */

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -8,4 +8,55 @@
 
 void replay(struct flags rr_flags);
 
+/**
+ * Describes the next step to be taken in order to replay a trace
+ * frame.
+ */
+struct rep_trace_step {
+	enum {
+		TSTEP_UNKNOWN,
+
+		/* Frame has been replayed, done. */
+		TSTEP_RETIRE,
+
+		/* Enter/exit a syscall.  |params.syscall| describe
+		 * what should be done at entry/exit. */
+		TSTEP_ENTER_SYSCALL,
+		TSTEP_EXIT_SYSCALL,
+
+		/* Advance to the synchronous signal
+		 * |params.signo|. */
+		TSTEP_SYNCHRONOUS_SIGNAL,
+
+		/* Advance until |params.interrupt.target_rcb| have
+		 * been retired and then |params.interrupt.target_ip|
+		 * is reached. */
+		TSTEP_PROGRAM_INTERRUPT,
+	} action;
+
+	union {
+		struct {
+			/* The syscall number we expect to
+			 * enter/exit. */
+			int no;
+			/* Is the kernel entry and exit for this
+			 * syscall emulated, that is, not executed? */
+			int emu;
+			/* The number of outparam arguments that are
+			 * set from what was recorded. */
+			size_t num_emu_args;
+			/* Nonzero if the return from the syscall
+			 * should be emulated.  |emu| implies this. */
+			int emu_ret;
+		} syscall;
+
+		int signo;
+
+		struct {
+			uint64_t target_rcb;
+			void* target_ip;
+		} slice;
+	} params;
+};
+
 #endif /* REPLAYER_H_ */


### PR DESCRIPTION
As of this commit, only regular syscalls use the new flow.  The other
execution steps will require significant extra work to use the changed
flow.  However, this puts enough in place to finish breakpoints, and
hopefully they'll "work" most of the time with only regular syscalls
aware of them.
