### PR TITLE
Start centralizing process state changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(BASIC_TESTS
   async_signal_syscalls
   async_usr1
   bad_ip
+#  bad_syscall
   barrier
   block
   breakpoint

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -2753,7 +2753,7 @@ void rec_process_syscall(struct context *ctx, int syscall, struct flags rr_flags
 	SYS_REC0(writev)
 
 	case RRCALL_init_syscall_buffer:
-		ctx->event = (-ctx->event | RRCALL_BIT);
+		ctx->event = (-syscall | RRCALL_BIT);
 		init_syscall_buffer(ctx, NULL, SHARE_DESCHED_EVENT_FD);
 		break;
 

--- a/src/test/bad_syscall.c
+++ b/src/test/bad_syscall.c
@@ -1,0 +1,13 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <syscall.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+	int ret = syscall(-10);
+	assert(-1 == ret && ENOSYS == errno);
+	return 0;
+}

--- a/src/test/bad_syscall.run.disabled
+++ b/src/test/bad_syscall.run.disabled
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh bad_syscall "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Took _way_ longer than it should have because of a stupid bug around encoding the init-buffer rrcall.  Really looking forward to dropping that silliness.
