### PR TITLE
Initial support for buffered may-block syscalls.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -457,7 +457,7 @@ int main(int argc, char* argv[], char** envp)
 			 * so that we can LD_PRELOAD the bare library
 			 * name.  Trying to do otherwise is possible,
 			 * but annoying. */
-			__rr_flags.syscall_buffer_lib_path = SYSCALL_BUFFER_LIB_FILENAME;
+			__rr_flags.syscall_buffer_lib_path = SYSCALLBUF_LIB_FILENAME;
 		}
 	}
 

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -38,225 +38,6 @@
 #include "../share/util.h"
 #include "../share/syscall_buffer.h"
 
-/**
- * Share |fd| to the other side of |sock|.
- */
-static void send_fd(int fd, int sock)
-{
-	struct msghdr msg;
-	struct iovec data;
-	struct cmsghdr* cmsg;
-	char cmsgbuf[CMSG_SPACE(sizeof(int))];
-
-	memset(&msg, 0, sizeof(msg));
-
-	data.iov_base = &fd;
-	data.iov_len = sizeof(fd);
-	msg.msg_iov = &data;
-	msg.msg_iovlen = 1;
-
-	msg.msg_control = cmsgbuf;
-	msg.msg_controllen = CMSG_LEN(sizeof(int));
-
-	cmsg = CMSG_FIRSTHDR(&msg);
-	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-	cmsg->cmsg_level = SOL_SOCKET;
-	cmsg->cmsg_type = SCM_RIGHTS;
-	*(int*)CMSG_DATA(cmsg) = fd;
-
-	if (0 >= sendmsg(sock, &msg, 0)) {
-		fatal("Failed to send fd");
-	}
-}
-
-/**
- * Block until receiving an fd the other side of |sock| sent us, then
- * return the fd (valid in this address space).  Optionally return the
- * remote fd number that was shared to us in |remote_fdno|.
- */
-static int recv_fd(int sock, int* remote_fdno)
-{
-	struct msghdr msg;
-	int fd, remote_fd;
-	struct iovec data;
-	struct cmsghdr* cmsg;
-	char cmsgbuf[CMSG_SPACE(sizeof(int))];
-
-	memset(&msg, 0, sizeof(msg));
-
-	data.iov_base = &remote_fd;
-	data.iov_len = sizeof(remote_fd);
-	msg.msg_iov = &data;
-	msg.msg_iovlen = 1;
-
-	msg.msg_control = cmsgbuf;
-	msg.msg_controllen = sizeof(cmsgbuf);
-
-	if (0 >= recvmsg(sock, &msg, 0)) {
-		fatal("Failed to receive fd");
-	}
-
-	cmsg = CMSG_FIRSTHDR(&msg);
-	assert(cmsg->cmsg_level == SOL_SOCKET
-	       && cmsg->cmsg_type == SCM_RIGHTS);
-
-	fd = *(int*)CMSG_DATA(cmsg);
-	if (remote_fdno) {
-		*remote_fdno = remote_fd;
-	}
-
-	return fd;
-}
-
-static void write_socketcall_args(struct context* ctx, void* child_args_vec,
-				  long arg1, long arg2, long arg3)
-{
-	struct socketcall_args args = { { arg1, arg2, arg3 } };
-	write_child_data(ctx, sizeof(args), child_args_vec, &args);
-}
-
-static void map_syscall_buffer(struct context* ctx)
-{
-	pid_t tid = ctx->child_tid;
-	char shmem_filename[PATH_MAX];
-	struct current_state_buffer state;
-	struct sockaddr_un addr;
-	long child_ret;
-	long child_sockaddr, child_msg;
-	void* child_fdptr;
-	void* child_args_vec;
-	int listen_sock, sock, child_sock;
-	int shmem_fd, child_shmem_fd;
-	void* map_addr;
-	void* child_map_addr;
-
-	/* NB: the tracee can't be interrupted with a signal while
-	 * we're processing the rrcall, because it's masked off all
-	 * signals. */
-
-	/* Arguments to the rrcall. */
-	prepare_remote_syscalls(ctx, &state);
-	child_sockaddr = state.regs.ebx;
-	child_msg = state.regs.ecx;
-	child_fdptr = (void*)state.regs.edx;
-	child_args_vec = (void*)state.regs.esi;
-
-	snprintf(shmem_filename, sizeof(shmem_filename) - 1,
-		 "/dev/shm/rr-tracee-shmem-%d", tid);
-	prepare_syscallbuf_socket_addr(&addr, tid);
-
-	/* Create the segment we'll share with the tracee. */
-	if (0 > (shmem_fd = open(shmem_filename, O_CREAT | O_RDWR, 0640))) {
-		fatal("Failed to open shmem file %s", shmem_filename);
-	}
-	/* Remove the fs name; we're about to "anonymously" share our
-	 * fd to the tracee. */
-	unlink(shmem_filename);
-	if (ftruncate(shmem_fd, SYSCALL_BUFFER_CACHE_SIZE)) {
-		fatal("Failed to resize syscall buffer shmem");
-	}
-
-	/* Bind the server socket, but don't start listening yet. */
-	listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (bind(listen_sock, (struct sockaddr*)&addr, sizeof(addr))) {
-		fatal("Failed to bind listen socket");
-	}
-	if (listen(listen_sock, 1)) {
-		fatal("Failed to mark listening for listen socket");
-	}
-
-	/* Initiate tracee connect(), but don't wait for it to
-	 * finish. */
-	write_socketcall_args(ctx, child_args_vec,
-			      AF_UNIX, SOCK_STREAM, 0);
-	child_sock = remote_syscall2(ctx, &state, SYS_socketcall,
-				     SYS_SOCKET, (uintptr_t)child_args_vec);
-	if (0 > child_sock) {
-		errno = -child_sock;
-		fatal("Failed to create child socket");
-	}
-	write_socketcall_args(ctx, child_args_vec,
-			      child_sock, child_sockaddr, sizeof(addr));
-	remote_syscall(ctx, &state, DONT_WAIT, SYS_socketcall,
-		       SYS_CONNECT, (uintptr_t)child_args_vec, 0, 0, 0, 0);
-	/* Now the child is waiting for us to accept it. */
-
-	/* Accept the child's connection and finish its syscall.
-	 *
-	 * XXX could be really anal and check credentials of
-	 * connecting endpoint ... */
-	sock = accept(listen_sock, NULL, NULL);
-	if ((child_ret = wait_remote_syscall(ctx, &state))) {
-		errno = -child_ret;
-		fatal("Failed to connect() in tracee");
-	}
-	/* Socket name not needed anymore. */
-	unlink(addr.sun_path);
-
-	/* Pull the puppet strings to have the child share its desched
-	 * counter with us.  Similarly to above, we DONT_WAIT on the
-	 * call to finish, since it's likely not defined whether the
-	 * sendmsg() may block on our recvmsg()ing what the tracee
-	 * sent us (in which case we would deadlock with the
-	 * tracee). */
-	write_socketcall_args(ctx, child_args_vec, child_sock, child_msg, 0);
-	remote_syscall(ctx, &state, DONT_WAIT, SYS_socketcall,
-		       SYS_SENDMSG, (uintptr_t)child_args_vec, 0, 0, 0, 0);
-	/* Child may be waiting on our recvmsg(). */
-
-	/* Read the shared fd and finish the child's syscall. */
-	ctx->desched_fd = recv_fd(sock, &ctx->desched_fd_child);
-	if (0 >=  wait_remote_syscall(ctx, &state)) {
-		errno = -child_ret;
-		fatal("Failed to sendmsg() in tracee");
-	}
-
-	/* Share the shmem fd with the child.  It's ok to reuse the
-	 * |child_msg| buffer. */
-	send_fd(shmem_fd, sock);
-	write_socketcall_args(ctx, child_args_vec,
-			      child_sock, child_msg, 0);
-	child_ret = remote_syscall2(ctx, &state, SYS_socketcall,
-				    SYS_RECVMSG, (uintptr_t)child_args_vec);
-	if (0 >= child_ret) {
-		errno = -child_ret;
-		fatal("Failed to recvmsg() shared fd in tracee");
-	}
-
-	/* Get the newly-allocated fd. */
-	child_shmem_fd = read_child_data_word(tid, child_fdptr);
-
-	/* Socket magic is now done. */
-	close(listen_sock);
-	close(sock);
-	remote_syscall1(ctx, &state, SYS_close, child_sock);
-
-	/* Map the segment in our address space and in the
-	 * tracee's. */
-	if ((void*)-1 ==
-	    (map_addr = mmap(NULL, SYSCALL_BUFFER_CACHE_SIZE,
-			     PROT_READ | PROT_WRITE, MAP_SHARED,
-			     shmem_fd, 0))) {
-		fatal("Failed to mmap shmem region");
-	}
-	child_map_addr = (void*)remote_syscall6(ctx, &state, SYS_mmap2,
-						0, SYSCALL_BUFFER_CACHE_SIZE,
-						PROT_READ | PROT_WRITE,
-						MAP_SHARED, child_shmem_fd, 0);
-
-	ctx->syscall_wrapper_cache_child = child_map_addr;
-	ctx->syscall_wrapper_cache = map_addr;
-	/* No entries to begin with. */
-	ctx->syscall_wrapper_cache[0] = 0;
-
-	close(shmem_fd);
-	remote_syscall1(ctx, &state, SYS_close, child_shmem_fd);
-
-	/* Return the mapped address to the child. */
-	state.regs.eax = (uintptr_t)child_map_addr;
-	finish_remote_syscalls(ctx, &state);
-}
-
 void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags)
 {
 	pid_t tid = ctx->child_tid;
@@ -2148,10 +1929,10 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 			record_mmapped_file_stats(&file);
 
 			int prot = regs.edx;
-			if (strstr(file.filename, SYSCALL_BUFFER_LIB_FILENAME) != NULL && // found the library
-				(prot & PROT_EXEC) ) { // notice: the library get loaded several times, we need the (hopefully one) copy that is executable
-				ctx->syscall_wrapper_start = file.start;
-				ctx->syscall_wrapper_end = file.end;
+			if (strstr(file.filename, SYSCALLBUF_LIB_FILENAME)
+			    && (prot & PROT_EXEC) ) { // notice: the library get loaded several times, we need the (hopefully one) copy that is executable
+				ctx->syscallbuf_lib_start = file.start;
+				ctx->syscallbuf_lib_end = file.end;
 			}
 
 			if (flags & MAP_SHARED) {
@@ -2189,16 +1970,41 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 	 */
 	case SYS_nanosleep:
 	{
-		// restore ecx
-		regs.ecx = (uintptr_t)ctx->recorded_scratch_ptr_0;
-		write_child_registers(ctx->child_tid, &regs);
+		void* scratch = (void*)regs.ecx;
+		size_t record_size = sizeof(struct timespec);
+		void* recorded_data;
+		void* source_ptr;
 
-		if (regs.ecx) {// a pointer was supplied
-			void *recorded_data = read_child_data(ctx, ctx->recorded_scratch_size, ctx->scratch_ptr);
-			write_child_data(ctx, ctx->recorded_scratch_size, ctx->recorded_scratch_ptr_0, recorded_data);
-			record_parent_data(ctx, syscall, ctx->recorded_scratch_size, ctx->recorded_scratch_ptr_0, recorded_data);
-			sys_free((void**)&recorded_data);
+		if (!scratch) {
+			/* No outparam was passed; nothing to do. */
+			break;
 		}
+
+		recorded_data = read_child_data(ctx, record_size, scratch);
+		if (ctx->recorded_scratch_ptr_0) {
+			/* We used a pointer into our scratch region.
+			 * Pretend that the written data came from
+			 * there, write it back to the source, and
+			 * restore the source as the param register to
+			 * be recorded. */
+			source_ptr = ctx->recorded_scratch_ptr_0;
+			write_child_data(ctx, record_size, source_ptr,
+					 recorded_data);
+			regs.ecx = (uintptr_t)source_ptr;
+			write_child_registers(ctx->child_tid, &regs);
+		} else {
+			/* We used the syscallbuf as scratch, but to
+			 * us that looks like the source ptr too.
+			 * (The syscallbuf will update the real
+			 * source.) */
+			source_ptr = scratch;
+		}
+		/* Even if we used the syscallbuf as scratch, we'll
+		 * need to restore the data, so record it. */
+		record_parent_data(ctx, syscall, record_size, source_ptr,
+				   recorded_data);
+
+		sys_free((void**)&recorded_data);
 		break;
 	}
 
@@ -2425,9 +2231,9 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 	 */
 	SYS_REC0(writev)
 
-	case RRCALL_map_syscall_buffer:
+	case RRCALL_init_syscall_buffer:
 		ctx->event = (-ctx->event | RRCALL_BIT);
-		map_syscall_buffer(ctx);
+		init_syscall_buffer(ctx, NULL, SHARE_DESCHED_EVENT_FD);
 		break;
 
 	default:

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -133,12 +133,12 @@ void rec_sched_register_thread(pid_t parent, pid_t child)
 
 	ctx->exec_state = EXEC_STATE_START;
 	ctx->status = 0;
-	ctx->child_tid = child;
+	ctx->rec_tid = ctx->child_tid = child;
 	ctx->child_mem_fd = sys_open_child_mem(child);
 	if (parent) {
-		struct context * parent_ctx = (struct context *)list_data(tid_to_node[parent]);
-		ctx->syscall_wrapper_start = parent_ctx->syscall_wrapper_start;
-		ctx->syscall_wrapper_end = parent_ctx->syscall_wrapper_end;
+		struct context* parent_ctx = (struct context *)list_data(tid_to_node[parent]);
+		ctx->syscallbuf_lib_start = parent_ctx->syscallbuf_lib_start;
+		ctx->syscallbuf_lib_end = parent_ctx->syscallbuf_lib_end;
 	}
 	/* These will be initialized when the syscall buffer is. */
 	ctx->desched_fd = ctx->desched_fd_child = -1;

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -6,6 +6,11 @@
 struct context;
 struct rep_trace_step;
 
+/**
+ * Replay up to and emulate the ioctl used to arm/disarm the desched
+ * event.
+ */
+void rep_skip_desched_ioctl(struct context* ctx);
 void rep_process_flush(struct context* ctx);
 /* |redirect_stdio| is nonzero if output written to stdout/stderr
  * during recording should be tee'd during replay, zero otherwise. */

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1365,9 +1365,21 @@ SYSCALL_DEF(IRREGULAR, write, -1)
 SYSCALL_DEF(EMU, writev, 0)
 
 /**
- *  void* rrcall_map_syscall_buffer(const char* shmem_filename)
+ *  void* rrcall_init_syscall_buffer(void* untraced_syscall_ip,
+ *                                   struct sockaddr_un* addr,
+ *                                   struct msghdr* msg, int* fdptr,
+ *                                   struct socketcall_args* args_vec);
  *
- * Create, open, and map the shmem file |shmem_filename| into the
- * caller's address space.  Return the mapped region.
+ * Do what's necessary to map the shared syscall buffer region in the
+ * caller's address space and return the mapped region.
+ * |untraced_syscall_ip| lets rr know where our untraced syscalls will
+ * originate from.  |addr| is the address of the control socket the
+ * child expects to connect to.  |msg| is a pre-prepared IPC that can
+ * be used to share fds; |fdptr| is a pointer to the control-message
+ * data buffer where the fd number being shared will be stored.
+ * |args_vec| provides the tracer with preallocated space to make
+ * socketcall syscalls.
+ *
+ * This is a "magic" syscall implemented by rr.
  */
-SYSCALL_DEF(IRREGULAR, rrcall_map_syscall_buffer, -1)
+SYSCALL_DEF(IRREGULAR, rrcall_init_syscall_buffer, -1)

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -18,7 +18,7 @@
 //#define DEBUGRR
 
 #ifdef DEBUGRR
-#define debug(M, ...) fprintf(stderr, "DEBUG %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__);
+#define debug(M, ...) fprintf(stderr, "[DEBUG] (%s) " M "\n", __FUNCTION__, ##__VA_ARGS__);
 #define do_debug(C) C
 #else
 #define debug(M, ...)
@@ -27,13 +27,13 @@
 
 #define clean_errno() (errno == 0 ? "None" : strerror(errno))
 
-#define fatal(M, ...) do { fprintf(stderr, "[FATAL] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, clean_errno(), ##__VA_ARGS__); abort(); } while (0)
+#define fatal(M, ...) do { fprintf(stderr, "[FATAL] (%s:%d:%s: errno: %s) " M "\n", __FILE__, __LINE__, __FUNCTION__, clean_errno(), ##__VA_ARGS__); abort(); } while (0)
 
-#define log_err(M, ...) fprintf(stderr, "[ERROR] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, clean_errno(), ##__VA_ARGS__)
+#define log_err(M, ...) fprintf(stderr, "[ERROR] (%s:%d:%s: errno: %s) " M "\n", __FILE__, __LINE__, __FUNCTION__, clean_errno(), ##__VA_ARGS__)
 
-#define log_warn(M, ...) fprintf(stderr, "[WARN] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, clean_errno(), ##__VA_ARGS__)
+#define log_warn(M, ...) fprintf(stderr, "[WARN] (%s: errno: %s) " M "\n", __FUNCTION__, clean_errno(), ##__VA_ARGS__)
 
-#define log_info(M, ...) fprintf(stderr, "[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define log_info(M, ...) fprintf(stderr, "[INFO] (%s) " M "\n", __FUNCTION__, ##__VA_ARGS__)
 
 #define check(A, M, ...) if(!(A)) { log_err(M, ##__VA_ARGS__); errno=0; goto error; }
 

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -330,30 +330,6 @@ static inline long time_difference(struct timeval *t1, struct timeval *t2) {
 	return (t2->tv_sec - t1->tv_sec) * 1000000 + (t2->tv_usec - t1->tv_usec);
 }
 
-/*
- * Waits for a child process for a certain time in micro seconds.
- */
-pid_t sys_waitpid_timeout(pid_t pid, int *status, int timeout_us)
-{
-	struct timeval start_time, curr_time;
-	/* get the start time */
-	gettimeofday(&start_time, NULL);
-
-	long time_diff;
-	pid_t ret = 0;
-	while (ret == 0) {
-		ret = sys_waitpid_nonblock(pid, status);
-
-		gettimeofday(&curr_time, NULL);
-		time_diff = time_difference(&start_time, &curr_time);
-		if (time_diff > timeout_us) {
-			break;
-		}
-
-	}
-	return ret;
-}
-
 void sys_fcntl(int fd, int option, pid_t pid)
 {
 	if (fcntl(fd, option, pid) < 0) {

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -48,7 +48,6 @@ void sys_ptrace_syscall(pid_t pid);
 
 pid_t sys_waitpid(pid_t pid, int *status);
 pid_t sys_waitpid_nonblock(pid_t pid, int *status);
-pid_t sys_waitpid_timeout(pid_t pid, int *status, int timeout_us);
 void sys_fcntl(int filedes, int option, pid_t pid);
 void sys_fcntl_f_setown(int filedes, pid_t pid);
 void sys_fcntl_f_setfl_o_async(int filedes);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -144,4 +144,19 @@ void finish_remote_syscalls(struct context* ctx,
 #define remote_syscall0(_c, _s, _no)		\
 	remote_syscall1(_c, _s, _no, 0)
 
+/**
+ * Initialize the syscall buffer in |ctx|, i.e., implement
+ * RRCALL_init_syscall_buffer.  |ctx| must be at the point of *exit
+ * from* the rrcall.  Its registers will be updated with the return
+ * value from the rrcall, which is also returned from this call.
+ * |map_hint| suggests where to map the region.
+ *
+ * Pass SHARE_DESCHED_EVENT_FD to additionally share that fd.
+ *
+ * XXX: this is a weird place to stick this helper
+ */
+enum { SHARE_DESCHED_EVENT_FD = 1, DONT_SHARE_DESCHED_EVENT_FD = 0 };
+void* init_syscall_buffer(struct context* ctx, void* map_hint,
+			  int share_desched_fd);
+
 #endif /* UTIL_H_ */

--- a/src/test/time.c
+++ b/src/test/time.c
@@ -1,7 +1,6 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <assert.h>
-#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,10 +23,6 @@ int main() {
 	for (i = 0; i < 100; ++i) {
 		struct timespec ts_now;
 		struct timeval tv_now;
-
-		if (0 == (i + 1) % 10) {
-			sched_yield();
-		}
 
 		clock_gettime(CLOCK_MONOTONIC, &ts_now);
 		test_assert(ts.tv_sec < ts_now.tv_sec


### PR DESCRIPTION
This commit includes quite a few changes, many of which are noise or
lesser bugs fixed along the way.  But the crux of the approach of this
patch, building on the desched event already being fired, is
1. When the desched event fires, check if the tracee has already
   finished the system call it was in.  If so, continue normally; the
   call will be recorded in the buffer and replay will Just Work.
2. If the syscall really did block, then record the syscall entry
   normally (outside the syscallbuf), flush the syscallbuf, and mark the
   context as preemptible.  Additionally, set things up so that the
   syscallbuf code _will not_ commit the current syscall into the buffer
   when it finishes.  Advance execution normally until the syscall
   finishes, then record the syscall exit normally.

A somewhat tricky part of the implementation is that desched'd
syscalls will still use the syscallbuf as "scratch storage" after the
buffer has been flushed, when the event fires --- even though they're
not going to commit to the buffer.  This is OK because
- rr records the outparams as if they were help in normal scratch buffers
- the tracee hold a lock on the storage throughout
- we do careful dance to replay the flushing / clearing of recorded
  size / marking for commit-abort in the right order

One large part but relatively minor part of the patch was refactoring
the code that initializes the shared buffer, because we need to share
the mapping during replay now.  Another large but minor part was
simplifying and correcting how the scratch-buffer setup is done in
prep_event().

This patch doesn't enable any may-block syscalls for buffering, but
there are two included in commented-out code in syscall_buffer.c which
can be used for testing.

Resolves #7.
