### PR TITLE
Handle segfaults caused by jumping into garbage, and add a test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(BASIC_TESTS
   async_segv
   async_signal_syscalls
   async_usr1
+  bad_ip
   barrier
   breakpoint
   chew_cpu

--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -45,7 +45,13 @@ static int try_handle_rdtsc(struct context *ctx)
 	}
 
 	int size;
-	char *inst = get_inst(tid, 0, &size);
+	char *inst = get_inst(ctx, 0, &size);
+	if (!inst) {
+		/* If the segfault was caused by a jump to a bad $ip,
+		 * then we obviously won't be able to read the
+		 * instruction. */
+		return 0;
+	}
 
 	/* if the current instruction is a rdtsc, the segfault was triggered by
 	 * by reading the rdtsc instruction */

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -41,7 +41,7 @@ void goto_next_event_singlestep(struct context* context)
 
 	while (1) {
 		int inst_size;
-		char* inst = get_inst(tid, 0, &inst_size);
+		char* inst = get_inst(context, 0, &inst_size);
 		if ((strncmp(inst, "sysenter", 7) == 0) || (strncmp(inst, "int", 3) == 0)) {
 			record_inst_done(context);
 			free(inst);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -33,10 +33,10 @@
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
 #define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
 
-char* get_inst(pid_t pid, int eip_offset, int* opcode_size);
+char* get_inst(struct context* ctx, int eip_offset, int* opcode_size);
 bool is_write_mem_instruction(pid_t pid, int eip_offset, int* opcode_size);
 void emulate_child_inst(struct context * ctx, int eip_offset);
-void print_inst(pid_t tid);
+void print_inst(struct context* ctx);
 void print_syscall(struct context *ctx, struct trace_frame *trace);
 void get_eip_info(pid_t tid);
 int check_if_mapped(struct context *ctx, void *start, void *end);

--- a/src/test/bad_ip.c
+++ b/src/test/bad_ip.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static void sighandler(int sig, siginfo_t* si, void* uctxp) {
+	assert(SIGSEGV == sig && si->si_addr == (void*)0x42);
+
+	puts("caught segfault @0x42");
+	fflush(stdout);
+	_exit(0);
+}
+
+int main() {
+	struct sigaction act;
+
+	memset(&act, 0, sizeof(act));
+	act.sa_sigaction = sighandler;
+	act.sa_flags = SA_SIGINFO;
+	sigaction(SIGSEGV, &act, NULL);
+
+	__asm__ __volatile__("call 0x42");
+	return 0;
+}

--- a/src/test/bad_ip.run
+++ b/src/test/bad_ip.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh bad_ip "$@"
+compare_test 'caught segfault @0x42'

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -126,6 +126,7 @@ echo Using lib arg "'$LIB_ARG'"
 function skip_if_no_syscall_buf {
     if [[ "-n" == "$LIB_ARG" || "" == "$LIB_ARG" ]]; then
 	echo NOTE: Skipping "'$TESTNAME'" because syscallbuf is disabled
+        passed=y
 	exit 0
     fi
 }
@@ -135,6 +136,7 @@ function skip_if_no_syscall_buf {
 function skip_if_syscall_buf {
     if [[ "-b" == "$LIB_ARG" ]]; then
 	echo NOTE: Skipping "'$TESTNAME'" because syscallbuf is enabled
+        passed=y
 	exit 0
     fi
 }


### PR DESCRIPTION
rr replay is pretty much the last (sane) hope for debugging whatever is going on in #228, which seems to be a syscall return that jumps into garbage.
