### PR TITLE
Remove a seemingly unnecessary fork().  Incidentally resolves #91.

### DIFF
--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -175,7 +175,7 @@ void rec_sched_deregister_thread(struct context **ctx_ptr)
 	/* close file descriptor to child memory */
 	sys_close(ctx->child_mem_fd);
 
-	sys_ptrace_detatch(ctx->child_tid);
+	sys_ptrace_detach(ctx->child_tid);
 
 	/* make sure that the child has exited */
 

--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -644,7 +644,8 @@ static int process_packet(struct dbg_context* dbg)
 		dbg->req.params.mem.len = strtoul(payload, &payload, 16);
 		assert('\0' == *payload);
 
-		debug("gdb requests set breakpoint (addr=%p, len=%u)",
+		debug("gdb requests %s breakpoint (addr=%p, len=%u)",
+		      'Z' == request ? "set" : "remove",
 		      dbg->req.params.mem.addr, dbg->req.params.mem.len);
 
 		ret = 1;

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -196,9 +196,12 @@ void __ptrace_cont(struct context *ctx)
 			ctx->child_sig = 0;
 			return;
 		}
-		fatal("stop reason: %x :%d  pending sig: %d\n"
+		fatal("\n"
+		      "stop reason: %x :%d  pending sig: %d\n"
+		      "recorded eip: 0x%lx;  current eip: 0x%lx\n"
 		      "Internal error: syscalls out of sync: rec: %d  now: %d\n",
 		      ctx->status, WSTOPSIG(ctx->status), ctx->child_sig,
+		      ctx->trace.recorded_regs.eip, ctx->child_regs.eip,
 		      rec_syscall, current_syscall);
 	}
 

--- a/src/replayer/rep_sched.c
+++ b/src/replayer/rep_sched.c
@@ -103,7 +103,7 @@ void rep_sched_deregister_thread(struct context **ctx_ptr)
 	assert(num_threads >= 0);
 
 	/* detatch the child process*/
-	sys_ptrace_detatch(ctx->child_tid);
+	sys_ptrace_detach(ctx->child_tid);
 	int ret;
 	do {
 		ret = waitpid(ctx->child_tid, &(ctx->status), __WALL | __WCLONE);
@@ -111,7 +111,7 @@ void rep_sched_deregister_thread(struct context **ctx_ptr)
 		/* Is this a bug in the ptrace impementation? After calling detach, we should not receive
 		 * any ptrace signals. However, we still do in some cases... */
 		if (event == 6) { // TODO: magic
-			sys_ptrace_detatch(ctx->child_tid);
+			sys_ptrace_detach(ctx->child_tid);
 		}
 	} while (ret != -1);
 

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -41,7 +41,7 @@ void sys_ptrace_syscall_sig(pid_t pid, int sig);
 int sys_ptrace_peekdata(pid_t pid, long addr, long* value);
 unsigned long sys_ptrace_getmsg(pid_t pid);
 void sys_ptrace_getsiginfo(pid_t pid, siginfo_t* sig);
-void sys_ptrace_detatch(pid_t pid);
+void sys_ptrace_detach(pid_t pid);
 void sys_ptrace_syscall(pid_t pid);
 
 pid_t sys_waitpid(pid_t pid, int *status);

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -69,11 +69,13 @@ def set_up():
     global gdb, rr
     try:
         rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('rr.log', 'w'))
+        expect_rr('server listening on :1111')
+
         gdb = pexpect.spawn('gdb a.out', timeout=TIMEOUT_SEC, logfile=open('gdb.log', 'w'))
 
-        expect_gdb('(gdb)')
+        expect_gdb(r'\(gdb\)')
         send_gdb('target remote :1111\n')
-        expect_gdb('(gdb)')
+        expect_gdb(r'\(gdb\)')
     except Exception, e:
         failed('initializing rr and gdb', e)
 


### PR DESCRIPTION
There also a few unrelated tweaks tossed in.
