### PR TITLE
Implement get_stop_reason and add a helper for debugging targets that get into a bad state

### DIFF
--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -198,7 +198,8 @@ void dbg_reply_get_regs(struct dbg_context* dbg,
 /**
  * Reply to the DREQ_GET_STOP_REASON request.
  */
-void dbg_reply_get_stop_reason(struct dbg_context* dbg/*, TODO */);
+void dbg_reply_get_stop_reason(struct dbg_context* dbg,
+			       dbg_threadid_t which, int sig);
 
 /**
  * |threads| contains the list of live threads, of which there are

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -9,6 +9,21 @@
 void replay(struct flags rr_flags);
 
 /**
+ * Open a temporary debugging connection for |ctx| and service
+ * requests until the user quits or requests execution to resume.  Use
+ * this when a target enters an illegal state and can't continue, for
+ * example
+ *
+ *  if (recorded_state != replay_state) {
+ *	 log_err("Bad state ...");
+ *	 emergency_debug(tid);
+ *  }
+ *
+ * This function does not return.
+ */
+void emergency_debug(struct context* ctx);
+
+/**
  * Describes the next step to be taken in order to replay a trace
  * frame.
  */


### PR DESCRIPTION
Getting closer to the problem with continue-after-breakpoint; it looks like for some reason the breakpoint instruction isn't being repaired properly.
