### PR TITLE
Re-use emergency_debug() in the recording code.

### DIFF
--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -16,7 +16,7 @@ void replay(struct flags rr_flags);
  *
  *  if (recorded_state != replay_state) {
  *	 log_err("Bad state ...");
- *	 emergency_debug(tid);
+ *	 emergency_debug(ctx);
  *  }
  *
  * This function does not return.


### PR DESCRIPTION
I started to polish up the dopey detach-and-exec-gdb code I'd been using for testing, but then I realized the `emergency_debug()` code doesn't care whether it's running on behalf of a recorded or replayed task at all, since it will never try to resume execution.  So we get to repurpose the helper "for free".  Resolves #216.
