### PR TITLE
Add support for StartNoAckMode. Resolves #113.

### DIFF
--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -12,8 +12,8 @@ expect_gdb('Breakpoint 1, hit_barrier')
 send_gdb('info threads\n')
 for i in xrange(NUM_THREADS + 1, 1, -1):
     # The threads are at the vdso, hence the '??' top frame.
-    expect_gdb(str(i) + r'\s+Thread[^t]+\?\? \(\)')
+    expect_gdb(str(i) + r'\s+Thread[^?]+\?\? \(\)')
 
-expect_gdb(r'1\s+Thread[^t]+hit_barrier \(\)')
+expect_gdb(r'1\s+Thread[^h]+hit_barrier \(\)')
 
 ok()


### PR DESCRIPTION
For some reason, ack'ing responses was causing degenerate socket
behavior in either gdb or rr.  Omitting ack's speeds things up _a
lot_.  The unit tests run about 3.5x faster, which leads me to guess
that the gdb interactions are sped up around 5-6x.
