### PR TITLE
Back up the $ip to before the trap instruction and fix tests.

### DIFF
--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -368,11 +368,9 @@ static int query(struct dbg_context* dbg, char* payload)
 	}
 	if (!strcmp(name, "Attached")) {
 		debug("gdb asks if this is a new or existing process");
-		/* Tell gdb we created a new process on its behalf.
-		 * We could go either way, but there's not much point
-		 * in continuing replay after gdb detaches, so this
-		 * seems to make the most sense. */
-		write_packet(dbg, "0");
+		/* Tell gdb this is an existing process; it might be
+		 * (see emergency_debug()). */
+		write_packet(dbg, "1");
 		return 0;
 	}
 	if (!strcmp(name, "fThreadInfo")) {

--- a/src/test/breakpoint.c
+++ b/src/test/breakpoint.c
@@ -19,6 +19,8 @@ static void A() {
 }
 
 int main() {
+	setvbuf(stdout, NULL, _IONBF, 0);
+
 	puts("calling A");
 	A();
 	puts("finished A");

--- a/src/test/breakpoint1.py
+++ b/src/test/breakpoint1.py
@@ -3,6 +3,7 @@ from rrutil import *
 send_gdb('b C\n')
 expect_gdb('Breakpoint 1')
 
+expect_gdb(r'\(gdb\)')
 send_gdb('c\n')
 
 expect_rr('calling C')

--- a/src/test/interrupt.c
+++ b/src/test/interrupt.c
@@ -17,6 +17,8 @@ void spin() {
 }
 
 int main(int argc, char *argv[]) {
+	setvbuf(stdout, NULL, _IONBF, 0);
+
 	spin();
 	puts("done");
 	return 0;

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -27,7 +27,7 @@ def ok():
     clean_up()
 
 # Internal helpers
-TIMEOUT_SEC = 5
+TIMEOUT_SEC = 20
 gdb = None
 rr = None
 


### PR DESCRIPTION
This gets breakpoints working with regular syscalls _without_ the filter lib.  Tracing with the filter lib still trips an assertion.
