### PR TITLE
Use /dev/shm for syscall buffer. Resolves #166.

### DIFF
--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1932,7 +1932,7 @@ SYS_REC1(sched_getaffinity, sizeof(cpu_set_t), (void*)regs.edx)
 					ctx->syscall_wrapper_cache_child = file.start;
 					// mmap as shared in rr as well
 					errno = 0;
-					int fd = open(file.filename, O_CREAT | O_RDWR, 0666); // beware of O_TRUNC!
+					int fd = open(file.filename, O_CREAT | O_RDWR, 0640);
 					assert(fd > 0 && errno == 0);
 					// no need to truncate, the child already did it.
 					int retval;

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -120,8 +120,7 @@ void sys_exit()
 	log_err("Exiting");
 	rec_sched_exit_all();
 	close_trace_files();
-	assert(0); // for debugging
-	exit(-1);
+	abort();
 }
 
 void sys_sched_setaffinity(unsigned long mask)


### PR DESCRIPTION
This lets us remove all the trace_dir hackery, which is a nice ancillary benefit.
