### PR TITLE
Fix a regression that a test should have caught, except that rr happily recorded a segfault and the test passed.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -571,7 +571,8 @@ void handle_signal(const struct flags* flags, struct context* ctx)
 		return;
 	}
 
-	debug("handling signal %s (pevent: %d, event: %s)", signalname(sig),
+	debug("%d: handling signal %s (pevent: %d, event: %s)",
+	      ctx->child_tid, signalname(sig),
 	      GET_PTRACE_EVENT(ctx->status), strevent(ctx->event));
 
 	sys_ptrace_getsiginfo(tid, &si);

--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -483,7 +483,6 @@ static void set_up_buffer()
 static void drop_buffer()
 {
 	buffer = NULL;
-	buffer_hdr()->locked = 0;
 }
 
 /**

--- a/src/test/chew_cpu.c
+++ b/src/test/chew_cpu.c
@@ -29,6 +29,6 @@ int spin() {
 int main(int argc, char *argv[]) {
 	setvbuf(stdout, NULL, _IONBF, 0);
 
-	printf("done: dummy=%d\n", spin());
+	printf("EXIT-SUCCESS dummy=%d\n", spin());
 	return 0;
 }

--- a/src/test/chew_cpu.run
+++ b/src/test/chew_cpu.run
@@ -1,2 +1,2 @@
 source util.sh
-compare_test chew_cpu
+compare_test chew_cpu EXIT-SUCCESS

--- a/src/test/fork_syscalls.c
+++ b/src/test/fork_syscalls.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -22,16 +24,20 @@ static void syscalls(int num) {
 }
 
 int main() {
+	int child;
+
 	syscalls(10);
 
-	if (0 == fork()) {
+	if (0 == (child = fork())) {
 		syscalls(10);
-		puts("child done");
+		printf("CHILD-EXIT ");
 		exit(0);
 	}
 
 	syscalls(10);
 
-	puts("EXIT-SUCCESS");
+	waitpid(child, NULL, 0);
+
+	puts("PARENT-EXIT");
 	return 0;
 }

--- a/src/test/fork_syscalls.run
+++ b/src/test/fork_syscalls.run
@@ -1,3 +1,3 @@
 source util.sh
 skip_if_no_syscall_buf fork_syscalls
-compare_test fork_syscalls
+compare_test fork_syscalls "CHILD-EXIT PARENT-EXIT"

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -152,6 +152,10 @@ function cleanup {
 # Compile $test.c, record it, then replay it (optionally with
 # $rr_flags) and verify record/replay output match.
 function compare_test { test=$1; token=$2; rr_flags=$3;
+	if [[ $token == "" ]]; then
+		echo "FAILED: Test $test didn't pass an exit token" >&2
+		exit 1
+	fi
 	compile $test
 	record $test
 	replay $test $rr_flags


### PR DESCRIPTION
Amusing and annoying at the same time.  This commit also makes "exit tokens" required in tests, so this shouldn't happen again.

Unfortunately just one of at least two distinct bugs breaking wrapped `poll`.
