### PR TITLE
Rename |struct context| to |struct task| and normalize some related style.

### DIFF
--- a/src/recorder/handle_ioctl.c
+++ b/src/recorder/handle_ioctl.c
@@ -32,9 +32,9 @@
 #include "../share/types.h"
 #include "../share/util.h"
 
-void handle_ioctl_request(struct context *ctx, int request)
+void handle_ioctl_request(struct task *t, int request)
 {
-	pid_t tid = ctx->tid;
+	pid_t tid = t->tid;
 	int syscall = SYS_ioctl;
 	int type = _IOC_TYPE(request);
 	int nr = _IOC_NR(request);
@@ -72,9 +72,9 @@ void handle_ioctl_request(struct context *ctx, int request)
 	case TIOCGPGRP:
 	/* request for a terminal device */
 	case TIOCGWINSZ:
-		push_syscall(ctx, syscall);
-		record_child_data(ctx, size, (void*)regs.edx);
-		pop_syscall(ctx);
+		push_syscall(t, syscall);
+		record_child_data(t, size, (void*)regs.edx);
+		pop_syscall(t);
 		break;
 
 	/* TODO: what are the 0x46 ioctls? */
@@ -146,7 +146,7 @@ void handle_ioctl_request(struct context *ctx, int request)
 		break;	/* not reached */
 
 	default:
-		print_register_file_tid(ctx->tid);
+		print_register_file_tid(t->tid);
 		fatal("Unknown ioctl(0x%x): type:0x%x nr:0x%x dir:0x%x size:%d addr:%p",
 		      request, type, nr, dir, size, (void*)regs.edx);
 	}

--- a/src/recorder/handle_ioctl.h
+++ b/src/recorder/handle_ioctl.h
@@ -3,8 +3,8 @@
 #ifndef HANDLE_IOCTL_H_
 #define HANDLE_IOCTL_H_
 
-struct context;
+struct task;
 
-void handle_ioctl_request(struct context* context, int request);
+void handle_ioctl_request(struct task* t, int request);
 
 #endif /* HANDLE_IOCTL_H_ */

--- a/src/recorder/handle_signal.h
+++ b/src/recorder/handle_signal.h
@@ -3,9 +3,9 @@
 #ifndef __HANDLE_SIGNAL_H__
 #define __HANDLE_SIGNAL_H__
 
-struct context;
+struct task;
 struct flags;
 
-void handle_signal(const struct flags* flags, struct context* context);
+void handle_signal(const struct flags* flags, struct task* context);
 
 #endif /* __HANDLE_SIGNAL_H__ */

--- a/src/recorder/rec_process_event.h
+++ b/src/recorder/rec_process_event.h
@@ -11,10 +11,10 @@
 #include "../share/util.h"
 
 /**
- * Prepare |ctx| to enter |syscallno|.  Return nonzero if a
- * context-switch is allowed for |ctx|, 0 if not.
+ * Prepare |t| to enter |syscallno|.  Return nonzero if a
+ * context-switch is allowed for |t|, 0 if not.
  */
-int rec_prepare_syscall(struct context* ctx, int syscallno);
-void rec_process_syscall(struct context* ctx, int syscall, struct flags rr_flags);
+int rec_prepare_syscall(struct task* t, int syscallno);
+void rec_process_syscall(struct task* t, int syscall, struct flags rr_flags);
 
 #endif /* PROCESS_SYSCALL_H_ */

--- a/src/recorder/rec_sched.h
+++ b/src/recorder/rec_sched.h
@@ -11,24 +11,24 @@
 /* TODO: should check kernel.pid_max at runtime.  */
 #define MAX_TID	(1 << 16)
 
-struct context;
+struct task;
 struct flags;
 
 int rec_sched_get_num_threads();
 /**
- * Given |flags| and the previously-scheduled task |ctx|, return a new
- * runnable task (which may be |ctx|).
+ * Given |flags| and the previously-scheduled task |t|, return a new
+ * runnable task (which may be |t|).
  *
  * The returned task is guaranteed to either have already been
  * runnable, or have been made runnable by a waitpid status change (in
  * which case, *by_waitpid will be nonzero.)
  */
