### PR TITLE
Support pwrite64 and add a test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(BASIC_TESTS
 #  mmap_shared
   perf_event
   priority
+  prw
   rdtsc
   segfault
   sigchld_interrupt_signal

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1064,6 +1064,7 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 	 * set
 	 */
 	SYS_REC1(pread64, regs.eax, (void*)regs.ecx)
+	SYS_REC0(pwrite64)
 
 	/**
 	 *  int prlimit(pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit);

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -795,6 +795,7 @@ SYSCALL_DEF(EMU, prctl, 1)
  * offset
  */
 SYSCALL_DEF(EMU, pread64, 1)
+SYSCALL_DEF(EMU, pwrite64, 0)
 
 /**
  *  int prlimit(pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit);

--- a/src/test/perf_event.c
+++ b/src/test/perf_event.c
@@ -46,6 +46,6 @@ int main(int argc, char *argv[]) {
 		printf("after yield: %llu\n", get_desched());
 	}
 
-	puts("EXIT_SUCCESS");
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/perf_event.run
+++ b/src/test/perf_event.run
@@ -1,2 +1,2 @@
 source `dirname $0`/util.sh perf_event "$@"
-compare_test EXIT_SUCCESS
+compare_test EXIT-SUCCESS

--- a/src/test/prw.c
+++ b/src/test/prw.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+	int fd = open("prw.txt", O_CREAT | O_RDWR);
+	const char content[] = "01234567890\nhello there\n";
+	char buf[sizeof(content)];
+	ssize_t nr;
+
+	memset(buf, '?', sizeof(buf));
+	nr = write(fd, buf, sizeof(buf));
+	assert(nr == sizeof(buf));
+	nr = write(fd, buf, 10);
+	assert(nr == 10);
+
+	nr = pwrite(fd, content, sizeof(content), 10);
+	assert(nr == sizeof(content));
+	printf("Wrote ```%s'''\n", content);
+
+	nr = pread(fd, buf, sizeof(buf), 10);
+	assert(nr == sizeof(content));
+	printf("Read ```%s'''\n", buf);
+
+	puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/prw.run
+++ b/src/test/prw.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh prw "$@"
+compare_test EXIT-SUCCESS

--- a/src/test/simple.c
+++ b/src/test/simple.c
@@ -3,6 +3,6 @@
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-	puts("EXIT_SUCCESS");
+	puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/simple.run
+++ b/src/test/simple.run
@@ -1,2 +1,2 @@
 source `dirname $0`/util.sh simple "$@"
-compare_test EXIT_SUCCESS
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Turns out we inherited support for pread, so only pwrite was required.  Resolves #208.
