### PR TITLE
Buffer access() calls.

### DIFF
--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -765,6 +765,18 @@ static int stat_something(int syscallno, int vers, unsigned long what,
 
 /* Keep syscalls in alphabetical order, please. */
 
+int access(const char* pathname, int mode)
+{
+	void* ptr = prep_syscall(NO_DESCHED);
+	long ret;
+
+	if (!can_buffer_syscall(ptr)) {
+		return syscall(SYS_access, pathname, mode);
+ 	}
+	ret = untraced_syscall2(SYS_access, pathname, mode);
+	return commit_syscall(SYS_access, ptr, ret, NO_DESCHED);
+}
+
 int clock_gettime(clockid_t clk_id, struct timespec* tp)
 {
 	void* ptr = prep_syscall(NO_DESCHED);


### PR DESCRIPTION
One of the remaining >1000-calls-hot syscalls on FF startup, and simple to wrap.  New top 10 is

<pre>
syscall count
------- -----
   5      3932  (open from within libc itself)
 240      3443  (futex)
 102      2480  (socketcall)
 168      1657  (poll)
   6       926  (close from within libc)
 220       912  (getdents64)
 192       884  (mmap2)
  85       766  (readlink)
 195       750  (stat64, presumably from within libc itself)
 140       714  (_llseek)
</pre>
