### PR TITLE
Implementation of breakpoints, with more refactoring.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -33,6 +33,7 @@ static int handle_sigsegv(struct context *ctx)
 	int retval = 0;
 	pid_t tid = ctx->child_tid;
 	int sig = signal_pending(ctx->status);
+	assert(sig != SIGTRAP);
 
 	if (sig <= 0 || sig != SIGSEGV) {
 		return retval;
@@ -70,6 +71,7 @@ static int handle_mmap_sigsegv(struct context *ctx)
 {
 	pid_t tid = ctx->child_tid;
 	int sig = signal_pending(ctx->status);
+	assert(sig != SIGTRAP);
 
 	if (sig <= 0 || sig != SIGSEGV) {
 		return 0;
@@ -159,6 +161,7 @@ static void record_signal(int sig, struct context* ctx)
 void handle_signal(struct context* ctx)
 {
 	int sig = signal_pending(ctx->status);
+	assert(sig != SIGTRAP);
 
 	if (sig <= 0) {
 		return;

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -146,6 +146,7 @@ static void cont_block(struct context *ctx)
 	sys_ptrace(PTRACE_CONT, ctx->child_tid, 0, (void*) ctx->child_sig);
 	sys_waitpid(ctx->child_tid, &ctx->status);
 	ctx->child_sig = signal_pending(ctx->status);
+	assert(ctx->child_sig != SIGTRAP);
 	read_child_registers(ctx->child_tid, &(ctx->child_regs));
 	ctx->event = ctx->child_regs.orig_eax;
 	handle_signal(ctx);
@@ -158,6 +159,7 @@ static void cont_syscall_block(struct context *ctx)
 {
 	sys_ptrace(PTRACE_SYSCALL, ctx->child_tid, 0, (void*) ctx->child_sig);
 	sys_waitpid(ctx->child_tid, &ctx->status);
+	assert(ctx->child_sig != SIGTRAP);
 	ctx->child_sig = signal_pending(ctx->status);
 	read_child_registers(ctx->child_tid, &(ctx->child_regs));
 	ctx->event = ctx->child_regs.orig_eax;
@@ -804,6 +806,7 @@ void start_recording(struct flags rr_flags)
 
 			if ((ctx != NULL) && (ctx->event != SYS_vfork)) {
 				ctx->child_sig = signal_pending(ctx->status);
+				assert(ctx->child_sig != SIGTRAP);
 				// a syscall_restart ending is equivalent to the restarted syscall ending
 				if (syscall == SYS_restart_syscall) {
 					debug("restart_syscall exit");

--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -81,25 +81,35 @@ struct dbg_request {
 		/* Is |target| alive? */
 		DREQ_GET_IS_THREAD_ALIVE,
 
-		/* Uses params.mem. */
+		/* These use params.mem. */
 		DREQ_GET_MEM,
+		DREQ_REMOVE_SW_BREAK,
+		DREQ_WATCH_FIRST = DREQ_REMOVE_SW_BREAK,
+		DREQ_REMOVE_HW_BREAK,
+		DREQ_REMOVE_RD_WATCH,
+		DREQ_REMOVE_WR_WATCH,
+		DREQ_REMOVE_RDWR_WATCH,
+		DREQ_SET_SW_BREAK,
+		DREQ_SET_HW_BREAK,
+		DREQ_SET_RD_WATCH,
+		DREQ_SET_WR_WATCH,
+		DREQ_SET_RDWR_WATCH,
+		DREQ_WATCH_LAST = DREQ_SET_RDWR_WATCH,
 
 		/* Uses params.reg. */
 		DREQ_GET_REG,
 
-		/* These use params.resume. */
+		/* Use params.resume. */
 		DREQ_CONTINUE,
 		DREQ_STEP,
 
 		/* No parameters. */
 		DREQ_INTERRUPT,
 
-		/* TODO */
-		DREQ_REMOVE_BREAKPOINT,
-		DREQ_SET_BREAKPOINT,
-		DREQ_SET_CURRENT_THREAD,
+		/* Use params.mem. */
 
-		DREQ_DETACH,
+		/* TODO */
+		DREQ_SET_CURRENT_THREAD,
 	} type;
 
 	dbg_threadid_t target;
@@ -203,10 +213,16 @@ void dbg_reply_get_stop_reason(struct dbg_context* dbg/*, TODO */);
 
 /**
  * |threads| contains the list of live threads, of which there are
-    |len|.
+ * |len|.
  */
 void dbg_reply_get_thread_list(struct dbg_context* dbg,
 			       const dbg_threadid_t* threads, size_t len);
+
+/**
+ * |code| is 0 if the request was successfully applied, nonzero if
+ * not.
+ */
+void dbg_reply_watchpoint_request(struct dbg_context* dbg, int code);
 
 /**
  * Destroy a gdb debugging context created by

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -240,7 +240,8 @@ void rep_process_flush(struct context* ctx) {
 		sys_ptrace_sysemu_sig(ctx->child_tid, 0);
 		sys_waitpid(ctx->child_tid, &(ctx->status));
 		if (signal_pending(ctx->status)) {
-			log_err("Signal recieved while pushing wrapped syscall content");
+			fatal("While pushing wrapped syscall content, received signal %d",
+			      signal_pending(ctx->status));
 		}
 		if (syscall == SYS_futex) {
 			/* replay *uaddr for futex */

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -23,8 +23,10 @@ void write_child_code(pid_t pid, void* addr, long code);
 void write_child_registers(pid_t tid, struct user_regs_struct* regs);
 void write_child_main_registers(pid_t tid, struct user_regs_struct *regs);
 void write_child_segment_registers(pid_t tid, struct user_regs_struct *regs);
-void write_child_data_n(pid_t tid, size_t size, void* addr, void* data);
-void write_child_data(struct context *ctx, size_t size, void *addr, void *data);
+void write_child_data_n(pid_t tid, size_t size, void* addr,
+			const void* data);
+void write_child_data(struct context *ctx, size_t size, void *addr,
+		      const void *data);
 size_t set_child_data(struct context *ctx);
 
 

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -286,6 +286,7 @@ void goto_next_event(struct context *ctx)
 	sys_waitpid(ctx->child_tid, &ctx->status);
 
 	ctx->child_sig = signal_pending(ctx->status);
+	assert(ctx->child_sig != SIGTRAP);
 	ctx->event = read_child_orig_eax(ctx->child_tid);
 }
 

--- a/src/test/int3.c
+++ b/src/test/int3.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <stdio.h>
+#include <signal.h>
+
+static void handle_sigtrap(int sig) {
+	puts("caught SIGTRAP!");
+	fflush(stdout);
+}
+
+int main(int argc, char *argv[]) {
+	signal(SIGTRAP, handle_sigtrap);
+
+	puts("raising SIGTRAP ...");
+	fflush(stdout);
+
+	__asm__ ("int $3");
+
+	return 0;
+}

--- a/src/test/int3.run.disabled
+++ b/src/test/int3.run.disabled
@@ -1,0 +1,2 @@
+source util.sh
+compare_test int3

--- a/src/test/sigtrap.c
+++ b/src/test/sigtrap.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <stdio.h>
+#include <signal.h>
+
+static void handle_sigtrap(int sig) {
+	puts("caught SIGTRAP!");
+	fflush(stdout);
+}
+
+int main(int argc, char *argv[]) {
+	signal(SIGTRAP, handle_sigtrap);
+
+	puts("raising SIGTRAP ...");
+	fflush(stdout);
+
+	raise(SIGTRAP);
+
+	return 0;
+}

--- a/src/test/sigtrap.run.disabled
+++ b/src/test/sigtrap.run.disabled
@@ -1,0 +1,2 @@
+source util.sh
+compare_test sigtrap


### PR DESCRIPTION
Breakpoints are disabled in this landing because gdb seems to require
stepi to get around some internally-set breakpoint.  But they work.
There's nothing particularly surprising in the implementation.

This one is a bit interesting so will leave open for a bit.
