### PR TITLE
Correct an unintended log_info() statement to debug().

### DIFF
--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -758,8 +758,8 @@ void start_recording(struct flags rr_flags)
 			// if the syscall is about to be restarted, save the last syscall performed by it.
 			if (syscall != SYS_restart_syscall &&
 			    (retval == ERESTART_RESTARTBLOCK || retval == ERESTARTNOINTR)) {
-				log_info("  retval %d, will restart %s",
-					 retval, syscallname(syscall));
+				debug("  retval %d, will restart %s",
+				      retval, syscallname(syscall));
 				ctx->last_syscall = syscall;
 				ctx->will_restart = 1;
 			}


### PR DESCRIPTION
(Using this trivial fix as a means of testing a new merge method.)
