### PR TITLE
Split out syscall-executing logic to make upcoming changes to task execution state simpler.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -187,7 +187,7 @@ static void start(int argc, char* argv[], char** envp)
 
 			/* perform the action recording */
 			log_info("Start recording...");
-			start_recording(__rr_flags);
+			record(&__rr_flags);
 			log_info("Done recording -- cleaning up");
 			/* cleanup all initialized data-structures */
 			close_trace_files();

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -3,11 +3,8 @@
 #ifndef RECORDER_H_
 #define RECORDER_H_
 
-#include <stdio.h>
-#include <sched.h>
+struct flags;
 
-#include "../share/util.h"
-
-void start_recording(struct flags rr_flags);
+void record(const struct flags* rr_flags);
 
 #endif /* RECORDER_H_ */


### PR DESCRIPTION
Looks big and scary, but it's just splitting some code into its own function and normalizing formatting a bit.  On the road to #293.
