### PR TITLE
Propagate DRI/DRM workaround to syscallbuf, and clean up ioctl handling a bit.

### DIFF
--- a/src/recorder/handle_ioctl.c
+++ b/src/recorder/handle_ioctl.c
@@ -1,27 +1,30 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "handle_ioctl.h"
+
+#include <stddef.h>		/* broken DRM headers need these */
+#include <stdint.h>
+
 #include <assert.h>
-#include <termios.h>
+#include <drm/drm.h>
+#include <drm/i915_drm.h>
+#include <drm/nouveau_drm.h>
+#include <drm/radeon_drm.h>
+#include <linux/arcfb.h>
+#include <linux/fb.h>
+#include <linux/ioctl.h>
+#include <linux/perf_event.h>
+#include <linux/soundcard.h>
+#include <linux/udf_fs_i.h>
 #include <stdio.h>
 #include <syscall.h>
 #include <stdint.h>
-
 #include <sys/ioctl.h>
-#include <asm-generic/ioctl.h>
-#include <linux/ioctl.h>
-#include <linux/arcfb.h>
-#include <linux/fb.h>
+#include <termios.h>
 
-#include <drm/drm.h>
-#include <drm/radeon_drm.h>
-#include <drm/i915_drm.h>
-
-#include <linux/udf_fs_i.h>
-
-
-#include <linux/soundcard.h>
 #include "recorder.h"
 
+#include "../share/dbg.h"
 #include "../share/ipc.h"
 #include "../share/sys.h"
 #include "../share/trace.h"
