### PR TITLE
Initial support for handling signals delivered to the syscallbuf lib.

### DIFF
--- a/src/share/util.h
+++ b/src/share/util.h
@@ -26,6 +26,8 @@
 #define PTRACE_EVENT_SECCOMP			7 // ubuntu 12.10 and future kernels
 #endif
 
+#define STOPSIG_SYSCALL (0x80 | SIGTRAP)
+
 #define ALEN(_arr) (sizeof(_arr) / (sizeof(_arr[0])))
 
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))

--- a/src/test/async_signal_syscalls.c
+++ b/src/test/async_signal_syscalls.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+static sig_atomic_t caught_usr1;
+
+static void handle_usr1(int sig) {
+	test_assert(SIGUSR1 == sig);
+	caught_usr1 = 1;
+	puts("caught usr1");
+}
+
+int main() {
+	struct timespec ts;
+	struct timeval tv;
+	int i;
+
+	signal(SIGUSR1, handle_usr1);
+
+	/* XXX arbitrarily chosen to take ~3s on a fast machine */
+	for (i = 0; i < 1 << 17; ++i) {
+		/* The odds of the signal being caught in the library
+		 * implementing these syscalls is very high.  But even
+		 * if it's not caught there, this test will pass. */
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+	}
+
+	puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/async_signal_syscalls.run
+++ b/src/test/async_signal_syscalls.run
@@ -1,0 +1,11 @@
+testname=async_signal_syscalls
+source util.sh
+compile $testname
+skip_if_no_syscall_buf $testname
+record $testname
+# Because of issue #184, replay takes longer than practical.  So for
+# now we'll skip it and hope other tests exercise the relevant code
+# well enough.
+#replay $testname
+#check $testname 'EXIT-SUCCESS'
+cleanup

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <stdio.h>
+#include <sys/time.h>
 
 #define ALEN(_a) (sizeof(_a) / sizeof(_a[0]))
 
@@ -27,9 +28,13 @@ static void* thread(void* barp) {
 }
 
 int main(int argc, char *argv[]) {
+	struct timeval tv;
 	pthread_barrier_t bar;
 	pthread_t threads[10];
 	int i;
+
+	/* (Kick on the syscallbuf lib.) */
+	gettimeofday(&tv, NULL);
 
 	pthread_barrier_init(&bar, NULL, 1 + ALEN(threads));
 

--- a/src/test/deliver_async_signal_during_syscalls.run.disabled
+++ b/src/test/deliver_async_signal_during_syscalls.run.disabled
@@ -1,0 +1,16 @@
+# Disabled because this test fails pretty frequently when SIGUSR1 is
+# delivered while rr processes a time-slice interrupt.  The test case
+# is pretty extreme, but let's hope this isn't a common occurrence!
+
+testname=async_signal_syscalls
+source util.sh
+compile $testname
+skip_if_no_syscall_buf $testname
+# SIGUSR1, wait 0.5s
+record_async_signal 10 0.5 $testname
+# Because of issue #184, replay takes longer than practical.  So for
+# now we'll skip it and hope other tests exercise the relevant code
+# well enough.
+#replay $testname
+#check $testname 'EXIT-SUCCESS'
+cleanup

--- a/src/test/threads.c
+++ b/src/test/threads.c
@@ -1,12 +1,13 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <signal.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <errno.h>
 #include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 long int counter = 0;
 
@@ -41,7 +42,11 @@ void* sender(void* id) {
 }
 
 int main() {
+	struct timeval tv;
 	pthread_t thread1, thread2;
+
+	/* (Kick on the syscallbuf lib.) */
+	gettimeofday(&tv, NULL);
 
 	/* Create independent threads each of which will execute
 	 * function */


### PR DESCRIPTION
This is _very_ basic support code-wise, but I think should document the edge cases reasonably well (and abort on the unhandled ones).  The code was pretty straightforward except that it turns out ptrace doesn't honor `PTRACE_O_TRACESYSGOOD` for `PTRACE_SINGLESTEP`.  I lost about an hour rewriting the syscallbuf code to make trace-traps through a new traced helper, when I realized that linux reports `int 0x80` as a breakpoint-trap signal instead of a trace-trap signal.  Oh well, I saved the WIP patch.
