### PR TITLE
Remove an unnecessary trace frame.

### DIFF
--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -224,12 +224,6 @@ void start_recording(struct flags rr_flags)
 	rr_flags_ = rr_flags;
 	struct context *ctx = NULL;
 
-	/* record the initial status of the register file */
-	ctx = rec_sched_get_active_thread(&rr_flags_, ctx);
-	ctx->event = -1000;
-	record_event(ctx, STATE_SYSCALL_ENTRY);
-	rec_init_scratch_memory(ctx);
-
 	while (rec_sched_get_num_threads() > 0) {
 		/* get a thread that is ready to be executed */
 		ctx = rec_sched_get_active_thread(&rr_flags_, ctx);

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1487,11 +1487,6 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 	debug_memory(ctx);
 }
 
-static void check_initial_register_file()
-{
-	rep_sched_get_thread();
-}
-
 void replay(struct flags flags)
 {
 	struct dbg_context* dbg = NULL;
@@ -1502,8 +1497,6 @@ void replay(struct flags flags)
 		dbg = dbg_await_client_connection("127.0.0.1",
 						  rr_flags->dbgport);
 	}
-
-	check_initial_register_file();
 
 	while (rep_sched_get_num_threads()) {
 		replay_one_trace_frame(dbg, rep_sched_get_thread());


### PR DESCRIPTION
Splitting out from refactoring changes to avoid confusion.
