### PR TITLE
Level up unit tests; now harder to fool. Resolves #68. Resolves #145.

### DIFF
--- a/src/test/alarm.run
+++ b/src/test/alarm.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test alarm
+compare_test alarm 'Signal caught'

--- a/src/test/async_segv.run
+++ b/src/test/async_segv.run
@@ -4,5 +4,5 @@ compile async_segv
 # SIGSEGV, wait 0.5s
 record_async_signal 11 0.5 async_segv
 replay async_segv
-check async_segv
+check async_segv 'caught segv, goodbye'
 cleanup

--- a/src/test/async_usr1.c
+++ b/src/test/async_usr1.c
@@ -15,6 +15,7 @@ static void handle_segv(int sig) {
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/test/async_usr1.run
+++ b/src/test/async_usr1.run
@@ -4,5 +4,5 @@ compile async_usr1
 # SIGUSR1, wait 0.5s
 record_async_signal 10 0.5 async_usr1
 replay async_usr1
-check async_usr1
+check async_usr1 'caught usr1, goodbye'
 cleanup

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -1,15 +1,18 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <pthread.h>
+#include <stdio.h>
 
 #define ALEN(_a) (sizeof(_a) / sizeof(_a[0]))
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 static void hit_barrier() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 static void* thread(void* barp) {

--- a/src/test/chew_cpu.c
+++ b/src/test/chew_cpu.c
@@ -6,6 +6,7 @@
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 int spin() {

--- a/src/test/exit_group.c
+++ b/src/test/exit_group.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <pthread.h>
+#include <stdio.h>
 #include <unistd.h>
 
 pthread_barrier_t bar;
@@ -20,6 +21,9 @@ int main(int argc, char *argv[]) {
 	pthread_create(&t, NULL, thread, NULL);
 
 	pthread_barrier_wait(&bar);
+
+	puts("_exit()ing");
+	fflush(stdout);
 
 	_exit(0);
 	return 0;		/* not reached */

--- a/src/test/exit_group.run
+++ b/src/test/exit_group.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test exit_group
+compare_test exit_group '_exit()ing'

--- a/src/test/fadvise.c
+++ b/src/test/fadvise.c
@@ -1,7 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <fcntl.h>
-#include <syscall.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 int main(int argc, char *argv[]) {
 	/* There's not a (simple) way to meaningfully test fadvise,
@@ -10,4 +12,7 @@ int main(int argc, char *argv[]) {
 	posix_fadvise(-1, 0, 0, POSIX_FADV_NORMAL);
 	syscall(SYS_fadvise64, -1, 0, 0, POSIX_FADV_NORMAL);
 	syscall(SYS_fadvise64_64, -1, POSIX_FADV_NORMAL, 0, 0);
+
+	puts("EXIT-SUCCESS");
+	return 0;
 }

--- a/src/test/fadvise.run
+++ b/src/test/fadvise.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test fadvise
+compare_test fadvise EXIT-SUCCESS

--- a/src/test/hello.run
+++ b/src/test/hello.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test hello
+compare_test hello 'Hi'

--- a/src/test/int3.run
+++ b/src/test/int3.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test int3
+compare_test int3 'caught SIGTRAP'

--- a/src/test/interrupt.c
+++ b/src/test/interrupt.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 void spin() {
-	int i, dummy;
+	int i;
 
 	puts("spinning");
 	for (i = 1; i < (1 << 30); ++i) {

--- a/src/test/link.c
+++ b/src/test/link.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #define TOKEN "ABC"
@@ -47,5 +48,6 @@ int main() {
 
 	unlink(link_name);
 
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/link.run
+++ b/src/test/link.run
@@ -1,3 +1,3 @@
 source util.sh
-compare_test link
+compare_test link 'EXIT-SUCCESS'
 rm -f /tmp/rr-link-file.txt /tmp/rr-link-file.link

--- a/src/test/mmap_private.c
+++ b/src/test/mmap_private.c
@@ -12,6 +12,7 @@
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/test/mmap_private.run
+++ b/src/test/mmap_private.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test mmap_private
+compare_test mmap_private 'done'

--- a/src/test/mmap_shared.run.disabled
+++ b/src/test/mmap_shared.run.disabled
@@ -1,2 +1,2 @@
 source util.sh
-compare_test mmap_shared
+compare_test mmap_shared 'done'

--- a/src/test/priority.c
+++ b/src/test/priority.c
@@ -21,5 +21,6 @@ int main() {
 	prio2 = getpriority(PRIO_PROCESS, 0);
 	assert(prio1 == prio2);
 	printf("Now priority is: %d\n", prio2);
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/priority.run
+++ b/src/test/priority.run
@@ -3,5 +3,5 @@ get_rr_cmd $# $1
 compile priority
 renice -n 1 $$ && record priority
 renice -n 2 $$ && replay priority
-check priority
+check priority 'EXIT-SUCCESS'
 cleanup

--- a/src/test/rdtsc.c
+++ b/src/test/rdtsc.c
@@ -15,6 +15,7 @@ static uint64_t rdtsc(void) {
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 int main(int argc, char *argv[]) {
@@ -32,5 +33,7 @@ int main(int argc, char *argv[]) {
 		printf("%" PRIu64 ",", tsc);
 		last_tsc = tsc;
 	}
+
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/rdtsc.run
+++ b/src/test/rdtsc.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test rdtsc
+compare_test rdtsc 'EXIT-SUCCESS'

--- a/src/test/segfault.c
+++ b/src/test/segfault.c
@@ -6,11 +6,13 @@
 
 static void sighandler(int sig) {
 	printf("caught signal %d, exiting\n", sig);
+	fflush(stdout);
 	_exit(0);
 }
 
 static void breakpoint() {
 	int break_here = 1;
+	(void)break_here;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/test/segfault.run
+++ b/src/test/segfault.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test segfault
+compare_test segfault 'caught signal 11, exiting'

--- a/src/test/sigill.c
+++ b/src/test/sigill.c
@@ -1,9 +1,19 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <assert.h>
+#include <signal.h>
 #include <stdio.h>
+#include <unistd.h>
+
+static void sighandler(int sig) {
+	printf("caught signal %d, exiting\n", sig);
+	fflush(stdout);
+	_exit(0);
+}
 
 int main(int argc, char *argv[]) {
+	signal(SIGILL, sighandler);
+
 	puts("running undefined instruction ...");
 	__asm__ ("ud2");
 	assert("should have terminated!" && 0);

--- a/src/test/sigill.run
+++ b/src/test/sigill.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test sigill
+compare_test sigill 'caught signal 4, exiting'

--- a/src/test/sigrt.c
+++ b/src/test/sigrt.c
@@ -7,9 +7,13 @@
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))
 
+static int num_signals_caught;
+
 static void handle_sigrt(int sig) {
 	printf("Caught signal %d\n", sig);
 	fflush(stdout);
+
+	++num_signals_caught;
 }
 
 int main(int argc, char *argv[]) {
@@ -20,5 +24,10 @@ int main(int argc, char *argv[]) {
 		raise(i);
 	}
 
+	printf("caught %d signals; expected %d\n", num_signals_caught,
+	       SIGRTMAX - SIGRTMIN);
+	test_assert(1 + SIGRTMAX - SIGRTMIN == num_signals_caught);
+
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/sigrt.run
+++ b/src/test/sigrt.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test sigrt
+compare_test sigrt 'EXIT-SUCCESS'

--- a/src/test/sigtrap.c
+++ b/src/test/sigtrap.c
@@ -3,10 +3,12 @@
 #include <assert.h>
 #include <stdio.h>
 #include <signal.h>
+#include <unistd.h>
 
 static void handle_sigtrap(int sig) {
 	puts("caught SIGTRAP!");
 	fflush(stdout);
+	_exit(0);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/test/sigtrap.run
+++ b/src/test/sigtrap.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test sigtrap
+compare_test sigtrap 'caught SIGTRAP'

--- a/src/test/splice.c
+++ b/src/test/splice.c
@@ -1,8 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#define _GNU_SOURCE
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #define TOKEN "ABC"
@@ -44,6 +47,8 @@ int main() {
 	/* The test driver will clean up after us if the test failed
 	 * before this. */
 	unlink(token_file);
+
+	puts("EXIT-SUCCESS");
 
 	return 0;
 }

--- a/src/test/splice.run
+++ b/src/test/splice.run
@@ -1,4 +1,4 @@
 source util.sh
-compare_test splice
+compare_test splice 'EXIT-SUCCESS'
 # Remove junk created by test, in case it fails
 rm -f /tmp/rr-splice-file.txt

--- a/src/test/step_thread.c
+++ b/src/test/step_thread.c
@@ -7,12 +7,12 @@ pthread_barrier_t bar;
 
 /* NB: these must *not* be macros so that debugger step-next works as
  * expected per the program source. */
-int A() {
+void A() {
 	puts("entered A");
 	pthread_barrier_wait(&bar);
 	pthread_barrier_wait(&bar);
 }
-int B() {
+void B() {
 	puts("entered B");
 	pthread_barrier_wait(&bar);
 	pthread_barrier_wait(&bar);
@@ -20,12 +20,14 @@ int B() {
 
 void* threadA(void* unused) {
 	A();
+	return NULL;
 }
 void* threadB(void* unused) {
 	B();
+	return NULL;
 }
 
-int C() {
+void C() {
 	puts("entered C");
 	pthread_barrier_wait(&bar);
 }

--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -1,9 +1,15 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include <assert.h>
 #include <signal.h>
 #include <stdio.h>
-#include <syscall.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+static int num_signals_caught;
 
 static pid_t gettid() {
 	return syscall(SYS_gettid);
@@ -15,6 +21,7 @@ static int tgkill(int tgid, int tid, int sig) {
 
 static void sighandler(int sig) {
 	printf("Task %d got signal %d\n", gettid(), sig);
+	++num_signals_caught;
 }
 
 int main(int argc, char *argv[]) {
@@ -22,5 +29,9 @@ int main(int argc, char *argv[]) {
 	signal(SIGUSR2, sighandler);
 	tgkill(getpid(), gettid(), SIGUSR1);
 	tgkill(getpid(), gettid(), SIGUSR2);
+
+	test_assert(2 == num_signals_caught);
+
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/threads.c
+++ b/src/test/threads.c
@@ -10,52 +10,51 @@
 
 long int counter = 0;
 
-void catcher( int sig ) {
-    char buf[1024];
-    sprintf(buf, "Signal caught, Counter is %ld\n", counter );
-    write(1,buf,strlen(buf));
-    exit(1);
+void catcher(int sig) {
+	printf("Signal caught, Counter is %ld\n", counter);
+	puts("EXIT-SUCCESS");
+	fflush(stdout);
+	_exit(0);
 }
 
-void * reciever( void * name )  {
-    struct sigaction sact;
+void* reciever(void* name) {
+	struct sigaction sact;
 
-    sigemptyset( &sact.sa_mask );
-    sact.sa_flags = 0;
-    sact.sa_handler = catcher;
-    sigaction( SIGALRM, &sact, NULL );
+	sigemptyset(&sact.sa_mask);
+	sact.sa_flags = 0;
+	sact.sa_handler = catcher;
+	sigaction(SIGALRM, &sact, NULL);
 
-    while (1) {
-    	counter++;
-    	if (counter % 100000 == 0)
-    		write(1,".",1);
-    }
-
+	while (1) {
+		counter++;
+		if (counter % 100000 == 0) {
+			write(1, ".", 1);
+		}
+	}
+	return NULL;
 }
 
-void * sender( void * id )
-{
+void* sender(void* id) {
 	sleep(1);
 	pthread_kill(*((pthread_t*)id), SIGALRM);
+	return NULL;
 }
 
-main()
-{
-     pthread_t thread1, thread2;
+int main() {
+	pthread_t thread1, thread2;
 
-    /* Create independent threads each of which will execute function */
+	/* Create independent threads each of which will execute
+	 * function */
+	pthread_create(&thread1, NULL, reciever, NULL);
+	pthread_create(&thread2, NULL, sender, &thread1);
 
-     pthread_create( &thread1, NULL, reciever, (void*) 0);
-     pthread_create( &thread2, NULL, sender, (void*) &thread1);
-
-     /* Wait till threads are complete before main continues. Unless we  */
-     /* wait we run the risk of executing an exit which will terminate   */
-     /* the process and all threads before the threads have completed.   */
-
-     pthread_join( thread1, NULL);
-     pthread_join( thread2, NULL);
-
-     exit(0);
+	/* Wait till threads are complete before main
+	 * continues. Unless we wait we run the risk of executing an
+	 * exit which will terminate the process and all threads
+	 * before the threads have completed. */
+	pthread_join(thread1, NULL);
+	pthread_join(thread2, NULL);
+	return 0;
 }
 
 

--- a/src/test/threads.run
+++ b/src/test/threads.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test threads
+compare_test threads EXIT-SUCCESS

--- a/src/test/time.c
+++ b/src/test/time.c
@@ -42,5 +42,7 @@ int main() {
 		       (double) ts.tv_sec, (long long int) ts.tv_nsec,
 		       (double) tv.tv_sec, (long long int) tv.tv_usec);
 	}
+
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/time.run
+++ b/src/test/time.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test time
+compare_test time 'EXIT-SUCCESS'


### PR DESCRIPTION
Tests now have to do something expected, in addition to having
identical execution across record/replay.  Additionally they must
compile with -Wall -Werr.
