### PR TITLE
Convert syscallbuf initialization into a "magic" rrcall, preparing for #7.

### DIFF
--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1346,9 +1346,17 @@ SYSCALL_DEF(IRREGULAR, write, -1)
 
 /**
  *  ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
-
+ *
  * The writev() function writes iovcnt buffers of data described by
  * iov to the file associated with the file descriptor fd ("gather
  * output").
  */
 SYSCALL_DEF(EMU, writev, 0)
+
+/**
+ *  void* rrcall_map_syscall_buffer(const char* shmem_filename)
+ *
+ * Create, open, and map the shmem file |shmem_filename| into the
+ * caller's address space.  Return the mapped region.
+ */
+SYSCALL_DEF(IRREGULAR, rrcall_map_syscall_buffer, -1)

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -3,8 +3,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /**

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -43,6 +43,14 @@ enum {
 	LAST_ASYNC_SIGNAL = -1,
 };
 
+enum {
+	/* "Magic" syscalls (traps initiated by rr code running in a
+	 * tracee) oare negative numbers to distinguish them from real
+	 * syscalls.  However, to avoid colliding with the signal
+	 * "namespace" in the event encoding, they're recorded as
+	 * (-syscallno | RRCALL_BIT). */
+	RRCALL_BIT = 0x8000
+};
 
 // Notice: these are defined in errno.h if _kernel_ is defined.
 #define ERESTARTNOINTR 			-513


### PR DESCRIPTION
This also comments out the (already dead) futex() syscallbuf code,
since it turns the ABI for syscall6 wasn't quite right.

The magic syscall impl feels oh so much cleaner than param matching.  It should be trivial to address #169 now.
