### PR TITLE
Move scratch-buf allocation state into syscall events.

### DIFF
--- a/src/share/task.h
+++ b/src/share/task.h
@@ -87,6 +87,74 @@ struct event {
 			       EXITING_SYSCALL } state;
 			/* Syscall number. */
 			int no;
+			/* When tasks enter syscalls that may block
+			 * and so must be prepared for a
+			 * context-switch, and the syscall params
+			 * include (in)outparams that point to
+			 * buffers, we need to redirect those
+			 * arguments to scratch memory.  This allows
+			 * rr to serialize execution of what may be
+			 * multiple blocked syscalls completing
+			 * "simulatenously" (from rr's perspective).
+			 * After the syscall exits, we restore the
+			 * data saved in scratch memory to the
+			 * original buffers.
+			 *
+			 * Then during replay, we simply restore the
+			 * saved data to the tracee's passed-in buffer
+			 * args and continue on.
+			 *
+			 * The array |saved_arg_ptr| stores the
+			 * original callee pointers that we replaced
+			 * with pointers into the syscallbuf.
+			 * |tmp_data_num_bytes| is the number of bytes
+			 * we'll be saving across *all* buffer
+			 * outparams.  (We can save one length value
+			 * because all the tmp pointers into scratch
+			 * are contiguous.)  |tmp_data_ptr| /usually/
+			 * points at |scratch_ptr|, except ...
+			 *
+			 * ... a fly in this ointment is may-block
+			 * buffered syscalls.  If a task blocks in one
+			 * of those, it will look like it just entered
+			 * a syscall that needs a scratch buffer.
+			 * However, it's too late at that point to
+			 * fudge the syscall args, because processing
+			 * of the syscall has already begun in the
+			 * kernel.  But that's OK: the syscallbuf code
+			 * has already swapped out the original
+			 * buffer-pointers for pointers into the
+			 * syscallbuf (which acts as its own scratch
+			 * memory).  We just have to worry about
+			 * setting things up properly for replay.
+			 *
+			 * The descheduled syscall will "abort" its
+			 * commit into the syscallbuf, so the outparam
+			 * data won't actually be saved there (and
+			 * thus, won't be restored during replay).
+			 * During replay, we have to restore them like
+			 * we restore the non-buffered-syscall scratch
+			 * data.
+			 *
+			 * What we do is add another level of
+			 * indirection to the "scratch pointer",
+			 * through |tmp_data_ptr|.  Usually that will
+			 * point at |scratch_ptr|, for unbuffered
+			 * syscalls.  But for desched'd buffered ones,
+			 * it will point at the region of the
+			 * syscallbuf that's being used as "scratch".
+			 * We'll save that region during recording and
+			 * restore it during replay without caring
+			 * which scratch space it points to.
+			 *
+			 * (The recorder code has to be careful,
+			 * however, not to attempt to copy-back
+			 * syscallbuf tmp data to the "original"
+			 * buffers.  The syscallbuf code will do that
+			 * itself.) */
+			FIXEDSTACK_DECL(, void*, 5) saved_args;
+			void* tmp_data_ptr;
+			int tmp_data_num_bytes;
 		} syscall;
 
 		/**
@@ -159,12 +227,36 @@ struct task {
 	 * back to the original buffers, serializing A and B in the
 	 * example above.
 	 *
+	 * Syscalls can "nest" due to signal handlers.  If a syscall A
+	 * is interrupted by a signal, and the sighandler calls B,
+	 * then we can have scratch buffers set up for args of both A
+	 * and B.  In linux, B won't actually re-enter A; A is exited
+	 * with a "will-restart" error code and its args are saved for
+	 * when (or if) it's restarted after the signal.  But that
+	 * doesn't really matter wrt scratch space.  (TODO: in the
+	 * future, we may be able to use that fact to simplify
+	 * things.)
+	 *
+	 * Because of nesting, at first blush it seems we should push
+	 * scratch allocations onto a stack and pop them as syscalls
+	 * (or restarts thereof) complete.  But under a critical
+	 * assumption, we can actually skip that.  The critical
+	 * assumption is that the kernel writes its (in)outparams
+	 * atomically wrt signal interruptions, and only writes them
+	 * on successful exit.  Each syscall will complete in stack
+	 * order, and it's invariant that the syscall processors must
+	 * only write back to user buffers *only* the data that was
+	 * written by the kernel.  So as long as the atomicity
+	 * assumption holds, the completion of syscalls higher in the
+	 * event stack may overwrite scratch space, but the completion
+	 * of each syscall will overwrite those overwrites again, and
+	 * that over-overwritten data is exactly and only what we'll
+	 * write back to the tracee.
+	 *
 	 * |scratch_ptr| points at the mapped address in the child,
-	 * |size| is the total available space, and |len| is the *
-	 * amount currently in use. */
+	 * and |size| is the total available space. */
 	void *scratch_ptr;
 	size_t scratch_size;
