### PR TITLE
Sundry syscall buffer bug fixes and cleanups.

### DIFF
--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -8,8 +8,6 @@
 
 #include "../share/types.h"
 
-typedef unsigned char byte;
-
 struct dbg_context;
 
 /**

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -14,7 +14,6 @@
 
 #define SYSCALL_BUFFER_CACHE_SIZE				((1 << 20) - sizeof(int)) /* Accounting for buffer[0] which holds size */
 #define SYSCALL_BUFFER_CACHE_FILENAME_PREFIX 	"record_cache_"
-#define SYSCALL_BUFFER_RECORD_BASE_SIZE 			(3) /* Base size in integers */
 
 /* Buffered syscalls need to be added here. Note: be careful of
  * syscalls that originate from wrapper internal code.
@@ -34,5 +33,28 @@
 	 || (_ctx)->event == SYS_epoll_wait				\
 	 || (_ctx)->event == SYS_socketcall				\
 	 || (_ctx)->event == SYS_futex))
+
+/**
+ * The syscall buffer comprises an array of these (variable-length)
+ * records.
+ */
+struct syscall_record {
+	int syscall;
+	/* Length of entire record: this struct plus extra recorded
+	 * data stored inline after |ret|, not including padding. */
+	int length;
+	int ret;
+	/* Extra recorded outparam data starts here. */
+} __attribute__((__packed__));
+
+/**
+ * Return the amount of space that a record of |length| will occupy in
+ * the buffer if committed, including padding.
+ */
+inline static int stored_record_size(int length)
+{
+	/* Round up to a whole number of 32-bit words. */
+	return (length + sizeof(int) - 1) & ~(sizeof(int) - 1);
+}
 
 #endif /* SYSCALL_BUFFER_H_ */

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -26,6 +26,8 @@
 
 typedef enum { FALSE = 0, TRUE = 1 } bool;
 
+typedef unsigned char byte;
+
 /**
  * A trace_frame is one "trace event" from a complete trace.  During
  * recording, a trace_frame is recorded upon each significant event,


### PR DESCRIPTION
Includes the following changes
- use stronger types and less casting and pointer hackery when dealing
  with syscall records
- fix bug where record padding could lead to undetected overflow
- simply and optimize flush replay by writing the entire buffer in one
  shot, instead of restoring data per syscall

@rocallahan ought to like this patch! ;)
