### PR TITLE
Handle ERESTART* codes better, and make scratch mem and syscallbuf play better together.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ install(TARGETS rr rr_syscall_buffer
 #
 # Alphabetical, please.
 set(BASIC_TESTS
+  accept
   alarm
   args
   async_segv
@@ -78,6 +79,7 @@ set(BASIC_TESTS
   async_usr1
   bad_ip
   barrier
+  block
   breakpoint
   chew_cpu
   clock

--- a/src/recorder/rec_process_event.h
+++ b/src/recorder/rec_process_event.h
@@ -3,10 +3,19 @@
 #ifndef PROCESS_SYSCALL_H_
 #define PROCESS_SYSCALL_H_
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include "../share/types.h"
 #include "../share/util.h"
 
-void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags);
+/**
+ * Prepare |ctx| to enter |syscallno|.  Return nonzero if a
+ * context-switch is allowed for |ctx|, 0 if not.
+ */
+int rec_prepare_syscall(struct context* ctx, int syscallno);
+void rec_process_syscall(struct context* ctx, int syscall, struct flags rr_flags);
 void process_thread_start(pid_t pid);
 
 /*

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -107,8 +107,7 @@ struct socketcall_args {
  * THIS POINTER IS NOT GUARANTEED TO BE VALID!!!  Caveat emptor.
  */
 inline static struct syscallbuf_record* next_record(struct syscallbuf_hdr* hdr)
-{
-	
+{	
 	return (void*)hdr->recs + hdr->num_rec_bytes;
 }
 

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -63,9 +63,12 @@ enum {
 	RRCALL_BIT = 0x8000
 };
 
-// Notice: these are defined in errno.h if _kernel_ is defined.
-#define ERESTARTNOINTR 			-513
-#define ERESTART_RESTARTBLOCK	-516
+/* These are defined by the include/linux/errno.h in the kernel tree.
+ * Since userspace doesn't see these errnos in normal operation, that
+ * header apparently isn't distributed with libc. */
+#define ERESTARTSYS 512
+#define ERESTARTNOINTR 513
+#define ERESTART_RESTARTBLOCK 516
 
 #define MAX_RAW_DATA_SIZE		(1 << 30)
 

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -90,10 +90,58 @@ struct context {
 	 * point, for not-well-understand reasons. */
 	int will_restart;
 
-	void *recorded_scratch_ptr_0;
-	void *recorded_scratch_ptr_1;
-
-	int recorded_scratch_size;
+	/* When tasks enter syscalls that may block and so must be
+	 * prepared for a context-switch, and the syscall params
+	 * include (in)outparams that point to buffers, we need to
+	 * redirect those arguments to scratch memory.  This allows rr
+	 * to serialize execution of what may be multiple blocked
+	 * syscalls completing "simulatenously" (from rr's
+	 * perspective).  After the syscall exits, we restore the data
+	 * saved in scratch memory to the original buffers.
+	 *
+	 * Then during replay, we simply restore the saved data to the
+	 * tracee's passed-in buffer args and continue on.
+	 *
+	 * The array |saved_arg_ptr| stores the original callee
+	 * pointers that we replaced with pointers into the
+	 * syscallbuf.  |tmp_data_num_bytes| is the number of bytes
+	 * we'll be saving across *all* buffer outparams.  (We can
+	 * save one length value because all the tmp pointers into
+	 * scratch are contiguous.)  |tmp_data_ptr| /usually/ points
+	 * at |scratch_ptr|, except ...
+	 *
+	 * ... a fly in this ointment is may-block buffered syscalls.
+	 * If a task blocks in one of those, it will look like it just
+	 * entered a syscall that needs a scratch buffer.  However,
+	 * it's too late at that point to fudge the syscall args,
+	 * because processing of the syscall has already begun in the
+	 * kernel.  But that's OK: the syscallbuf code has already
+	 * swapped out the original buffer-pointers for pointers into
+	 * the syscallbuf (which acts as its own scratch memory).  We
+	 * just have to worry about setting things up properly for
+	 * replay.
+	 *
+	 * The descheduled syscall will "abort" its commit into the
+	 * syscallbuf, so the outparam data won't actually be saved
+	 * there (and thus, won't be restored during replay).  During
+	 * replay, we have to restore them like we restore the
+	 * non-buffered-syscall scratch data.
+	 *
+	 * What we do is add another level of indirection to the
+	 * "scratch pointer", through |tmp_data_ptr|.  Usually that
+	 * will point at |scratch_ptr|, for unbuffered syscalls.  But
+	 * for desched'd buffered ones, it will point at the region of
+	 * the syscallbuf that's being used as "scratch".  We'll save
+	 * that region during recording and restore it during replay
+	 * without caring which scratch space it points to.
+	 *
+	 * (The recorder code has to be careful, however, not to
+	 * attempt to copy-back syscallbuf tmp data to the "original"
+	 * buffers.  The syscallbuf code will do that itself.) */
+	void* saved_arg_ptr[3];
+	int next_saved_arg;
+	void* tmp_data_ptr;
+	int tmp_data_num_bytes;
 
 	/* The child's desched counter event fd number, and our local
 	 * dup. */

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -18,7 +18,7 @@
 #define SYSCALL_FAILED(eax) \
 	(-ERANGE <= (int)(eax) && (int)(eax) < 0)
 #define SYSCALL_WILL_RESTART(eax) \
-	(ERESTART_RESTARTBLOCK == (eax) || ERESTARTNOINTR == (eax))
+	(-ERESTART_RESTARTBLOCK == (eax) || -ERESTARTNOINTR == (eax))
 
 #ifndef PTRACE_EVENT_SECCOMP
 #define PTRACE_O_TRACESECCOMP			0x00000080

--- a/src/test/accept.c
+++ b/src/test/accept.c
@@ -1,0 +1,53 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+static void client(const struct sockaddr_un* addr) {
+	int clientfd;
+
+	clientfd = socket(AF_UNIX, SOCK_STREAM, 0);
+	test_assert(0 == connect(clientfd, (struct sockaddr*)addr,
+				 sizeof(*addr)));
+}
+
+static void server() {
+	struct sockaddr_un addr;
+	int listenfd;
+	int servefd;
+	struct sockaddr_un peer_addr;
+	socklen_t len = sizeof(peer_addr);;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, "socket.unix", sizeof(addr.sun_path) - 1);
+	
+	test_assert(0 <= (listenfd = socket(AF_UNIX, SOCK_STREAM, 0)));
+	test_assert(0 == bind(listenfd, (struct sockaddr*)&addr,
+			      sizeof(addr)));
+	test_assert(0 == listen(listenfd, 1));
+
+	if (0 == fork()) {
+		return client(&addr);
+	}
+
+	test_assert(0 <= (servefd = accept(listenfd,
+					   (struct sockaddr*)&peer_addr,
+					   &len)));
+	test_assert(AF_UNIX == peer_addr.sun_family);
+
+	unlink(addr.sun_path);
+
+	puts("EXIT-SUCCESS");
+}
+
+int main(int argc, char *argv[]) {
+	server();
+	return 0;
+}

--- a/src/test/accept.run
+++ b/src/test/accept.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh accept "$@"
+compare_test EXIT-SUCCESS

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -1,0 +1,103 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+const char token = '?';
+
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+int sockfds[2];
+
+void* reader_thread(void* dontcare) {
+	struct timeval ts;
+	struct pollfd pfd;
+	char c;
+
+	gettimeofday(&ts, NULL);
+
+	puts("r: acquiring mutex ...");
+	pthread_mutex_lock(&lock);
+	puts("r:   ... releasing mutex");
+	pthread_mutex_unlock(&lock);
+
+	puts("r: polling socket ...");
+	pfd.fd = sockfds[1];
+	pfd.events = POLLIN;
+	poll(&pfd, 1, -1);
+	puts("r:   ... done, doing nonblocking read ...");
+	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
+	printf("r:   ... read '%c'\n", c);
+	test_assert(c == token);
+
+	puts("r: reading socket ...");
+	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
+	printf("r:   ... read '%c'\n", c);
+	test_assert(c == token);
+
+	puts("r: recv'ing socket ...");
+	test_assert(1 == recv(sockfds[1], &c, sizeof(c), 0));
+	printf("r:   ... recv'd '%c'\n", c);
+	test_assert(c == token);
+
+	/* Make the main thread wait on our join() */
+	puts("r: sleeping ...");
+	usleep(500000);
+
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	struct timeval ts;
+	pthread_t reader;
+
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	gettimeofday(&ts, NULL);
+
+	socketpair(AF_LOCAL, SOCK_STREAM, 0, sockfds);
+
+	pthread_mutex_lock(&lock);
+
+	pthread_create(&reader, NULL, reader_thread, NULL);
+
+	/* Make the reader thread wait on its pthread_mutex_lock() */
+	puts("M: sleeping ...");
+	usleep(500000);
+	puts("M: unlocking mutex ...");
+	pthread_mutex_unlock(&lock);
+	puts("M:   ... done");
+
+	/* Force a wait on poll() */
+	puts("M: sleeping again ...");
+	usleep(500000);
+	printf("M: writing '%c' to socket ...\n", token);
+	write(sockfds[0], &token, sizeof(token));
+	puts("M:   ... done");
+
+	/* Force a wait on read() */
+	puts("M: sleeping again ...");
+	usleep(500000);
+	printf("M: writing '%c' to socket ...\n", token);
+	write(sockfds[0], &token, sizeof(token));
+	puts("M:   ... done");
+
+	/* Force a wait on recv() */
+	puts("M: sleeping again ...");
+	usleep(500000);
+	printf("M: sending '%c' to socket ...\n", token);
+	send(sockfds[0], &token, sizeof(token), 0);
+	puts("M:   ... done");
+
+	pthread_join(reader, NULL);
+
+	puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/block.run
+++ b/src/test/block.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh block "$@"
+compare_test EXIT-SUCCESS

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -27,17 +27,17 @@ function delay_kill { sig=$1; delay_secs=$2; proc=$3
 
     pid=""
     for i in `seq 1 5`; do
-	live=`ps -C $3 -o pid=`
-	num=`echo -e $live | wc -w`
-	if [[ $num == 1 ]]; then
-	    pid=$live
+	live=`ps ax -o 'pid= cmd=' | awk '{print $1 " " $2}' | grep $proc`
+	num=`echo "$live" | wc -l`
+	if [[ "$num" -eq 1 ]]; then
+	    pid=`echo "$live" | awk '{print $1}'`
 	    break
 	fi
 	sleep 0.1
     done
 
-    if [[ $num > 1 ]]; then
-	echo FAILED: more than one "'$proc'" >&2
+    if [[ "$num" -gt 1 ]]; then
+	echo FAILED: "$num" of "'$proc'" >&2
 	exit 1
     elif [[ -z "$pid" ]]; then
 	echo FAILED: process "'$proc'" not located >&2


### PR DESCRIPTION
This commit changes the way scratch memory state is saved: instead of
always using |scratch_ptr| as the saved scratch area, another level of
indirection is added.  This enables syscallbuf _or_ scratch memory to
be recorded.  This invasive change required touching most of the code
that used scratch, so was a convenient excuse to clean up a bit and
add some consistency checks.

Adds two tests, of blocking syscalls and socket usage.

Resolves #282.
