### PR TITLE
Save a ref to the desched'd syscall record before we reset the counter, and record the right scratch pointer.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -347,6 +347,7 @@ static int try_handle_desched_event(struct context* ctx, const siginfo_t* si,
 
 	if (-ERESTARTSYS == regs->eax) {
 		int sig = advance_syscall_boundary(ctx, regs);
+		debug("  (restarted ERESTARTSYS syscall)");
 		assert(STOPSIG_SYSCALL == sig);
 		assert(-ENOSYS == regs->eax);
 		assert(call == regs->orig_eax);

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -390,6 +390,13 @@ void start_recording(struct flags rr_flags)
 			}
 
 			if (ctx->desched) {
+				/* Stash away this breadcrumb so that
+				 * we can figure out what syscall the
+				 * tracee was in, and how much
+				 * "scratch" space it carved off the
+				 * syscallbuf, if needed. */
+				ctx->desched_rec =
+					next_record(ctx->syscallbuf_hdr);
 				/* Replay needs to be prepared to see
 				 * the ioctl() that arms the desched
 				 * counter when it's trying to step to

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -29,6 +29,7 @@ typedef enum { FALSE = 0, TRUE = 1 } bool;
 typedef unsigned char byte;
 
 struct syscallbuf_hdr;
+struct syscallbuf_record;
 
 /**
  * A trace_frame is one "trace event" from a complete trace.  During
@@ -73,6 +74,12 @@ struct context {
 	 * progress, in general.  We also need to record some extra
 	 * trace data to ensure replay doesn't diverge. */
 	int desched;
+	/* Record of the syscall that was interrupted by the desched
+	 * notification.  It's legal to reference this memory /while
+	 * the desched is being processed only/, because |ctx| is in
+	 * the middle of a desched, which means it's successfully
+	 * allocated (but not yet committed) a syscall record. */
+	const struct syscallbuf_record* desched_rec;
 	/* Nonzero after the trace recorder has flushed the
 	 * syscallbuf.  When this happens, the recorder must prepare a
 	 * "reset" of the buffer, to zero the record count, at the

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -4,6 +4,7 @@
 #include <poll.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <sys/epoll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -11,15 +12,14 @@
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))
 
-const char token = '?';
-
 pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 int sockfds[2];
 
 void* reader_thread(void* dontcare) {
+	char token = '!';
+	int readsock = sockfds[1];
 	struct timeval ts;
-	struct pollfd pfd;
-	char c;
+	char c = '\0';
 
 	gettimeofday(&ts, NULL);
 
@@ -28,25 +28,54 @@ void* reader_thread(void* dontcare) {
 	puts("r:   ... releasing mutex");
 	pthread_mutex_unlock(&lock);
 
-	puts("r: polling socket ...");
-	pfd.fd = sockfds[1];
-	pfd.events = POLLIN;
-	poll(&pfd, 1, -1);
-	puts("r:   ... done, doing nonblocking read ...");
-	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
-	printf("r:   ... read '%c'\n", c);
-	test_assert(c == token);
-
 	puts("r: reading socket ...");
-	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
+	gettimeofday(&ts, NULL);
+	test_assert(1 == read(readsock, &c, sizeof(c)));
 	printf("r:   ... read '%c'\n", c);
 	test_assert(c == token);
+	++token;
 
 	puts("r: recv'ing socket ...");
-	test_assert(1 == recv(sockfds[1], &c, sizeof(c), 0));
+	gettimeofday(&ts, NULL);
+	test_assert(1 == recv(readsock, &c, sizeof(c), 0));
 	printf("r:   ... recv'd '%c'\n", c);
 	test_assert(c == token);
+	++token;
+	{
+		struct pollfd pfd;
 
+		puts("r: polling socket ...");
+		pfd.fd = readsock;
+		pfd.events = POLLIN;
+		gettimeofday(&ts, NULL);
+		poll(&pfd, 1, -1);
+		puts("r:   ... done, doing nonblocking read ...");
+		test_assert(1 == read(readsock, &c, sizeof(c)));
+		printf("r:   ... read '%c'\n", c);
+		test_assert(c == token);
+		++token;
+	}
+	{
+		int epfd;
+		struct epoll_event ev;
+
+		puts("r: epolling socket ...");
+		test_assert(0 <= (epfd = epoll_create(1/*num events*/)));
+		ev.events = EPOLLIN;
+		ev.data.fd = readsock;
+		gettimeofday(&ts, NULL);
+		test_assert(0 == epoll_ctl(epfd, EPOLL_CTL_ADD, ev.data.fd,
+					   &ev));
+		test_assert(1 == epoll_wait(epfd, &ev, 1, -1));
+		puts("r:   ... done, doing nonblocking read ...");
+		test_assert(readsock == ev.data.fd);
+		test_assert(1 == read(readsock, &c, sizeof(c)));
+		printf("r:   ... read '%c'\n", c);
+		test_assert(c == token);
+		++token;
+
+		close(epfd);
+	}
 	/* Make the main thread wait on our join() */
 	puts("r: sleeping ...");
 	usleep(500000);
@@ -55,6 +84,7 @@ void* reader_thread(void* dontcare) {
 }
 
 int main(int argc, char *argv[]) {
+	char token = '!';
 	struct timeval ts;
 	pthread_t reader;
 
@@ -75,18 +105,12 @@ int main(int argc, char *argv[]) {
 	pthread_mutex_unlock(&lock);
 	puts("M:   ... done");
 
-	/* Force a wait on poll() */
-	puts("M: sleeping again ...");
-	usleep(500000);
-	printf("M: writing '%c' to socket ...\n", token);
-	write(sockfds[0], &token, sizeof(token));
-	puts("M:   ... done");
-
 	/* Force a wait on read() */
 	puts("M: sleeping again ...");
 	usleep(500000);
 	printf("M: writing '%c' to socket ...\n", token);
 	write(sockfds[0], &token, sizeof(token));
+	++token;
 	puts("M:   ... done");
 
 	/* Force a wait on recv() */
@@ -94,6 +118,23 @@ int main(int argc, char *argv[]) {
 	usleep(500000);
 	printf("M: sending '%c' to socket ...\n", token);
 	send(sockfds[0], &token, sizeof(token), 0);
+	++token;
+	puts("M:   ... done");
+
+	/* Force a wait on poll() */
+	puts("M: sleeping again ...");
+	usleep(500000);
+	printf("M: writing '%c' to socket ...\n", token);
+	write(sockfds[0], &token, sizeof(token));
+	++token;
+	puts("M:   ... done");
+
+	/* Force a wait on epoll_wait() */
+	puts("M: sleeping again ...");
+	usleep(500000);
+	printf("M: writing '%c' to socket ...\n", token);
+	write(sockfds[0], &token, sizeof(token));
+	++token;
 	puts("M:   ... done");
 
 	pthread_join(reader, NULL);


### PR DESCRIPTION
Resolves #289.
