### PR TITLE
Track sighandlers established by sigaction.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -183,7 +183,8 @@ static void start(int argc, char* argv[], char** envp)
 			init_libpfm();
 
 			/* register thread at the scheduler and start the HPC */
-			rec_sched_register_thread(&__rr_flags, 0, pid);
+			rec_sched_register_thread(&__rr_flags, 0, pid,
+						  COPY_SIGHANDLERS);
 
 			/* perform the action recording */
 			log_info("Start recording...");

--- a/src/recorder/rec_sched.h
+++ b/src/recorder/rec_sched.h
@@ -26,8 +26,17 @@ int rec_sched_get_num_threads();
 struct task* rec_sched_get_active_thread(const struct flags* flags,
 					    struct task* t,
 					    int* by_waitpid);
+/**
+ * Register the new OS task |child|, created by |parent|.  |parent|
+ * may be 0 for the first registered task, but must be a registered
+ * task for all subsequent calls.  |share_sighandlers| is nonzero if
+ * |parent| and |child| will share the same sighandlers table, and
+ * zero if |child| will get a copy of |parent|'s table.
+ */
+enum { COPY_SIGHANDLERS = 0, SHARE_SIGHANDLERS = 1 };
 void rec_sched_register_thread(const struct flags* flags,
-			       pid_t parent, pid_t child);
+			       pid_t parent, pid_t child,
+			       int share_sighandlers);
 void rec_sched_deregister_thread(struct task** t);
 void rec_sched_exit_all();
 

--- a/src/share/task.c
+++ b/src/share/task.c
@@ -2,6 +2,24 @@
 
 #include "task.h"
 
+#include <stdlib.h>
+#include <string.h>
+
+#include "util.h"
+
+/**
+ * Stores the table of signal dispositions and metadata for an
+ * arbitrary set of tasks.  Each of those task must own one one of the
+ * |refcount|s while they still refer to this.
+ */
+struct sighandlers {
+	int refcount;
+	struct {
+		sig_handler_t handler;
+		int resethand;
+	} handlers[_NSIG];
+};
+
 /**
  * Push a new event onto |t|'s event stack of type |type|.
  */
@@ -60,4 +78,131 @@ void pop_syscall(struct task* t)
 {
 	int type = pop_event(t);
 	assert(EV_SYSCALL == type);
+}
+
+static void assert_valid(const struct sighandlers* t)
+{
+	assert(t->refcount > 0);
+}
+
+static void assert_table_has_sig(const struct sighandlers* t, int sig)
+{
+	assert_valid(t);
+	assert(0 < sig && sig < ALEN(t->handlers));
+}
+
+static int is_user_handler(sig_handler_t sh)
+{
+	/* We assume this in order to make the check below simpler.
+	 * TODO: static assert */
+	assert((void*)1 == SIG_IGN);
+
+	return !!((uintptr_t)sh & ~(uintptr_t)SIG_IGN);
+}
+
+struct sighandlers* sighandlers_new()
+{
+	struct sighandlers* t = calloc(1, sizeof(*t));
+
+	/* We assume this in order to skip explicitly initializing the
+	 * table.  TODO: static assert */
+	assert(NULL == SIG_DFL);
+
+	t->refcount = 1;
+	return t;
+}
+
+void sighandlers_init_from_current_process(struct sighandlers* table)
+{
+	int i;
+	for (i = 0; i < ALEN(table->handlers); ++i) {
+		struct sigaction act;
+
+		if (-1 == sigaction(i, NULL, &act)) {
+			/* EINVAL means we're querying an unused
+			 * signal number. */
+			assert(EINVAL == errno);
+			assert(SIG_DFL == table->handlers[i].handler);
+			assert(!table->handlers[i].resethand);
+			continue;
+		}
+		table->handlers[i].handler = (SA_SIGINFO & act.sa_flags) ?
+					     (void*)act.sa_sigaction :
+					     act.sa_handler;
+		table->handlers[i].resethand = (act.sa_flags & SA_RESETHAND);
+	}
+}
+
+int sighandlers_has_user_handler(const struct sighandlers* table, int sig)
+{
+	assert_table_has_sig(table, sig);
+	return is_user_handler(table->handlers[sig].handler);
+}
+
+int sighandlers_is_resethand(const struct sighandlers* table, int sig)
+{
+	assert_table_has_sig(table, sig);
+	return !!table->handlers[sig].resethand;
+}
+
+void sighandlers_set_disposition(struct sighandlers* table, int sig,
+				 sig_handler_t disp, int resethand)
+{
+	assert_table_has_sig(table, sig);
+	table->handlers[sig].handler = disp;
+	/* The sigaction() spec says to only honor SA_RESETHAND if
+	 * it's set for a user signal handler.  So ignore it if it's
+	 * specified for SIG_IGN.  (It would have no effect for
+	 * SIG_DFL.) */
+	table->handlers[sig].resethand = is_user_handler(disp) ? resethand : 0;
+}
+
+struct sighandlers* sighandlers_copy(struct sighandlers* from)
+{
+	struct sighandlers* copy = sighandlers_new();
+
+	memcpy(copy, from, sizeof(*copy));
+	copy->refcount = 1;
+
+	return copy;
+}
+
+struct sighandlers* sighandlers_ref(struct sighandlers* table)
+{
+	assert_valid(table);
+	++table->refcount;
+	return table;
+}
+
+void sighandlers_reset_user_handlers(struct sighandlers* table)
+{
+	int i;
+
+	for (i = 0; i < ALEN(table->handlers); ++i) {
+		sig_handler_t oh = table->handlers[i].handler;
+		/* If the handler was a user handler, reset to
+		 * default.  If it was SIG_IGN or SIG_DFL, leave it
+		 * alone. */
+		if (is_user_handler(oh)) {
+			table->handlers[i].handler = SIG_DFL;
+			table->handlers[i].resethand = 0;
+		}
+	}
+}
+
+void sighandlers_unref(struct sighandlers** table)
+{
+	struct sighandlers* t;
+
+	if (!table || !*table) {
+		return;
+	}
+
+	t = *table;
+	*table = NULL;
+	assert_valid(t);
+
+	if (0 == --t->refcount) {
+		free(t);
+	}
 }

--- a/src/share/trace.c
+++ b/src/share/trace.c
@@ -1146,6 +1146,3 @@ char* peek_next_inst(struct task* t)
 	fsetpos(t->inst_dump, &pos);
 	return tmp;
 }
-
-
-


### PR DESCRIPTION
If we SINGLESTEP to see if we entered a sighandler from some execution
states, like from a blocked SIG_IGN syscall on a non-main thread, or a
core-dumping fatal signal on a non-main thread, we can end up
deadlocking.  What we want to know is whether we /will/ enter a
sighandler, before we step (or whatever) and record the sigframe.
This patch adds that information but only checks it against what we
see from the SINGLESTEP.  A later patch will use the sighandler table
to selectively SINGLESTEP into sighandlers.

This adds sigaction tracking as a "sidecar" to the SINGLESTEP approach for the time being.  We'll get the responsibilities sorted out as part of #293.
