### PR TITLE
Make buffer-flushes interruptible, incidentally protecting them from stray SIGCHLDs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(BASIC_TESTS
 #
 # Alphabetical, please.
 set(CUSTOM_TESTS
+  break_clock
 #  break_int3
   break_mmap_private
   break_rdtsc

--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -134,27 +134,6 @@ static int try_handle_shared_mmap_access(struct context *ctx,
 	return ctx->event;
 }
 
-static int is_desched_event_syscall(struct context* ctx,
-				    const struct user_regs_struct* regs)
-{
-	return (SYS_ioctl == regs->orig_eax
-		&& ctx->desched_fd_child == regs->ebx);
-}
-
-static int is_arm_desched_event_syscall(struct context* ctx,
-					const struct user_regs_struct* regs)
-{
-	return (is_desched_event_syscall(ctx, regs)
-		&& PERF_EVENT_IOC_ENABLE == regs->ecx);
-}
-
-static int is_disarm_desched_event_syscall(struct context* ctx,
-					   const struct user_regs_struct* regs)
-{
-	return (is_desched_event_syscall(ctx, regs)
-		&& PERF_EVENT_IOC_DISABLE == regs->ecx);
-}
-
 static void disarm_desched_event(struct context* ctx)
 {
 	if (ioctl(ctx->desched_fd, PERF_EVENT_IOC_DISABLE, 0)) {

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -6,15 +6,21 @@
 struct context;
 struct rep_trace_step;
 
-/**
- * Replay up to and emulate the ioctl used to arm/disarm the desched
- * event.
- */
-void rep_skip_desched_ioctl(struct context* ctx);
-void rep_process_flush(struct context* ctx, int redirect_stdio);
 /* |redirect_stdio| is nonzero if output written to stdout/stderr
  * during recording should be tee'd during replay, zero otherwise. */
 void rep_process_syscall(struct context* ctx, int redirect_stdio,
 			 struct rep_trace_step* step);
+
+/**
+ * |ctx| is at a "write" syscall.  If the recorded write was to STDOUT
+ * or STDERR, then also write the output to the current STDOUT/STDERR
+ * (if the user wishes).
+ *
+ * NB: this doesn't bother to check for writes to the actual
+ * STDOUT/STDERR /files/, just the fd numbers.  We don't record file
+ * information.  That means output written to a dup of STDOUT will not
+ * be replayed by this helper.  This could maybe be a todo.
+ */
+void rep_maybe_replay_stdio_write(struct context* ctx, int redirect_stdio);
 
 #endif /* REP_PROCESS_EVENT_H_ */

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -96,6 +96,25 @@ void inject_code(struct current_state_buffer* buf, char* code);
 int inject_and_execute_syscall(struct context * ctx, struct user_regs_struct * call_regs);
 void mprotect_child_region(struct context * ctx, void * addr, int prot);
 
+/**
+ * Return nonzero if |ctx|'s current registers |regs| indicate that
+ * |ctx| is at an arm-desched-event or disarm-desched-event syscall.
+ */
+int is_desched_event_syscall(struct context* ctx,
+			     const struct user_regs_struct* regs);
+/**
+ * Return nonzero if |ctx|'s current registers |regs| indicate that
+ * |ctx| is at an arm-desched-event syscall.
+ */
+int is_arm_desched_event_syscall(struct context* ctx,
+				 const struct user_regs_struct* regs);
+/**
+ * Return nonzero if |ctx|'s current registers |regs| indicate that
+ * |ctx| is at a disarm-desched-event syscall.
+ */
+int is_disarm_desched_event_syscall(struct context* ctx,
+				    const struct user_regs_struct* regs);
+
 /* XXX should this go in ipc.h? */
 
 /**

--- a/src/test/break_clock.py
+++ b/src/test/break_clock.py
@@ -1,0 +1,10 @@
+from rrutil import *
+
+send_gdb('b breakpoint\n')
+expect_gdb('Breakpoint 1')
+
+for i in xrange(3):
+    send_gdb('c\n')
+    expect_gdb('Breakpoint 1, breakpoint')
+
+ok()

--- a/src/test/break_clock.run
+++ b/src/test/break_clock.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh break_clock "$@"
+record clock
+debug clock break_clock

--- a/src/test/clock.c
+++ b/src/test/clock.c
@@ -9,6 +9,11 @@
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))
 
+static void breakpoint() {
+	int break_here = 1;
+	(void)break_here;
+}
+
 int main() {
 	struct timespec ts;
 	struct timeval tv;
@@ -20,6 +25,7 @@ int main() {
 	memset(&ts, 0, sizeof(ts));
 	memset(&tv, 0, sizeof(tv));
 
+	breakpoint();
 	for (i = 0; i < 100; ++i) {
 		struct timespec ts_now;
 		struct timeval tv_now;
@@ -29,6 +35,10 @@ int main() {
 			    || (ts.tv_sec == ts_now.tv_sec
 				&& ts.tv_nsec <= ts_now.tv_nsec));
 		ts = ts_now;
+
+		if (i == 50) {
+			breakpoint();
+		}
 
 		/* technically gettimeofday() isn't monotonic, but the
 		 * value of this check is higher than the remote
@@ -43,6 +53,7 @@ int main() {
 		       (double) ts.tv_sec, (long long int) ts.tv_nsec,
 		       (double) tv.tv_sec, (long long int) tv.tv_usec);
 	}
+	breakpoint();
 
 	puts("EXIT-SUCCESS");
 	return 0;


### PR DESCRIPTION
I had another test I really wanted to add, but it's too easy to hit #215, and replay is too slow because of #184.  The latter is definitely becoming a major annoyance.

Resolves #123.
