### PR TITLE
Run tests faster when there are multiple CPUs.

### DIFF
--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -134,7 +134,7 @@ struct dbg_context* dbg_await_client_connection(const char* address, short port)
 	if (ret) {
 		fatal("Couldn't bind to server address");
 	}
-	log_info("rr debug server listening on %s:%d",
+	log_info("(rr debug server listening on %s:%d)",
 		 !strcmp(address, "127.0.0.1") ? "" : address,
 		 ntohs(dbg->addr.sin_port));
 	/* block until debugging client connects to us */

--- a/src/share/config.h
+++ b/src/share/config.h
@@ -74,7 +74,4 @@
  */
 #define MAX_WAIT_TIMEOUT_SYS_WRITE_US		800
 
-/* Set the logical core on which the child process will be pinned on */
-#define CHILD_LOGICAL_CORE_AFFINITY_MASK (unsigned long) 0x1
-
 #endif /* CONFIG_H_ */

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -22,8 +22,6 @@ pid_t sys_fork();
 int sys_open_child_mem(pid_t child_tid);
 void sys_kill(int pid, int msg);
 void sys_exit();
-void sys_sched_setaffinity(unsigned long mask);
-void sys_setup_process();
 void sys_start_trace(char* executable, char** fake_argv, char** envp);
 
 void goto_next_event(struct context *ctx);

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -73,7 +73,7 @@ def set_up():
     global gdb, rr
     try:
         rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('rr.log', 'w'))
-        expect_rr('server listening on :(\d+)$')
+        expect_rr(r'server listening on :(\d+)\)')
         dbgport = int(rr.match.group(1))
 
         gdb = pexpect.spawn('gdb '+ get_exe(), timeout=TIMEOUT_SEC, logfile=open('gdb.log', 'w'))


### PR DESCRIPTION
The big problem here was that rr was pinning all tracees (and threads thereof) to CPU 0.  Not so friendly to -j unit tests ;).  I had a solution that randomly assigned tracess to CPUs, but it turned out that letting linux handle CPU pseudo-pinning was ~12% faster than randomly assigning.  That's good, since it's what I would expect from a decent scheduler.  So in light of that, this patch rips out the setaffinity code.

I'm testing on a 4-core machine with HT (8 HW threads).  Before this change, in a VM allocated 1 physical CPU, `make check` took ~250s.  After this change, in the same VM allocated 8 "physical" CPUs , `make check` is ~31s.  In the same 8-HW-thread VM, without this change, `make check` took around 149s.