@@ -32,165 +35,116 @@ void handle_ioctl_request(struct context *ctx, int request)
 {
 	pid_t tid = ctx->child_tid;
 	int syscall = SYS_ioctl;
+	int type = _IOC_TYPE(request);
+	int nr = _IOC_NR(request);
+	int dir = _IOC_DIR(request);
+	int size = _IOC_SIZE(request);
 	struct user_regs_struct regs;
+
+	debug("handling ioctl(0x%x): type:0x%x nr:0x%x dir:0x%x size:%d",
+	      request, type, nr, dir, size);
+
+	/* (here "WRITE" means: write from OS to the process) */
+	if (!(_IOC_WRITE & dir)) {
+		/* If the kernel isn't going to write any data back to
+		 * us, we hope and pray that the result of the ioctl
+		 * (observable to the tracee) is deterministic. */
+		debug("  (deterministic ioctl, nothing to do)");
+		return;
+	}
+
 	read_child_registers(tid, &regs);
-	//debug("request: %x", _IOC_NR(request));
 
-	/* here writing means: write from OS to the process */
-	if (request & _IOC_WRITE) {
-		int size = _IOC_SIZE(request);
-		switch (request) {
+	switch (request) {
 
-		case TCGETS: /* Get and Set Terminal Attributes (from: man 4 tty_ioctl) */
-		{
-			record_child_data(ctx, syscall, sizeof(struct termios), (void*)regs.edx);
-			break;
-		}
+	/* The following are thought to be "regular" ioctls, the
+	 * processing of which is only known to (observably) write to
+	 * the bytes in the structure passed to the kernel.  So all we
+	 * need is to record |size| bytes.*/
+	/* Terminal Buffer count and flushing (from: man 4
+	 * tty_ioctl) */
+	case FIONREAD:
+	/* Get and Set Terminal Attributes (from: man 4 tty_ioctl) */
+	case TCGETS:
+	/* Terminal process group and session ID (from: man 4
+	 * tty_ioctl) */
+	case TIOCGPGRP:
+	/* request for a terminal device */
+	case TIOCGWINSZ:
+		record_child_data(ctx, syscall, size, (void*)regs.edx);
+		break;
 
+	/* TODO: what are the 0x46 ioctls? */
+	case 0xc020462b:
+	case 0xc048464d:
+	case 0xc0204637:
+	case 0xc0304627:
+		fatal("Unknown 0x46-series ioctl nr 0x%x", nr);
+		break;	/* not reached */
 
-		case FIONREAD: /* Terminal Buffer count and flushing (from: man 4 tty_ioctl) */
-		case TIOCGPGRP: /* Terminal process group and session ID (from: man 4 tty_ioctl) */
-		{
-			record_child_data(ctx, syscall, sizeof(int), (void*)regs.edx);
-			break;
-		}
+	/* The following are ioctls for the linux Direct Rendering
+	 * Manager (DRM).  The ioctl "type" is 0x64 (100, or ASCII 'd'
+	 * as they docs helpfully declare it :/).  The ioctl numbers
+	 * are allocated as follows
+	 *
+	 *  [0x00, 0x40) -- generic commands
+	 *  [0x40, 0xa0) -- device-specific commands
+	 *  [0xa0, 0xff) -- more generic commands
+	 *
+	 * Chasing down unknown ioctls is somewhat annoying in this
+	 * scheme, but here's an example: request "0xc0406481".  "0xc"
+	 * means it's a read/write ioctl, and "0x0040" is the size of
+	 * the payload.  The actual ioctl request is "0x6481".
+	 *
+	 * As we saw above, "0x64" is the DRM type.  So now we need to
+	 * see what command "0x81" is.  It's in the
+	 * device-specific-command space, so we can start by
+	 * subtracting "0x40" to get a command "0x41".  Then
+	 *
+	 *  $ cd 
+	 *  $ grep -rn 0x41 *
+	 *  nouveau_drm.h:200:#define DRM_NOUVEAU_GEM_PUSHBUF        0x41
+	 *
+	 * Well that was lucky!  So the command is
+	 * DRM_NOUVEAU_GEM_PUSHBUF, and the parameters etc can be
+	 * tracked down from that.
+	 */
 
-		case 0xc020462b:
-		case 0xc048464d:
-		case 0xc0204637:
-		case 0xc0304627:
-		{
-			record_child_data(ctx, syscall, _IOC_SIZE(request), (void*)regs.edx);
-			break;
-		}
+	/* TODO: At least one of these ioctl()s, most likely
+	 * NOUVEAU_GEM_NEW, opens a file behind rr's back on behalf of
+	 * the callee.  That wreaks havoc later on in execution, so we
+	 * disable the whole lot for now until rr can handle that
+	 * behavior (by recording access to shmem segments). */
+	case DRM_IOCTL_VERSION:
+	case DRM_IOCTL_NOUVEAU_GETPARAM:
+	case DRM_IOCTL_NOUVEAU_CHANNEL_ALLOC:
+	case DRM_IOCTL_NOUVEAU_CHANNEL_FREE:
+	case DRM_IOCTL_NOUVEAU_GEM_NEW:
+	case DRM_IOCTL_NOUVEAU_GEM_PUSHBUF:
+		fatal("Intentionally unhandled DRM(0x64) ioctl nr 0x%x", nr);
+		break;
 
-		// Firefox ioctls FIXME: find out what these mean.
-		case 0x4010644d:
-		case 0xc0186441:
-		case 0x80086447:
-		case 0xc0306449:
-		case 0xc030644b:
-		{
-			record_child_data(ctx, syscall, _IOC_SIZE(request), (void*)regs.edx);
-			break;
-		}
+	case DRM_IOCTL_GET_MAGIC:
+	case DRM_IOCTL_RADEON_INFO:
+	case DRM_IOCTL_I915_GEM_PWRITE:
+	case DRM_IOCTL_GEM_OPEN:
+	case DRM_IOCTL_I915_GEM_MMAP:
+	case DRM_IOCTL_RADEON_GEM_CREATE:
+	case DRM_IOCTL_RADEON_GEM_GET_TILING:
+		fatal("Not-understood DRM(0x64) ioctl nr 0x%x", nr);
+		break;	/* not reached */
 
-		/*if (request == FIONREAD) {
-		 record_child_data(tid, syscall, sizeof(int), regs.edx);
-		 } else if (request == TCGETS) {
-		 record_child_data(tid, syscall, sizeof(struct termios), regs.edx);
-		 } else if (request == TIOCGWINSZ) {
-		 record_child_data(tid, syscall, sizeof(struct winsize), regs.edx);
-		 } else {*/
+	case 0x4010644d:
+	case 0xc0186441:
+	case 0x80086447:
+	case 0xc0306449:
+	case 0xc030644b:
+		fatal("Unknown DRM(0x64) ioctl nr 0x%x", nr);
+		break;	/* not reached */
 
-		/* requests starting with '64' (= 'd') */
-		case DRM_IOCTL_VERSION:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_version));
-			struct drm_version *version = read_child_data(ctx, sizeof(struct drm_version), (void*)regs.edx);
-
-			record_child_data(ctx, syscall, sizeof(struct drm_version), (void*)regs.edx);
-			record_child_data(ctx, syscall, version->name_len, version->name);
-			record_child_data(ctx, syscall, version->date_len, version->date);
-			record_child_data(ctx, syscall, version->desc_len, version->desc);
-
-			sys_free((void**) &version);
-			break;
-		}
-
-		case DRM_IOCTL_GET_MAGIC:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_auth));
-			record_child_data(ctx, syscall, sizeof(struct drm_auth), (void*)regs.edx);
-			break;
-		}
-
-		case DRM_IOCTL_RADEON_INFO:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_radeon_info));
-			record_child_data(ctx, syscall, sizeof(struct drm_radeon_info), (void*)regs.esi);
-			break;
-		}
-
-		case DRM_IOCTL_I915_GEM_PWRITE:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_i915_gem_pwrite));
-			struct drm_i915_gem_pwrite* tmp = read_child_data(ctx, size, (void*)regs.edx);
-			record_child_data(ctx, syscall, sizeof(struct drm_i915_gem_pwrite), (void*)regs.edx);
-			record_child_data(ctx, syscall, tmp->size, (void*)(uintptr_t)tmp->data_ptr);
-			sys_free((void**) &tmp);
-			break;
-		}
-
-		case DRM_IOCTL_RADEON_GEM_CREATE:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_radeon_gem_create));
-			record_child_data(ctx, syscall, sizeof(struct drm_radeon_gem_create), (void*)regs.edx);
-			break;
-		}
-
-		case DRM_IOCTL_I915_GEM_MMAP:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_i915_gem_mmap));
-			struct drm_i915_gem_mmap* tmp = read_child_data_tid(tid, sizeof(struct drm_i915_gem_mmap), (void*)regs.edx);
-			record_child_data(ctx, syscall, sizeof(struct drm_i915_gem_mmap), (void*)regs.edx);
-			record_child_data(ctx, syscall, tmp->size, (void*)(uintptr_t)(tmp->addr_ptr + tmp->offset));
-			sys_free((void**) &tmp);
-			break;
-		}
-
-		case DRM_IOCTL_GEM_OPEN:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_gem_open));
-			struct drm_gem_open* tmp = read_child_data_tid(tid, size, (void*)regs.edx);
-			record_child_data(ctx, syscall, sizeof(struct drm_gem_open), (void*)regs.edx);
-			record_child_data(ctx, syscall, tmp->size, (void*)tmp->handle);
-			sys_free((void**) &tmp);
-			break;
-		}
-
-		case DRM_IOCTL_RADEON_GEM_GET_TILING:
-		{
-			assert(1==0);
-
-			assert(size == sizeof(struct drm_radeon_gem_get_tiling));
-			record_child_data(ctx, syscall, sizeof(struct drm_radeon_gem_get_tiling), (void*)regs.edx);
-			break;
-		}
-
-		case TIOCGWINSZ: /* request for a terminal device */
-		{
-			/* don't care what size asked, record the buffer at the return state */
-			struct winsize* tmp = read_child_data_tid(tid, size, (void*)regs.edx);
-			record_child_data(ctx, syscall, sizeof(struct winsize), (void*)regs.edx);
-			sys_free((void**) &tmp);
-			break;
-		}
-
-		default:
-		{
-			fprintf(stderr, "Unknown ioctl request: %x -- bailing out\n", request);
-			fprintf(stderr, "type bites: %x\n", _IOC_TYPE(request));
-			fprintf(stderr, "size: %d\n", _IOC_SIZE(request));
-			fprintf(stderr, "addr: %lx\n", read_child_edx(ctx->child_tid));
-			print_register_file_tid(ctx->child_tid);
-			sys_exit();
-			break;
-		}
-		}
+	default:
+		print_register_file_tid(ctx->child_tid);
+		fatal("Unknown ioctl(0x%x): type:0x%x nr:0x%x dir:0x%x size:%d addr:%p",
+		      request, type, nr, dir, size, (void*)regs.edx);
 	}
 }