-	size_t scratch_len;
 
 	int exec_state;
 	int event;
@@ -188,58 +280,6 @@ struct task {
 	 * PTRACE_CONT has been observed to miss the syscall re-entry
 	 * point, for not-well-understand reasons. */
 	int will_restart;
-
-	/* When tasks enter syscalls that may block and so must be
-	 * prepared for a context-switch, and the syscall params
-	 * include (in)outparams that point to buffers, we need to
-	 * redirect those arguments to scratch memory.  This allows rr
-	 * to serialize execution of what may be multiple blocked
-	 * syscalls completing "simulatenously" (from rr's
-	 * perspective).  After the syscall exits, we restore the data
-	 * saved in scratch memory to the original buffers.
-	 *
-	 * Then during replay, we simply restore the saved data to the
-	 * tracee's passed-in buffer args and continue on.
-	 *
-	 * The array |saved_arg_ptr| stores the original callee
-	 * pointers that we replaced with pointers into the
-	 * syscallbuf.  |tmp_data_num_bytes| is the number of bytes
-	 * we'll be saving across *all* buffer outparams.  (We can
-	 * save one length value because all the tmp pointers into
-	 * scratch are contiguous.)  |tmp_data_ptr| /usually/ points
-	 * at |scratch_ptr|, except ...
-	 *
-	 * ... a fly in this ointment is may-block buffered syscalls.
-	 * If a task blocks in one of those, it will look like it just
-	 * entered a syscall that needs a scratch buffer.  However,
-	 * it's too late at that point to fudge the syscall args,
-	 * because processing of the syscall has already begun in the
-	 * kernel.  But that's OK: the syscallbuf code has already
-	 * swapped out the original buffer-pointers for pointers into
-	 * the syscallbuf (which acts as its own scratch memory).  We
-	 * just have to worry about setting things up properly for
-	 * replay.
-	 *
-	 * The descheduled syscall will "abort" its commit into the
-	 * syscallbuf, so the outparam data won't actually be saved
-	 * there (and thus, won't be restored during replay).  During
-	 * replay, we have to restore them like we restore the
-	 * non-buffered-syscall scratch data.
-	 *
-	 * What we do is add another level of indirection to the
-	 * "scratch pointer", through |tmp_data_ptr|.  Usually that
-	 * will point at |scratch_ptr|, for unbuffered syscalls.  But
-	 * for desched'd buffered ones, it will point at the region of
-	 * the syscallbuf that's being used as "scratch".  We'll save
-	 * that region during recording and restore it during replay
-	 * without caring which scratch space it points to.
-	 *
-	 * (The recorder code has to be careful, however, not to
-	 * attempt to copy-back syscallbuf tmp data to the "original"
-	 * buffers.  The syscallbuf code will do that itself.) */
-	FIXEDSTACK_DECL(, void*, 5) saved_args;
-	void* tmp_data_ptr;
-	int tmp_data_num_bytes;
 
 	/* The child's desched counter event fd number, and our local
 	 * dup. */


### PR DESCRIPTION
Working towards #293.
