### PR TITLE
Handle the case when orig_eax is garbage, for whatever reason.

### DIFF
--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1425,13 +1425,13 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 		 */
 		case SYS_RECV:
 		{
+			int length = ctx->recorded_scratch_size;//regs.eax;
+			if (length <= 0) {
+				break;
+			}
 			// restore ecx
 			regs.ecx = (uintptr_t)ctx->recorded_scratch_ptr_0;
 			write_child_registers(tid,&regs);
-
-			int length = ctx->recorded_scratch_size;//regs.eax;
-			if (length <= 0)
-				break;
 
 			// copy the buffer back to the original location
 			size_t num_args = 4;

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -149,6 +149,12 @@ static int prep_event(struct context* ctx, int event)
 	 * general.  Descheds only happen for buffered syscalls, so we
 	 * know there's no scratch-buffer prep needed. */
 	if (ctx->desched) {
+		/* We're not using the scratch_* buffers, so make sure
+		 * rec_process_event() knows not to restore the
+		 * buffers. */
+		ctx->recorded_scratch_ptr_0 = NULL;
+		ctx->recorded_scratch_ptr_1 = NULL;
+		ctx->recorded_scratch_size = -1;
 		return 1;
 	}
 
@@ -750,6 +756,9 @@ void start_recording(struct flags rr_flags)
 			read_child_registers(ctx->child_tid,&regs);
 			int syscall = regs.orig_eax;
 			int retval = regs.eax;
+
+			debug("  orig_eax is %d (%s)",
+			      syscall, syscallname(syscall));
 
 			/* we received a signal while in the system call and send it right away*/
 			/* we have already sent the signal and process sigreturn */

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -171,8 +171,8 @@ long sys_ptrace(int request, pid_t pid, void *addr, void *data)
 {
 	long ret;
 	if ((ret = ptrace(request, pid, addr, data)) == -1) {
-		log_err("ptrace_error: request: %d of tid: %d: addr %p, data %p", request, pid, addr, data);
-		sys_exit();
+		fatal("ptrace_error: request: %d of tid: %d: addr %p, data %p",
+		      request, pid, addr, data);
 	}
 	return ret;
 }

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -102,6 +102,17 @@ struct socketcall_args {
 } __attribute__((packed));
 
 /**
+ * Return a pointer to what may be the next syscall record.
+ *
+ * THIS POINTER IS NOT GUARANTEED TO BE VALID!!!  Caveat emptor.
+ */
+inline static struct syscallbuf_record* next_record(struct syscallbuf_hdr* hdr)
+{
+	
+	return (void*)hdr->recs + hdr->num_rec_bytes;
+}
+
+/**
  * Return the amount of space that a record of |length| will occupy in
  * the buffer if committed, including padding.
  */


### PR DESCRIPTION
Another nasty bug that, quite frustratingly, I can't write a sane test for :/.  Adding to the frustration, I have no idea where the weird orig_eax values are coming from, but even if I did, I don't think there's anything we could do about it.

Anyway, after pretty extensive FF testing, this change looks pretty solid.  Resolves #265.  Resolves #266.
