### PR TITLE
Let detached tasks exit normally. Resolves #118.

### DIFF
--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -46,7 +46,7 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 	struct user_regs_struct regs;
 	read_child_registers(tid, &regs);
 
-	debug("%d: processing syscall: %s(%ld) -- time: %u  status: %x\n", tid, syscall_to_str(syscall), syscall, get_global_time(), ctx->exec_state);
+	debug("%d: processing syscall: %s(%d) -- time: %u  status: %x", tid, syscall_to_str(syscall), syscall, get_global_time(), ctx->exec_state);
 	//print_register_file_tid(ctx->child_tid);
 	//print_process_memory(ctx->child_tid);
 

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -177,13 +177,6 @@ void rec_sched_deregister_thread(struct context **ctx_ptr)
 
 	sys_ptrace_detach(ctx->child_tid);
 
-	/* make sure that the child has exited */
-
-	int ret;
-	do {
-		ret = waitpid(ctx->child_tid, &ctx->status, __WALL | __WCLONE);
-	} while (ret != -1);
-
 	/* finally, free the memory */
 	sys_free((void**) ctx_ptr);
 }

--- a/src/replayer/rep_sched.c
+++ b/src/replayer/rep_sched.c
@@ -134,16 +134,6 @@ void rep_sched_deregister_thread(struct context **ctx_ptr)
 
 	/* detatch the child process*/
 	sys_ptrace_detach(ctx->child_tid);
-	int ret;
-	do {
-		ret = waitpid(ctx->child_tid, &(ctx->status), __WALL | __WCLONE);
-		int event = GET_PTRACE_EVENT(ctx->status);
-		/* Is this a bug in the ptrace impementation? After calling detach, we should not receive
-		 * any ptrace signals. However, we still do in some cases... */
-		if (event == 6) { // TODO: magic
-			sys_ptrace_detach(ctx->child_tid);
-		}
-	} while (ret != -1);
 
 	sys_free((void**) ctx_ptr);
 }

--- a/src/test/exit_group.c
+++ b/src/test/exit_group.c
@@ -1,0 +1,26 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <pthread.h>
+#include <unistd.h>
+
+pthread_barrier_t bar;
+
+static void* thread(void* unused) {
+	pthread_barrier_wait(&bar);
+
+	sleep(-1);
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	pthread_t t;
+
+	pthread_barrier_init(&bar, NULL, 2);
+
+	pthread_create(&t, NULL, thread, NULL);
+
+	pthread_barrier_wait(&bar);
+
+	_exit(0);
+	return 0;		/* not reached */
+}

--- a/src/test/exit_group.run
+++ b/src/test/exit_group.run
@@ -1,0 +1,2 @@
+source util.sh
+compare_test exit_group


### PR DESCRIPTION
There may have been some reason for waitpid'ing tasks until they're gone, but that reason seems to have been lost to the sands of time.  Without that code, all the tests pass, and we can record and replay firefox right up to shutdown, so progress seems to have been made.  Until we rediscover what knowledge was lost ;).
