### PR TITLE
Move state-changing logic out of scheduler and be more explicit about waitpid-status vs. state.

### DIFF
--- a/src/recorder/rec_sched.h
+++ b/src/recorder/rec_sched.h
@@ -15,8 +15,17 @@ struct context;
 struct flags;
 
 int rec_sched_get_num_threads();
+/**
+ * Given |flags| and the previously-scheduled task |ctx|, return a new
+ * runnable task (which may be |ctx|).
+ *
+ * If the returned task was scheduled because its waitpid status
+ * changed (meaning no tasks ahead of it in run order were runnable),
+ * then set |by_waitpid| to nonzero.
+ */
 struct context* rec_sched_get_active_thread(const struct flags* flags,
-					    struct context* ctx);
+					    struct context* ctx,
+					    int* by_waitpid);
 void rec_sched_register_thread(const struct flags* flags,
 			       pid_t parent, pid_t child);
 void rec_sched_deregister_thread(struct context** ctx);


### PR DESCRIPTION
On the road to #293.  This is most of what we need for #260 specifically.
