### PR TITLE
Normalize seccomp-bpf traps to remove some special cases.

### DIFF
--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -405,27 +405,6 @@ void record(const struct flags* rr_flags)
 			cont_syscall_block(ctx);
 
 			debug_exec_state("  post-seccomp trap", ctx);
-		} else if (ptrace_event == PTRACE_EVENT_CLONE
-			   || ptrace_event == PTRACE_EVENT_FORK) {
-			/* clone(),fork() are handled differently with
-			 * seccomp
-			 *
-			 * TODO: vfork() */
-			debug("Handling ptrace event: %d",
-			      GET_PTRACE_EVENT(ctx->status));
-			record_event(ctx, STATE_SYSCALL_ENTRY);
-			handle_ptrace_event(&ctx);
-			rec_process_syscall(ctx,SYS_clone,rr_flags_);
-			record_event(ctx, STATE_SYSCALL_EXIT);
-			continue;
-		} else if (ptrace_event) {
-			/* TODO: this should only be the exit event
-			 * really... */
-			debug("Handling ptrace event: %d",
-			      GET_PTRACE_EVENT(ctx->status));
-			record_event(ctx, STATE_SYSCALL_EXIT);
-			handle_ptrace_event(&ctx);
-			continue;
 		}
 
 		if (ctx->event < 0) {

--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -311,18 +311,6 @@ static void install_syscall_filter()
 		/* Allow all system calls from our protected_call
 		 * callsite */
 		ALLOW_SYSCALLS_FROM_CALLSITE((uintptr_t)protected_call_start),
-		/* Grab the system call number. */
-		EXAMINE_SYSCALL,
-		/* Note: if these are traced, we get a SIGSTOP after
-		 * child creation We don't need to trace them as they
-		 * will be captured by their own ptrace event */
-		ALLOW_SYSCALL(clone),
-		ALLOW_SYSCALL(fork),
-		ALLOW_SYSCALL(vfork),
-		/* There is really no need for us to ptrace
-		 * restart_syscall. In fact, this will cause an error
-		 * in case the restarted syscall is in the wrapper */
-		ALLOW_SYSCALL(restart_syscall),
 		/* All the rest are handled in rr */
 		TRACE_PROCESS,
 	};


### PR DESCRIPTION
These traps aren't "hot", so all this is serving to do is complicate things.