-struct context* rec_sched_get_active_thread(const struct flags* flags,
-					    struct context* ctx,
+struct task* rec_sched_get_active_thread(const struct flags* flags,
+					    struct task* t,
 					    int* by_waitpid);
 void rec_sched_register_thread(const struct flags* flags,
 			       pid_t parent, pid_t child);
-void rec_sched_deregister_thread(struct context** ctx);
+void rec_sched_deregister_thread(struct task** t);
 void rec_sched_exit_all();
 
 #endif /* REC_SCHED_H_ */

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -33,72 +33,72 @@
 static struct flags rr_flags_ = { 0 };
 static bool filter_on_ = FALSE;
 
-static void rec_init_scratch_memory(struct context *ctx)
+static void rec_init_scratch_memory(struct task *t)
 {
 	const int scratch_size = 512 * sysconf(_SC_PAGE_SIZE);
 	/* initialize the scratchpad for blocking system calls */
 	struct current_state_buffer state;
 
-	prepare_remote_syscalls(ctx, &state);
-	ctx->scratch_ptr = (void*)remote_syscall6(
-		ctx, &state, SYS_mmap2,
+	prepare_remote_syscalls(t, &state);
+	t->scratch_ptr = (void*)remote_syscall6(
+		t, &state, SYS_mmap2,
 		0, scratch_size,
 		PROT_READ | PROT_WRITE | PROT_EXEC, /* EXEC, really? */
 		MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	ctx->scratch_size = scratch_size;
-	finish_remote_syscalls(ctx, &state);
+	t->scratch_size = scratch_size;
+	finish_remote_syscalls(t, &state);
 
 	// record this mmap for the replay
 	struct user_regs_struct orig_regs;
-	read_child_registers(ctx->tid,&orig_regs);
+	read_child_registers(t->tid,&orig_regs);
 	int eax = orig_regs.eax;
-	orig_regs.eax = (uintptr_t)ctx->scratch_ptr;
-	write_child_registers(ctx->tid,&orig_regs);
+	orig_regs.eax = (uintptr_t)t->scratch_ptr;
+	write_child_registers(t->tid,&orig_regs);
 	struct mmapped_file file = {0};
 	file.time = get_global_time();
-	file.tid = ctx->tid;
-	file.start = ctx->scratch_ptr;
-	file.end = ctx->scratch_ptr + scratch_size;
-	sprintf(file.filename,"scratch for thread %d",ctx->tid);
+	file.tid = t->tid;
+	file.start = t->scratch_ptr;
+	file.end = t->scratch_ptr + scratch_size;
+	sprintf(file.filename,"scratch for thread %d",t->tid);
 	record_mmapped_file_stats(&file);
 
-	int event = ctx->event;
-	ctx->event = USR_INIT_SCRATCH_MEM;
-	push_pseudosig(ctx, EUSR_INIT_SCRATCH_MEM, HAS_EXEC_INFO);
-	record_event(ctx);
-	pop_pseudosig(ctx);
-	ctx->event = event;
+	int event = t->event;
+	t->event = USR_INIT_SCRATCH_MEM;
+	push_pseudosig(t, EUSR_INIT_SCRATCH_MEM, HAS_EXEC_INFO);
+	record_event(t);
+	pop_pseudosig(t);
+	t->event = event;
 
 	orig_regs.eax = eax;
-	write_child_registers(ctx->tid,&orig_regs);
+	write_child_registers(t->tid,&orig_regs);
 }
 
-static void status_changed(struct context* ctx)
+static void status_changed(struct task* t)
 {
-	read_child_registers(ctx->tid, &ctx->regs);
-	ctx->event = ctx->regs.orig_eax;
-	if (ctx->event == RRCALL_init_syscall_buffer) {
-		ctx->event = (-ctx->event | RRCALL_BIT);
+	read_child_registers(t->tid, &t->regs);
+	t->event = t->regs.orig_eax;
+	if (t->event == RRCALL_init_syscall_buffer) {
+		t->event = (-t->event | RRCALL_BIT);
 	}
-	handle_signal(&rr_flags_, ctx);
+	handle_signal(&rr_flags_, t);
 }
 
-static void cont_nonblock(struct context *ctx)
+static void cont_nonblock(struct task *t)
 {
-	sys_ptrace_syscall(ctx->tid);
+	sys_ptrace_syscall(t->tid);
 }
 
 uintptr_t progress;
 
-static void handle_ptrace_event(struct context** ctxp)
+static void handle_ptrace_event(struct task** tp)
 {
-	struct context* ctx = *ctxp;
+	struct task* t = *tp;
 
 	/* handle events */
-	int event = GET_PTRACE_EVENT(ctx->status);
+	int event = GET_PTRACE_EVENT(t->status);
 	if (event != PTRACE_EVENT_NONE) {
 		debug("  %d: handle_ptrace_event %d: syscall %s",
-		      ctx->tid, event, syscallname(ctx->event));
+		      t->tid, event, syscallname(t->event));
 	}
 	switch (event) {
 
@@ -106,79 +106,79 @@ static void handle_ptrace_event(struct context** ctxp)
 		break;
 
 	case PTRACE_EVENT_VFORK_DONE:
-		push_syscall(ctx, ctx->event);
-		ctx->ev->syscall.state = EXITING_SYSCALL;
-		rec_process_syscall(ctx, ctx->event, rr_flags_);
-		record_event(ctx);
+		push_syscall(t, t->event);
+		t->ev->syscall.state = EXITING_SYSCALL;
+		rec_process_syscall(t, t->event, rr_flags_);
+		record_event(t);
 
 		/* issue an additional continue, since the process was stopped by the additional ptrace event */
-		sys_ptrace_syscall(ctx->tid);
-		sys_waitpid(ctx->tid, &ctx->status);
-		status_changed(ctx);
+		sys_ptrace_syscall(t->tid);
+		sys_waitpid(t->tid, &t->status);
+		status_changed(t);
 
-		record_event(ctx);
-		pop_syscall(ctx);
+		record_event(t);
+		pop_syscall(t);
 
-		ctx->exec_state = RUNNABLE;
-		ctx->switchable = 1;
+		t->exec_state = RUNNABLE;
+		t->switchable = 1;
 		break;
 
 	case PTRACE_EVENT_CLONE:
 	case PTRACE_EVENT_FORK:
 	case PTRACE_EVENT_VFORK: {
 		/* get new tid, register at the scheduler and setup HPC */
-		int new_tid = sys_ptrace_getmsg(ctx->tid);
+		int new_tid = sys_ptrace_getmsg(t->tid);
 
 		/* ensure that clone was successful */
-		assert(read_child_eax(ctx->tid) != -1);
+		assert(read_child_eax(t->tid) != -1);
 
 		/* wait until the new thread is ready */
-		sys_waitpid(new_tid, &(ctx->status));
-		rec_sched_register_thread(&rr_flags_, ctx->tid, new_tid);
+		sys_waitpid(new_tid, &(t->status));
+		rec_sched_register_thread(&rr_flags_, t->tid, new_tid);
 
 		/* execute an additional ptrace_sysc((0xFF0000 & status) >> 16), since we setup trace like that.
 		 * If the event is vfork we must no execute the cont_block, since the parent sleeps until the
 		 * child has finished */
 		if (event == PTRACE_EVENT_VFORK) {
-			ctx->exec_state = PROCESSING_SYSCALL;
-			ctx->switchable = 1;
+			t->exec_state = PROCESSING_SYSCALL;
+			t->switchable = 1;
 
-			push_syscall(ctx, ctx->event);
-			ctx->ev->syscall.state = ENTERING_SYSCALL;
-			record_event(ctx);
-			pop_syscall(ctx);
+			push_syscall(t, t->event);
+			t->ev->syscall.state = ENTERING_SYSCALL;
+			record_event(t);
+			pop_syscall(t);
 
-			cont_nonblock(ctx);
+			cont_nonblock(t);
 		} else {
-			sys_ptrace_syscall(ctx->tid);
-			sys_waitpid(ctx->tid, &ctx->status);
-			status_changed(ctx);
+			sys_ptrace_syscall(t->tid);
+			sys_waitpid(t->tid, &t->status);
+			status_changed(t);
 		}
 		break;
 	}
 
 	case PTRACE_EVENT_EXEC:
-		push_syscall(ctx, ctx->event);
-		ctx->ev->syscall.state = ENTERING_SYSCALL;
-		record_event(ctx);
-		pop_syscall(ctx);
+		push_syscall(t, t->event);
+		t->ev->syscall.state = ENTERING_SYSCALL;
+		record_event(t);
+		pop_syscall(t);
 
-		sys_ptrace_syscall(ctx->tid);
-		sys_waitpid(ctx->tid, &ctx->status);
-		status_changed(ctx);
+		sys_ptrace_syscall(t->tid);
+		sys_waitpid(t->tid, &t->status);
+		status_changed(t);
 
-		rec_init_scratch_memory(ctx);
-		assert(signal_pending(ctx->status) == 0);
+		rec_init_scratch_memory(t);
+		assert(signal_pending(t->status) == 0);
 		break;
 
 	case PTRACE_EVENT_EXIT:
-		ctx->event = USR_EXIT;
-		push_pseudosig(ctx, EUSR_EXIT, HAS_EXEC_INFO);
-		record_event(ctx);
-		pop_pseudosig(ctx);
+		t->event = USR_EXIT;
+		push_pseudosig(t, EUSR_EXIT, HAS_EXEC_INFO);
+		record_event(t);
+		pop_pseudosig(t);
 
-		rec_sched_deregister_thread(ctxp);
-		ctx = *ctxp;
+		rec_sched_deregister_thread(tp);
+		t = *tp;
 		break;
 
 	default:
@@ -188,38 +188,38 @@ static void handle_ptrace_event(struct context** ctxp)
 	}
 }
 
-#define debug_exec_state(_msg, _ctx)					\
+#define debug_exec_state(_msg, _t)					\
 	debug(_msg ": pevent=%d, event=%s",				\
-	      GET_PTRACE_EVENT(_ctx->status), strevent(_ctx->event))
+	      GET_PTRACE_EVENT(_t->status), strevent(_t->event))
 
 /**
- * Resume execution of |ctx| to the next notable event, such as a
- * syscall.  |ctx->event| may be mutated if a signal is caught.
+ * Resume execution of |t| to the next notable event, such as a
+ * syscall.  |t->event| may be mutated if a signal is caught.
  *
  * (Pass DEFAULT_CONT to the |force_syscall| parameter and ignore it;
  * it's an implementation detail.)
  */
 enum { DEFAULT_CONT = 0, FORCE_SYSCALL = 1 };
-static void resume_execution(struct context* ctx, int force_cont)
+static void resume_execution(struct task* t, int force_cont)
 {
 	int ptrace_event;
 
-	assert(RUNNABLE == ctx->exec_state);
+	assert(RUNNABLE == t->exec_state);
 
-	debug_exec_state("EXEC_START", ctx);
+	debug_exec_state("EXEC_START", t);
 
-	if (ctx->will_restart && filter_on_) {
+	if (t->will_restart && filter_on_) {
 		debug("  PTRACE_SYSCALL to restarted %s",
-		      syscallname(ctx->last_syscall));
+		      syscallname(t->last_syscall));
 	}
 
-	if (!filter_on_ || FORCE_SYSCALL == force_cont || ctx->will_restart) {
+	if (!filter_on_ || FORCE_SYSCALL == force_cont || t->will_restart) {
 		/* We won't receive PTRACE_EVENT_SECCOMP events until
 		 * the seccomp filter is installed by the
 		 * syscall_buffer lib in the child, therefore we must
 		 * record in the traditional way (with PTRACE_SYSCALL)
 		 * until it is installed. */
-		sys_ptrace_syscall(ctx->tid);
+		sys_ptrace_syscall(t->tid);
 	} else {
 		/* When the seccomp filter is on, instead of capturing
 		 * syscalls by using PTRACE_SYSCALL, the filter will
@@ -231,69 +231,69 @@ static void resume_execution(struct context* ctx, int force_cont)
 		 * process to continue to the actual entry point of
 		 * the syscall (using cont_syscall_block()) and then
 		 * using the same logic as before. */
-		sys_ptrace_cont(ctx->tid);
+		sys_ptrace_cont(t->tid);
 	}
-	ctx->will_restart = 0;
+	t->will_restart = 0;
 
-	sys_waitpid(ctx->tid, &ctx->status);
-	status_changed(ctx);
+	sys_waitpid(t->tid, &t->status);
+	status_changed(t);
 
-	debug_exec_state("  after resume", ctx);
+	debug_exec_state("  after resume", t);
 
-	ptrace_event = GET_PTRACE_EVENT(ctx->status);
+	ptrace_event = GET_PTRACE_EVENT(t->status);
 	if (PTRACE_EVENT_SECCOMP == ptrace_event
 	    || PTRACE_EVENT_SECCOMP_OBSOLETE == ptrace_event) {
 		filter_on_ = TRUE;
 		/* See long comments above. */
 		debug("  (skipping past seccomp-bpf trap)");
-		return resume_execution(ctx, FORCE_SYSCALL);
+		return resume_execution(t, FORCE_SYSCALL);
 	}
 }
 
-static void syscall_state_changed(struct context** ctxp, int by_waitpid)
+static void syscall_state_changed(struct task** tp, int by_waitpid)
 {
-	struct context* ctx = *ctxp;
+	struct task* t = *tp;
 
-	switch (ctx->exec_state) {
+	switch (t->exec_state) {
 	case ENTERING_SYSCALL:
-		debug_exec_state("EXEC_SYSCALL_ENTRY", ctx);
+		debug_exec_state("EXEC_SYSCALL_ENTRY", t);
 
 		/* continue and execute the system call */
-		ctx->switchable = rec_prepare_syscall(ctx, ctx->event);
-		cont_nonblock(ctx);
+		t->switchable = rec_prepare_syscall(t, t->event);
+		cont_nonblock(t);
 
-		debug_exec_state("after cont", ctx);
+		debug_exec_state("after cont", t);
 
-		ctx->exec_state = PROCESSING_SYSCALL;
+		t->exec_state = PROCESSING_SYSCALL;
 		return;
 
 	case PROCESSING_SYSCALL:
-		debug_exec_state("EXEC_IN_SYSCALL", ctx);
+		debug_exec_state("EXEC_IN_SYSCALL", t);
 
-		assert(ctx->exec_state = PROCESSING_SYSCALL);
+		assert(t->exec_state = PROCESSING_SYSCALL);
 		assert(by_waitpid);
 
-		if (signal_pending(ctx->status)) {
+		if (signal_pending(t->status)) {
 			/* TODO: need state stack to properly handle
 			 * signals, if they indeed are ever delivered
 			 * in this state. */
 			log_warn("Signal %s may not be handled correctly",
-				 signalname(signal_pending(ctx->status)));
+				 signalname(signal_pending(t->status)));
 		}
-		status_changed(ctx);
-		ctx->exec_state = EXITING_SYSCALL;
-		ctx->switchable = 0;
+		status_changed(t);
+		t->exec_state = EXITING_SYSCALL;
+		t->switchable = 0;
 		return;
 
 	case EXITING_SYSCALL: {
 		struct user_regs_struct regs;
 		int syscall, retval;
 
-		debug_exec_state("EXEC_SYSCALL_DONE", ctx);
+		debug_exec_state("EXEC_SYSCALL_DONE", t);
 
-		assert(signal_pending(ctx->status) == 0);
+		assert(signal_pending(t->status) == 0);
 
-		read_child_registers(ctx->tid,&regs);
+		read_child_registers(t->tid,&regs);
 		syscall = regs.orig_eax;
 		retval = regs.eax;
 		if (0 <= syscall
@@ -302,7 +302,7 @@ static void syscall_state_changed(struct context** ctxp, int by_waitpid)
 		    && -ENOSYS == retval) {
 			log_err("Exiting syscall %s, but retval is -ENOSYS, usually only seen at entry",
 				syscallname(syscall));
-			emergency_debug(ctx);
+			emergency_debug(t);
 		}
 
 		debug("  orig_eax:%d (%s); eax:%ld",
@@ -312,7 +312,7 @@ static void syscall_state_changed(struct context** ctxp, int by_waitpid)
 		 * send it right away*/
 		/* we have already sent the signal and process
 		 * sigreturn */
-		assert(ctx->event != SYS_sigreturn);
+		assert(t->event != SYS_sigreturn);
 
 		/* if the syscall is about to be restarted, save the
 		 * last syscall performed by it. */
@@ -320,90 +320,90 @@ static void syscall_state_changed(struct context** ctxp, int by_waitpid)
 		    && SYSCALL_WILL_RESTART(retval)) {
 			debug("  retval %d, will restart %s",
 			      retval, syscallname(syscall));
-			ctx->last_syscall = syscall;
-			ctx->will_restart = 1;
+			t->last_syscall = syscall;
+			t->will_restart = 1;
 		}
 
 		/* TODO: are there any other points where we need to
 		 * handle ptrace events (other than the seccomp-bpf
 		 * traps)? */
-		handle_ptrace_event(ctxp);
-		ctx = *ctxp;
-		if (!ctx || ctx->event == SYS_vfork) {
+		handle_ptrace_event(tp);
+		t = *tp;
+		if (!t || t->event == SYS_vfork) {
 			return;
 		}
 
-		assert(signal_pending(ctx->status) != SIGTRAP);
+		assert(signal_pending(t->status) != SIGTRAP);
 		/* a syscall_restart ending is equivalent to the
 		 * restarted syscall ending */
 		if (syscall == SYS_restart_syscall) {
-			syscall = ctx->last_syscall;
-			ctx->event = syscall;
+			syscall = t->last_syscall;
+			t->event = syscall;
 			debug("  exiting restarted %s", syscallname(syscall));
 		}
 
-		push_syscall(ctx, syscall);
-		ctx->ev->syscall.state = EXITING_SYSCALL;
+		push_syscall(t, syscall);
+		t->ev->syscall.state = EXITING_SYSCALL;
 		/* no need to process the syscall in case its
 		 * restarted this will be done in the exit from the
 		 * restart_syscall */
 		if (!SYSCALL_WILL_RESTART(retval)) {
-			rec_process_syscall(ctx, syscall, rr_flags_);
+			rec_process_syscall(t, syscall, rr_flags_);
 		}
-		record_event(ctx);
-		pop_syscall(ctx);
+		record_event(t);
+		pop_syscall(t);
 
-		ctx->exec_state = RUNNABLE;
-		ctx->switchable = 1;
-		if (ctx->desched_rec) {
+		t->exec_state = RUNNABLE;
+		t->switchable = 1;
+		if (t->desched_rec) {
 			/* If this syscall was interrupted by a
 			 * desched event, then just after the finished
 			 * syscall there will be an ioctl() to disarm
 			 * the event that we won't record here.  So
 			 * save a breadcrumb so that replay knows to
 			 * expect it and skip over it. */
-			ctx->desched_rec = NULL;
+			t->desched_rec = NULL;
 
-			push_pseudosig(ctx, EUSR_DISARM_DESCHED, NO_EXEC_INFO);
-			record_event(ctx);
-			pop_pseudosig(ctx);
+			push_pseudosig(t, EUSR_DISARM_DESCHED, NO_EXEC_INFO);
+			record_event(t);
+			pop_pseudosig(t);
 
 			/* We also need to ensure that the syscallbuf
 			 * doesn't try to commit to the syscallbuf;
 			 * we've already recorded the syscall. */
-			ctx->syscallbuf_hdr->abort_commit = 1;
-			push_pseudosig(ctx, EUSR_SYSCALLBUF_ABORT_COMMIT,
+			t->syscallbuf_hdr->abort_commit = 1;
+			push_pseudosig(t, EUSR_SYSCALLBUF_ABORT_COMMIT,
 				       NO_EXEC_INFO);
-			record_event(ctx);
-			pop_pseudosig(ctx);
+			record_event(t);
+			pop_pseudosig(t);
 		}
 		return;
 	}
 
 	default:
-		fatal("Unknown exec state %d", ctx->exec_state);
+		fatal("Unknown exec state %d", t->exec_state);
 	}
 }
 
-static void runnable_state_changed(struct context* ctx)
+static void runnable_state_changed(struct task* t)
 {
 	/* Have to disable context-switching until we know it's safe
 	 * to allow switching the context. */
-	ctx->switchable = 0;
+	t->switchable = 0;
 
-	if (ctx->event < 0) {
+	if (t->event < 0) {
 		/* We just saw a (pseudo-)signal.  handle_signal()
 		 * took care of recording any events related to the
 		 * (pseudo-)signal. */
 		/* TODO: is there any reason not to enable switching
 		 * after signals are delivered? */
-		ctx->switchable = (ctx->event == SIG_SEGV_RDTSC
-				   || ctx->event == USR_SCHED);
-	} else if (ctx->event == SYS_sigreturn
-		   || ctx->event == SYS_rt_sigreturn) {
-		int orig_event = ctx->event;
-		push_syscall(ctx, ctx->event);
-		ctx->ev->syscall.state = ENTERING_SYSCALL;
+		t->switchable = (t->event == SIG_SEGV_RDTSC
+				   || t->event == USR_SCHED);
+	} else if (t->event == SYS_sigreturn
+		   || t->event == SYS_rt_sigreturn) {
+		int orig_event = t->event;
+		push_syscall(t, t->event);
+		t->ev->syscall.state = ENTERING_SYSCALL;
 
 		/* These system calls never return; we remain
 		 * in the same execution state */
@@ -411,44 +411,44 @@ static void runnable_state_changed(struct context* ctx)
 		 * to do another ptrace_cont to fully process the
 		 * sigreturn system call. */
 		debug("  sigreturn");
-		record_event(ctx);
-		assert(!ctx->flushed_syscallbuf);
+		record_event(t);
+		assert(!t->flushed_syscallbuf);
 		/* do another step */
-		sys_ptrace_syscall(ctx->tid);
-		sys_waitpid(ctx->tid, &ctx->status);
-		status_changed(ctx);
+		sys_ptrace_syscall(t->tid);
+		sys_waitpid(t->tid, &t->status);
+		status_changed(t);
 
 		/* TODO: can signals interrupt a sigreturn? */
-		assert(signal_pending(ctx->status) != SIGTRAP);
+		assert(signal_pending(t->status) != SIGTRAP);
 
 		/* orig_eax seems to be -1 here for not-understood
 		 * reasons. */
-		assert(ctx->event == -1);
-		ctx->event = orig_event;
-		ctx->ev->syscall.state = EXITING_SYSCALL;
-		record_event(ctx);
-		pop_syscall(ctx);
+		assert(t->event == -1);
+		t->event = orig_event;
+		t->ev->syscall.state = EXITING_SYSCALL;
+		record_event(t);
+		pop_syscall(t);
 
-		ctx->switchable = 0;
-	} else if (ctx->event > 0) {
+		t->switchable = 0;
+	} else if (t->event > 0) {
 		/* We just entered a syscall. */
-		if (ctx->desched_rec) {
+		if (t->desched_rec) {
 			/* Replay needs to be prepared to see the
 			 * ioctl() that arms the desched counter when
 			 * it's trying to step to the entry of
 			 * |call|. */
-			push_pseudosig(ctx, EUSR_ARM_DESCHED, NO_EXEC_INFO);
-			record_event(ctx);
-			pop_pseudosig(ctx);
+			push_pseudosig(t, EUSR_ARM_DESCHED, NO_EXEC_INFO);
+			record_event(t);
+			pop_pseudosig(t);
 		}
 
-		push_syscall(ctx, ctx->event);
-		ctx->ev->syscall.state = ENTERING_SYSCALL;
-		record_event(ctx);
-		pop_syscall(ctx);
+		push_syscall(t, t->event);
+		t->ev->syscall.state = ENTERING_SYSCALL;
+		record_event(t);
+		pop_syscall(t);
 
-		ctx->exec_state = ENTERING_SYSCALL;
-	} else if (ctx->event == SYS_restart_syscall) {
+		t->exec_state = ENTERING_SYSCALL;
+	} else if (t->event == SYS_restart_syscall) {
 		/* Syscalls like nanosleep(), poll() which can't be
 		 * restarted with their original arguments use the
 		 * ERESTART_RESTARTBLOCK code.
@@ -465,48 +465,48 @@ static void runnable_state_changed(struct context* ctx)
 		 * which in turn saves another such restart block, old
 		 * data is lost and restart becomes impossible) */
 		debug("  restarting syscall %s",
-		      syscallname(ctx->last_syscall));
+		      syscallname(t->last_syscall));
 		/* From errno.h:
 		 * These should never be seen by user programs.  To
 		 * return one of ERESTART* codes, signal_pending()
 		 * MUST be set.  Note that ptrace can observe these at
 		 * syscall exit tracing, but they will never be left
 		 * for the debugged user process to see. */
-		ctx->exec_state = ENTERING_SYSCALL;
-		assert(!ctx->flushed_syscallbuf);
+		t->exec_state = ENTERING_SYSCALL;
+		assert(!t->flushed_syscallbuf);
 	} else {
 		fatal("Unhandled event %s (%d)",
-		      strevent(ctx->event), ctx->event);
+		      strevent(t->event), t->event);
 	}
 
-	if (ctx->flushed_syscallbuf) {
-		push_pseudosig(ctx, EUSR_SYSCALLBUF_RESET, NO_EXEC_INFO);
-		record_event(ctx);
-		ctx->flushed_syscallbuf = 0;
-		pop_pseudosig(ctx);
+	if (t->flushed_syscallbuf) {
+		push_pseudosig(t, EUSR_SYSCALLBUF_RESET, NO_EXEC_INFO);
+		record_event(t);
+		t->flushed_syscallbuf = 0;
+		pop_pseudosig(t);
 	}
 }
 
 void record(const struct flags* rr_flags)
 {
 	rr_flags_ = *rr_flags;
-	struct context *ctx = NULL;
+	struct task *t = NULL;
 
 	while (rec_sched_get_num_threads() > 0) {
 		int by_waitpid;
 
-		ctx = rec_sched_get_active_thread(&rr_flags_, ctx,
+		t = rec_sched_get_active_thread(&rr_flags_, t,
 						  &by_waitpid);
 
-		debug("Active task is %d", ctx->tid);
+		debug("Active task is %d", t->tid);
 
-		if (ctx->scratch_ptr == NULL) {
-			rec_init_scratch_memory(ctx);
+		if (t->scratch_ptr == NULL) {
+			rec_init_scratch_memory(t);
 		}
 
-		assert(!by_waitpid || PROCESSING_SYSCALL == ctx->exec_state);
-		if (ctx->exec_state > RUNNABLE) {
-			syscall_state_changed(&ctx, by_waitpid);
+		assert(!by_waitpid || PROCESSING_SYSCALL == t->exec_state);
+		if (t->exec_state > RUNNABLE) {
+			syscall_state_changed(&t, by_waitpid);
 			continue;
 		}
 
@@ -515,7 +515,7 @@ void record(const struct flags* rr_flags)
 			fflush(stdout);
 		}
 
-		resume_execution(ctx, DEFAULT_CONT);
-		runnable_state_changed(ctx);
+		resume_execution(t, DEFAULT_CONT);
+		runnable_state_changed(t);
 	}
 }

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -3,16 +3,16 @@
 #ifndef REP_PROCESS_EVENT_H_
 #define REP_PROCESS_EVENT_H_
 
-struct context;
+struct task;
 struct rep_trace_step;
 
 /* |redirect_stdio| is nonzero if output written to stdout/stderr
  * during recording should be tee'd during replay, zero otherwise. */
-void rep_process_syscall(struct context* ctx, int redirect_stdio,
+void rep_process_syscall(struct task* t, int redirect_stdio,
 			 struct rep_trace_step* step);
 
 /**
- * |ctx| is at a "write" syscall.  If the recorded write was to STDOUT
+ * |t| is at a "write" syscall.  If the recorded write was to STDOUT
  * or STDERR, then also write the output to the current STDOUT/STDERR
  * (if the user wishes).
  *
@@ -21,6 +21,6 @@ void rep_process_syscall(struct context* ctx, int redirect_stdio,
  * information.  That means output written to a dup of STDOUT will not
  * be replayed by this helper.  This could maybe be a todo.
  */
-void rep_maybe_replay_stdio_write(struct context* ctx, int redirect_stdio);
+void rep_maybe_replay_stdio_write(struct task* t, int redirect_stdio);
 
 #endif /* REP_PROCESS_EVENT_H_ */

--- a/src/replayer/rep_sched.h
+++ b/src/replayer/rep_sched.h
@@ -8,15 +8,15 @@
 #include "../share/trace.h"
 
 int rep_sched_get_num_threads();
-struct context* rep_sched_register_thread(pid_t my_tid, pid_t rec_tid);
-struct context* rep_sched_get_thread();
-struct context* rep_sched_lookup_thread(pid_t rec_tid);
+struct task* rep_sched_register_thread(pid_t my_tid, pid_t rec_tid);
+struct task* rep_sched_get_thread();
+struct task* rep_sched_lookup_thread(pid_t rec_tid);
 /**
  * Return a freshly-allocated array of tids in |tids|, which is of
  * length |len|.  The caller is reponsible for freeing the returned
  * array.
  */
 void rep_sched_enumerate_tasks(pid_t** tids, size_t* len);
-void rep_sched_deregister_thread(struct context** context_ptr);
+void rep_sched_deregister_thread(struct task** context_ptr);
 
 #endif /* REP_SCHED_H_ */

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -9,19 +9,19 @@
 void replay(struct flags rr_flags);
 
 /**
- * Open a temporary debugging connection for |ctx| and service
+ * Open a temporary debugging connection for |t| and service
  * requests until the user quits or requests execution to resume.  Use
  * this when a target enters an illegal state and can't continue, for
  * example
  *
  *  if (recorded_state != replay_state) {
  *	 log_err("Bad state ...");
- *	 emergency_debug(ctx);
+ *	 emergency_debug(t);
  *  }
  *
  * This function does not return.
  */
-void emergency_debug(struct context* ctx);
+void emergency_debug(struct task* t);
 
 /**
  * The state of a (dis)arm-desched-event ioctl that's being processed.

--- a/src/share/hpc.h
+++ b/src/share/hpc.h
@@ -13,7 +13,7 @@
 #include <sys/ioctl.h>
 #include <linux/perf_event.h>
 
-struct context;
+struct task;
 
 typedef struct _hpc_event
 {
@@ -35,13 +35,13 @@ void init_libpfm();
 void libpfm_event_encoding(struct perf_event_attr* attr, const char* event_str, int hw_event);
 void close_libpfm();
 
-void init_hpc(struct context *ctx);
-void destry_hpc(struct context *ctx);
-void start_hpc(struct context *ctx, uint64_t val);
-void stop_hpc(struct context *ctx);
-void cleanup_hpc(struct context* ctx);
-void reset_hpc(struct context *ctx, uint64_t val);
-void stop_rbc(struct context *ctx);
+void init_hpc(struct task *t);
+void destry_hpc(struct task *t);
+void start_hpc(struct task *t, uint64_t val);
+void stop_hpc(struct task *t);
+void cleanup_hpc(struct task* t);
+void reset_hpc(struct task *t, uint64_t val);
+void stop_rbc(struct task *t);
 int pending_rbc_down(struct hpc_context *counters);
 
 uint64_t read_page_faults(struct hpc_context *counters);

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -10,16 +10,16 @@
 
 #include "types.h"
 
-struct context;
+struct task;
 
 void read_child_registers(int child_id, struct user_regs_struct* regs);
 long read_child_code(pid_t pid, void* addr);
 long read_child_data_word(pid_t pid, void* addr);
-void* read_child_data(struct context *ctx, size_t size, void* addr);
-void read_child_usr(struct context *ctx, void *dest, void *src, size_t size);
-void* read_child_data_checked(struct context *ctx, size_t size, void* addr, ssize_t *read_bytes);
-ssize_t checked_pread(struct context *ctx, void *buf, size_t size, off_t offset);
-void memcpy_child(struct context *ctx, void *dest, void *src, int size);
+void* read_child_data(struct task *t, size_t size, void* addr);
+void read_child_usr(struct task *t, void *dest, void *src, size_t size);
+void* read_child_data_checked(struct task *t, size_t size, void* addr, ssize_t *read_bytes);
+ssize_t checked_pread(struct task *t, void *buf, size_t size, off_t offset);
+void memcpy_child(struct task *t, void *dest, void *src, int size);
 
 void write_child_code(pid_t pid, void* addr, long code);
 void write_child_data_word(pid_t pid, void *addr, uintptr_t data);
@@ -28,9 +28,9 @@ void write_child_main_registers(pid_t tid, struct user_regs_struct *regs);
 void write_child_segment_registers(pid_t tid, struct user_regs_struct *regs);
 void write_child_data_n(pid_t tid, size_t size, void* addr,
 			const void* data);
-void write_child_data(struct context *ctx, size_t size, void *addr,
+void write_child_data(struct task *t, size_t size, void *addr,
 		      const void *data);
-size_t set_child_data(struct context *ctx);
+size_t set_child_data(struct task *t);
 
 
 /* access functions to child registers */
@@ -52,7 +52,7 @@ void write_child_ecx(int tid, long int val);
 void write_child_edx(int tid, long int val);
 void write_child_edi(int tid, long int val);
 void write_child_ebp(int tid, long int val);
-void set_return_value(struct context* context);
+void set_return_value(struct task* context);
 
 
 char* read_child_str(pid_t pid, void* addr);

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -275,21 +275,21 @@ void sys_ptrace_traceme()
 	sys_ptrace(PTRACE_TRACEME, 0, 0, 0);
 }
 
-void goto_next_event(struct context *ctx)
+void goto_next_event(struct task *t)
 {
 
-	if (ctx->child_sig != 0) {
-		printf("sending signal: %d\n",ctx->child_sig);
+	if (t->child_sig != 0) {
+		printf("sending signal: %d\n",t->child_sig);
 	}
-	sys_ptrace(PTRACE_SYSCALL, ctx->tid, 0, (void*) ctx->child_sig);
-	sys_waitpid(ctx->tid, &ctx->status);
+	sys_ptrace(PTRACE_SYSCALL, t->tid, 0, (void*) t->child_sig);
+	sys_waitpid(t->tid, &t->status);
 
-	ctx->child_sig = signal_pending(ctx->status);
-	if (ctx->child_sig == SIGTRAP) {
+	t->child_sig = signal_pending(t->status);
+	if (t->child_sig == SIGTRAP) {
 		log_err("Caught unexpected SIGTRAP while going to next event");
-		emergency_debug(ctx);
+		emergency_debug(t);
 	}
-	ctx->event = read_child_orig_eax(ctx->tid);
+	t->event = read_child_orig_eax(t->tid);
 }
 
 long sys_ptrace_peektext_word(pid_t pid, void* addr)

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -11,7 +11,7 @@
 
 #include "types.h"
 
-struct context;
+struct task;
 
 void sys_close(int filedes);
 FILE* sys_fopen(const char* path, const char* mode);
@@ -26,7 +26,7 @@ void sys_kill(int pid, int msg);
 void sys_exit();
 void sys_start_trace(char* executable, char** fake_argv, char** envp);
 
-void goto_next_event(struct context *ctx);
+void goto_next_event(struct task *t);
 
 long sys_ptrace(int request, pid_t pid, void* addr, void* data);
 void sys_ptrace_setup(pid_t pid);

--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -86,7 +86,7 @@ static __thread byte* buffer = NULL;
  * made by scheduling R, but no one tells rr to do that.  Oops!
  *
  * Thus enter the "desched counter".  It's a perf_event for the "sw
- * context switches" event (which, more precisely, is "sw deschedule";
+ * t switches" event (which, more precisely, is "sw deschedule";
  * it counts schedule-out, not schedule-in).  We program the counter
  * to deliver SIGIO to this task when there's new counter data
  * available.  And we set up the "sample period", how many descheds

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -28,17 +28,17 @@
  * not* imply that $ip is at a buffered syscall; use the macro below
  * for that.
  */
-#define SYSCALLBUF_IS_IP_IN_LIB(_eip, _ctx)				\
-	((uintptr_t)(_ctx)->syscallbuf_lib_start <= (uintptr_t)(_eip)	\
-	 && (uintptr_t)(_eip) <= (uintptr_t)(_ctx)->syscallbuf_lib_end)
+#define SYSCALLBUF_IS_IP_IN_LIB(_eip, _t)				\
+	((uintptr_t)(_t)->syscallbuf_lib_start <= (uintptr_t)(_eip)	\
+	 && (uintptr_t)(_eip) <= (uintptr_t)(_t)->syscallbuf_lib_end)
 
 /**
  * True when |_eip| is at a buffered syscall, i.e. one initiated by a
  * libc wrapper in the library.  Callers may assume
  * |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
  */
-#define SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(_eip, _ctx)			\
-	((uintptr_t)(_eip) == (uintptr_t)(_ctx)->untraced_syscall_ip)	\
+#define SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(_eip, _t)			\
+	((uintptr_t)(_eip) == (uintptr_t)(_t)->untraced_syscall_ip)	\
 
 /**
  * The syscall buffer comprises an array of these variable-length

--- a/src/share/task.c
+++ b/src/share/task.c
@@ -3,61 +3,61 @@
 #include "task.h"
 
 /**
- * Push a new event onto |ctx|'s event stack of type |type|.
+ * Push a new event onto |t|'s event stack of type |type|.
  */
-static void push_new_event(struct context* ctx, int type)
+static void push_new_event(struct task* t, int type)
 {
 	struct event ev = { .type = type };
-	FIXEDSTACK_PUSH(&ctx->pending_events, ev);
-	ctx->ev = FIXEDSTACK_TOP(&ctx->pending_events);
+	FIXEDSTACK_PUSH(&t->pending_events, ev);
+	t->ev = FIXEDSTACK_TOP(&t->pending_events);
 }
 
 /**
  * Pop the pending-event stack and return the type of the previous top
  * element.
  */
-static int pop_event(struct context* ctx)
+static int pop_event(struct task* t)
 {
-	int last_top_type = FIXEDSTACK_POP(&ctx->pending_events).type;
-	ctx->ev = !FIXEDSTACK_EMPTY(&ctx->pending_events) ?
-		  FIXEDSTACK_TOP(&ctx->pending_events) : NULL;
+	int last_top_type = FIXEDSTACK_POP(&t->pending_events).type;
+	t->ev = !FIXEDSTACK_EMPTY(&t->pending_events) ?
+		  FIXEDSTACK_TOP(&t->pending_events) : NULL;
 	return last_top_type;
 }
 
-void push_pseudosig(struct context* ctx, int no, int has_exec_info)
+void push_pseudosig(struct task* t, int no, int has_exec_info)
 {
-	push_new_event(ctx, EV_PSEUDOSIG);
-	ctx->ev->pseudosig.no = no;
-	ctx->ev->pseudosig.has_exec_info = has_exec_info;
+	push_new_event(t, EV_PSEUDOSIG);
+	t->ev->pseudosig.no = no;
+	t->ev->pseudosig.has_exec_info = has_exec_info;
 }
 
-void pop_pseudosig(struct context* ctx)
+void pop_pseudosig(struct task* t)
 {
-	int type = pop_event(ctx);
+	int type = pop_event(t);
 	assert(EV_PSEUDOSIG == type);
 }
 
-void push_signal(struct context* ctx, int no, int deterministic)
+void push_signal(struct task* t, int no, int deterministic)
 {
-	push_new_event(ctx, EV_SIGNAL);
-	ctx->ev->signal.no = no;
-	ctx->ev->signal.deterministic = deterministic;
+	push_new_event(t, EV_SIGNAL);
+	t->ev->signal.no = no;
+	t->ev->signal.deterministic = deterministic;
 }
 
-void pop_signal(struct context* ctx)
+void pop_signal(struct task* t)
 {
-	int type = pop_event(ctx);
+	int type = pop_event(t);
 	assert(EV_SIGNAL == type);
 }
 
-void push_syscall(struct context* ctx, int no)
+void push_syscall(struct task* t, int no)
 {
-	push_new_event(ctx, EV_SYSCALL);
-	ctx->ev->syscall.no = no;
+	push_new_event(t, EV_SYSCALL);
+	t->ev->syscall.no = no;
 }
 
-void pop_syscall(struct context* ctx)
+void pop_syscall(struct task* t)
 {
-	int type = pop_event(ctx);
+	int type = pop_event(t);
 	assert(EV_SYSCALL == type);
 }

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -96,15 +96,15 @@ struct event {
 };
 
 /**
- * A "context" is a task, in the linux usage: the unit of scheduling.
- * (OS people sometimes call this a "thread control block".)  Multiple
+ * A "task" is a task in the linux usage: the unit of scheduling.  (OS
+ * people sometimes call this a "thread control block".)  Multiple
  * tasks may share the same address space and file descriptors, in
  * which case they're commonly called "threads".  Or two tasks may
  * have their own address spaces and file descriptors, in which case
  * they're called "processes".  Both look the same to rr (on linux),
  * so no distinction is made here.
  */
-struct context {
+struct task {
 	/* State only used during recording. */
 
 	/* For convenience, the current top of |pending_events| if
@@ -114,7 +114,7 @@ struct context {
 	/* The current stack of events being processed. */
 	FIXEDSTACK_DECL(, struct event, 2) pending_events;
 
-	/* Whether switching away from this context is allowed in its
+	/* Whether switching away from this task is allowed in its
 	 * current state.  Some operations must be completed
 	 * atomically and aren't switchable. */
 	int switchable;
@@ -147,7 +147,7 @@ struct context {
 	int event;
 	/* Record of the syscall that was interrupted by a desched
 	 * notification.  It's legal to reference this memory /while
-	 * the desched is being processed only/, because |ctx| is in
+	 * the desched is being processed only/, because |t| is in
 	 * the middle of a desched, which means it's successfully
 	 * allocated (but not yet committed) a syscall record. */
 	const struct syscallbuf_record* desched_rec;
@@ -259,7 +259,7 @@ struct context {
 	/* Points at the tracee's mapping of the buffer. */
 	void* syscallbuf_child;
 
-	RB_ENTRY(context) entry;
+	RB_ENTRY(task) entry;
 };
 
 /**
@@ -269,22 +269,22 @@ struct context {
  * so should be recorded for consistency-checking purposes.
  */
 enum { NO_EXEC_INFO = 0, HAS_EXEC_INFO };
-void push_pseudosig(struct context* ctx, int no, int has_exec_info);
-void pop_pseudosig(struct context* ctx);
+void push_pseudosig(struct task* t, int no, int has_exec_info);
+void pop_pseudosig(struct task* t);
 
 /**
  * Push/pop signal events on the pending stack.  |no| is the signum,
  * and |deterministic| is nonzero for deterministically-delivered
  * signals (see handle_signal.c).
  */
-void push_signal(struct context* ctx, int no, int deterministic);
-void pop_signal(struct context* ctx);
+void push_signal(struct task* t, int no, int deterministic);
+void pop_signal(struct task* t);
 
 /**
  * Push/pop syscall events on the pending stack.  |no| is the syscall
  * number.
  */
-void push_syscall(struct context* ctx, int no);
-void pop_syscall(struct context* ctx);
+void push_syscall(struct task* t, int no);
+void pop_syscall(struct task* t);
 
 #endif /* TASK_H_ */

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -14,7 +14,7 @@
 #define STATE_SYSCALL_EXIT		  1
 #define STATE_PRE_MMAP_ACCESS     2
 
-struct context;
+struct task;
 
 enum {
 	/* "Magic" (rr-generated) pseudo-signals can't be represented
@@ -140,25 +140,25 @@ const char* strevent(int event);
 
 void clear_trace_files(void);
 void rec_init_trace_files(void);
-void write_open_inst_dump(struct context* context);
+void write_open_inst_dump(struct task* context);
 void record_input_str(pid_t pid, int syscall, int len);
 void sc_record_data(pid_t tid, int syscall, size_t len, void* buf);
-void record_inst(struct context* context, char* inst);
+void record_inst(struct task* context, char* inst);
 
-void record_inst_done(struct context* context);
-void record_child_data(struct context *ctx, size_t len, void* child_ptr);
+void record_inst_done(struct task* context);
+void record_child_data(struct task *t, size_t len, void* child_ptr);
 
 void record_timestamp(int tid, long int* eax_, long int* edx_);
 void record_child_data_tid(pid_t tid, int event, size_t len, void* child_ptr);
-void record_child_str(struct context* ctx, void* child_ptr);
-void record_parent_data(struct context *ctx, size_t len, void *addr, void *buf);
+void record_child_str(struct task* t, void* child_ptr);
+void record_parent_data(struct task *t, size_t len, void *addr, void *buf);
 /**
- * Record the current event of |ctx|.  Record the registers of |ctx|
+ * Record the current event of |t|.  Record the registers of |t|
  * (and other relevant execution state) so that it can be used or
  * verified during replay, if that state is available and meaningful
- * at |ctx|'s current execution point.
+ * at |t|'s current execution point.
  */
-void record_event(struct context* ctx);
+void record_event(struct task* t);
 void record_mmapped_file_stats(struct mmapped_file *file);
 unsigned int get_global_time(void);
 unsigned int get_time(pid_t tid);
@@ -190,10 +190,10 @@ pid_t get_recorded_main_thread();
 void rep_setup_trace_dir(const char* path);
 
 /*         function declaration for instruction dump                  */
-void read_open_inst_dump(struct context* context);
-char* peek_next_inst(struct context* context);
-char* read_inst(struct context* context);
-void inst_dump_parse_register_file(struct context* context, struct user_regs_struct* reg);
+void read_open_inst_dump(struct task* context);
+char* peek_next_inst(struct task* context);
+char* read_inst(struct task* context);
+void inst_dump_parse_register_file(struct task* context, struct user_regs_struct* reg);
 /* ------------------------------------------------------------------ */
 
 void inst_dump_skip_entry();

--- a/src/test/bad_ip.c
+++ b/src/test/bad_ip.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 
-static void sighandler(int sig, siginfo_t* si, void* uctxp) {
+static void sighandler(int sig, siginfo_t* si, void* utp) {
 	assert(SIGSEGV == sig && si->si_addr == (void*)0x42);
 
 	puts("caught segfault @0x42");


### PR DESCRIPTION
Obviously nothing urgent, but this has been a festering boil since I first saw the code, and now that large amounts are being touched for #293, and  the former struct context is going to start looking more like the linux task, I feel like the few minutes of `sed` is finally justified.  Less typing from now on too.
