### PR TITLE
Adjust the rbc downwards after a buffer-flush, to simplify debugger interrupts.

### DIFF
--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -202,8 +202,10 @@ static void emulate_buffered_syscall(struct context* ctx,
 	}
 
 	read_child_registers(tid, &regs);
-	if (rec->syscallno != regs.orig_eax) {
-		log_err("Trying to emulate %s but replayed to entry of %s",
+	if (!SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(regs.eip, ctx)
+	    || rec->syscallno != regs.orig_eax) {
+		log_err("Bad ip %p, or trying to emulate %s but replayed to entry of %s",
+			(void*)regs.eip,
 			syscallname(rec->syscallno),
 			syscallname(regs.orig_eax));
 		emergency_debug(ctx);


### PR DESCRIPTION
Resolves #183.  Resolves #201.

As an aside, this was a relatively simple bug that was tremendously difficult to find because of bad luck; I kept seeing rcb values like, `start_rbc < failure_rbc < target_rbc`, so it looked like execution was advancing normally but failing during the continue.  And the code that happened to be failing in FF was some crazy xpcom/JS-module junk that made me wonder if we'd missed some source of nondeterminism.  Need to be more arrogant in the future! :)