--- a/src/recorder/handle_ioctl.h
+++ b/src/recorder/handle_ioctl.h
@@ -3,7 +3,8 @@
 #ifndef HANDLE_IOCTL_H_
 #define HANDLE_IOCTL_H_
 
-void handle_ioctl_request(struct context* context, int request);
+struct context;
 
+void handle_ioctl_request(struct context* context, int request);
 
 #endif /* HANDLE_IOCTL_H_ */

--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -1087,9 +1087,20 @@ int open(const char* pathname, int flags, ...)
 	 * allowing descheds here may cause performance issues if the
 	 * open does block for a while.  Err on the side of simplicity
 	 * until we have perf data. */
-	void* ptr = prep_syscall(NO_DESCHED);
+	void* ptr;
 	int mode = 0;
 	long ret;
+
+	if (is_blacklisted_filename(pathname)) {
+		/* Would be nice to log_info() here, but that would
+		 * flush the syscallbuf ...  This special bail-out
+		 * case is deterministic, so no need to save any
+		 * breadcrumbs in the syscallbuf. */
+		errno = ENOENT;
+		return -1;
+	}
+
+	ptr = prep_syscall(NO_DESCHED);
 
 	if (O_CREAT & flags) {
 		va_list mode_arg;

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -124,4 +124,20 @@ inline static void prepare_syscallbuf_socket_addr(struct sockaddr_un* addr,
 		 "/tmp/rr-tracee-ctrlsock-%d", tid);
 }
 
+/**
+ * Return nonzero if an attempted open() of |filename| should be
+ * blocked.
+ *
+ * The background of this hack is that rr doesn't support DRI/DRM
+ * currently, so we use the blunt stick of refusing to open this
+ * interface file as a way of disabling it entirely.  (In addition to
+ * tickling xorg.conf, which doesn't entirely do the trick.)  It's
+ * known how to fix this particular, so let's not let this hack grow
+ * too much by piling on.
+ */
+inline static int is_blacklisted_filename(const char* filename)
+{
+	return !strcmp("/dev/dri/card0", filename);
+}
+
 #endif /* SYSCALL_BUFFER_H_ */


### PR DESCRIPTION
Resolves #254 in what became quite a wild goose chase.  Turns out I forgot that syscallbuf became the default, and there was a hack in traced `open()` that needed to be propagated to the buffered one.  Oh well.  Net reduction in code.
