### PR TITLE
Don't leave nondeterministic bits of rr state on tracees' stacks.

### DIFF
--- a/src/share/ipc.c
+++ b/src/share/ipc.c
@@ -126,10 +126,10 @@ void write_child_code(pid_t pid, void* addr, long code)
 	sys_ptrace(PTRACE_POKETEXT, pid, addr, (void*) code);
 }
 
-static void write_child_data_word(pid_t pid, void *addr, void *data)
+void write_child_data_word(pid_t pid, void *addr, uintptr_t data)
 {
 	CHECK_ALIGNMENT(addr);
-	sys_ptrace(PTRACE_POKEDATA, pid, addr, data);
+	sys_ptrace(PTRACE_POKEDATA, pid, addr, (void*)data);
 }
 
 long int read_child_syscall(int child_id)
@@ -486,7 +486,7 @@ void write_child_data_n(pid_t tid, size_t size, void* addr, const void* data)
 	int i;
 	for (i = 0; i < write_size; i += READ_SIZE) {
 		uint32_t word = *(uint32_t*) (write_data + i);
-		write_child_data_word(tid, write_addr + i, (void*) word);
+		write_child_data_word(tid, write_addr + i, word);
 	}
 
 	free(write_data);

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -20,6 +20,7 @@ ssize_t checked_pread(struct context *ctx, void *buf, size_t size, off_t offset)
 void memcpy_child(struct context *ctx, void *dest, void *src, int size);
 
 void write_child_code(pid_t pid, void* addr, long code);
+void write_child_data_word(pid_t pid, void *addr, uintptr_t data);
 void write_child_registers(pid_t tid, struct user_regs_struct* regs);
 void write_child_main_registers(pid_t tid, struct user_regs_struct *regs);
 void write_child_segment_registers(pid_t tid, struct user_regs_struct *regs);


### PR DESCRIPTION
Tried but was unable to write a simple test (that didn't hook into the syscall buf code itself.)
