### PR TITLE
Tweak the scheduler to avoid busy-waiting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(rr
 # TODO remove this when we can manage pfm and disasm dependencies
 # properly
 target_link_libraries(rr
+  -lrt
   libpfm.a
   libdisasm.a
 )

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -13,6 +13,7 @@
 
 #include <sys/syscall.h>
 
+#include "../share/dbg.h"
 #include "../share/hpc.h"
 #include "../share/list.h"
 #include "../share/sys.h"
@@ -49,48 +50,93 @@ static void set_switch_counter(struct context *last_ctx, struct context *ctx,
 struct context* get_active_thread(const struct flags* flags,
 				  struct context* ctx)
 {
+	struct context* next_ctx = NULL;
 	int max_events = flags->max_events;
+	struct list* node = current_thread_ptr;
 
-	/* This maintains the order in which the threads are signaled to continue and
-	 * when the the record is actually written
-	 */
+	debug("Scheduling next task");
 
-	if (ctx != 0) {
-		if (!ctx->allow_ctx_switch) {
-			return ctx;
-		}
-
-		/* switch to next thread if the thread reached the maximum number of RBCs */
-		if (ctx->switch_counter < 0) {
-			current_thread_ptr = list_next(current_thread_ptr);
-			ctx->switch_counter = max_events;
-		}
+	if (ctx && !ctx->allow_ctx_switch) {
+		debug("  (previous task was uninterruptible)");
+		return ctx;
 	}
 
-	struct context *return_ctx;
-	while (1) {
-		/* check all threads again, do a full circle and wait */
-		for (; !list_end(current_thread_ptr); current_thread_ptr = list_next(current_thread_ptr)) {
-			return_ctx = (struct context *) list_data(current_thread_ptr);
-			if (return_ctx != NULL) {
-				if (return_ctx->exec_state == EXEC_STATE_IN_SYSCALL) {
-					if (sys_waitpid_nonblock(return_ctx->child_tid, &(return_ctx->status)) != 0) {
-						return_ctx->exec_state = EXEC_STATE_IN_SYSCALL_DONE;
-						set_switch_counter(last_ctx, return_ctx, max_events);
-						last_ctx = return_ctx;
-						return return_ctx;
-					}
-					continue;
-				}
-				set_switch_counter(last_ctx, return_ctx, max_events);
-				last_ctx = return_ctx;
-				return return_ctx;
+	/* Prefer switching to the next task if |ctx| exceeded its
+	 * event limit. */
+	if (ctx && ctx->switch_counter < 0) {
+		debug("  previous task exceeded event limit, preferring next");
+		node = current_thread_ptr = list_next(current_thread_ptr);
+		ctx->switch_counter = max_events;
+	}
+
+	/* Go around the task list exactly one time looking for a
+	 * runnable thread. */
+	do {
+		if (list_end(node)) {
+			/* Wrap around the end of the list. */
+			node = registered_threads;
+		}
+		next_ctx = (struct context*)list_data(node);
+		/* XXX when can next_ctx be null? */
+		if (next_ctx
+		    && next_ctx->exec_state != EXEC_STATE_IN_SYSCALL) {
+			/* |next_ctx| is non-null and not blocked on a
+			 * syscall; that's what we're looking for. */
+			debug("  %d isn't blocked, done", next_ctx->child_tid);
+			break;
+		}
+		if (next_ctx) {
+			pid_t tid = next_ctx->child_tid;
+			/* We don't know yet whether |next_ctx| is
+			 * runnable; check quickly.  We do this check
+			 * to preserve scheduler fairness: if we
+			 * skipped this check, we would starve tasks
+			 * that enter syscalls.  */
+			debug("  %d is blocked, checking status ...", tid);
+			if (sys_waitpid_nonblock(tid, &(next_ctx->status))) {
+				debug("  ready!");
+				next_ctx->exec_state = EXEC_STATE_IN_SYSCALL_DONE;
+				break;
 			}
+			/* |next_ctx| isn't ready, try to find another
+			 * thread.*/
+			debug("  still blocked");
+			next_ctx = NULL;
 		}
-		current_thread_ptr = registered_threads;
+		node = list_next(node);
+	} while (node != current_thread_ptr);
+
+	if (!next_ctx) {
+		/* All the tasks are blocked.  Wait for the next one
+		 * to change state. */
+		int status;
+		pid_t tid;
+
+		debug("  all tasks blocked, waiting for runnable (%d total)",
+		      num_active_threads);
+		while (-1 == (tid = waitpid(-1, &status,
+					    __WALL | WSTOPPED | WUNTRACED))) {
+			if (EINTR == errno) {
+				debug("  waitpid() interrupted by EINTR");
+				continue;
+			}
+			fatal("Failed to waitpid()");
+		}
+		debug("  %d changed state", tid);
+
+		next_ctx = list_data(tid_to_node[tid]);
+
+		assert(next_ctx->exec_state == EXEC_STATE_IN_SYSCALL);
+
+		next_ctx->status = status;
+		next_ctx->exec_state = EXEC_STATE_IN_SYSCALL_DONE;
 	}
 
-	return 0;
+	current_thread_ptr = node;
+	/* XXX shouldn't the next two statements be reversed? */
+	set_switch_counter(last_ctx, next_ctx, max_events);
+	last_ctx = ctx;
+	return next_ctx;
 }
 
 /**

--- a/src/share/util.c
+++ b/src/share/util.c
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "../recorder/rec_sched.h"
@@ -57,6 +58,13 @@ bool is_protected_map(struct context *ctx, void *start){
 		}
 	}
 	return FALSE;
+}
+
+double now_sec()
+{
+	struct timespec tp;
+	clock_gettime(CLOCK_MONOTONIC, &tp);
+	return (double)tp.tv_sec + (double)tp.tv_nsec / 1e9;
 }
 
 const char* signalname(int sig)

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -64,6 +64,12 @@ char * get_mmaped_region_filename(struct context * ctx, void * mmap_start);
 int get_memory_size(struct context * ctx);
 
 /**
+ * Get the current time from the preferred monotonic clock in units of
+ * seconds, relative to an unspecific point in the past.
+ */
+double now_sec();
+
+/**
  * Return the symbolic name of |sig|, f.e. "SIGILL", or "???signal" if
  * unknown.
  */


### PR DESCRIPTION
This is the most immediate important change to make to the scheduler, so let's say this resolves #141.  In the future we can make things cleaner and use a more sophisticated scheduling algorithm.

This also adds a `now_sec()` helper that I've been using for instrumentation for a while.
