### PR TITLE
Switch to using the sighandlers table to determine whether a sighandler is entered.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -355,13 +355,10 @@ static int is_deterministic_signal(const siginfo_t* si)
 static void record_signal(int sig, struct task* t, const siginfo_t* si,
 			  uint64_t max_rbc)
 {
-	/* TODO: the sighandler table should be the SSoT once the
-	 * replayer knows how to look ahead and determine whether to
-	 * enter a sighandler.  For the time being, we'll check the
-	 * two answers against each other. */
 	int has_user_handler = sighandlers_has_user_handler(t->sighandlers,
 							    sig);
 	int resethand = sighandlers_is_resethand(t->sighandlers, sig);
+	size_t sigframe_size = 0;
 
 	push_signal(t, sig, is_deterministic_signal(si));
 
@@ -374,40 +371,40 @@ static void record_signal(int sig, struct task* t, const siginfo_t* si,
 	/* This event is used by the replayer to advance to the point
 	 * of signal delivery. */
 	record_event(t);
-	reset_hpc(t, max_rbc); // TODO: the hpc gets reset in record event.
-	assert(read_insts(t->hpc) == 0);
-	// enter the sig handler
-	sys_ptrace_singlestep_sig(t->tid, sig);
-	// wait for the kernel to finish setting up the handler
-	sys_waitpid(t->tid, &(t->status));
-	// 0 instructions means we entered a handler
-	int entered_handler = (0 == read_insts(t->hpc));
-	// TODO: find out actual struct sigframe size. 128 seems to be too small
-	size_t frame_size = entered_handler ? 1024 : 0;
+	reset_hpc(t, max_rbc);
 
-	if (has_user_handler != entered_handler) {
-		log_err("We were%s supposed to have a sighandler for %s, but did%s enter a sigframe",
-			has_user_handler ? "" :"n't",
-			signalname(sig),
-			entered_handler ? "" : "n't");
-		emergency_debug(t);
+	if (has_user_handler) {
+		debug("  %s has user handler", signalname(sig));
+		/* Enter the signal handler. */
+		sys_ptrace_singlestep_sig(t->tid, sig);
+		sys_waitpid(t->tid, &t->status);
+		/* It's been observed that when tasks enter
+		 * sighandlers, the singlestep operation above doesn't
+		 * retire any instructions.  This cross-checks the
+		 * sighandler information we maintain in
+		 * |t->sighandlers|. */
+		assert(0 == read_insts(t->hpc));
+
+		/* TODO: find out actual struct sigframe size. 128
+		 * seems to be too small. */
+		sigframe_size = 1024;
+
+		read_child_registers(t->tid, &t->regs);
+	} else {
+		debug("  no user handler for %s", signalname(sig));
 	}
+
+	/* We record this data regardless to simplify replay. */
+	record_child_data(t, sigframe_size, (void*)t->regs.esp);
 
 	if (resethand) {
 		sighandlers_set_disposition(t->sighandlers, sig,
 					    SIG_DFL, NO_RESET);
-		/* NBB: the tracee must have entered the sighandler at
-		 * this point, or the next action must be to continue
-		 * the tracee into its sighandler. */
 	}
 
-	struct user_regs_struct regs;
-	read_child_registers(t->tid, &regs);
-	record_child_data(t, frame_size, (void*)regs.esp);
-
-	/* This event is used to set up the signal handler frame, or
-	 * to record the resulting state of the stepi if there wasn't
-	 * a signal handler. */
+	/* This event is used by the replayer to set up the signal
+	 * handler frame, or to record the resulting state of the
+	 * stepi if there wasn't a signal handler. */
 	record_event(t);
 
 	pop_signal(t);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -42,7 +42,20 @@ void print_inst(struct task* t);
 void print_syscall(struct task *t, struct trace_frame *trace);
 void get_eip_info(pid_t tid);
 int check_if_mapped(struct task *t, void *start, void *end);
-int compare_register_files(char* name1, const struct user_regs_struct* reg1, char* name2, const struct user_regs_struct* reg2, int print, int stop);
+
+/**
+ * Return nonzero if |reg1| matches |reg2|.  Passing EXPECT_MISMATCHES
+ * indicates that the caller is using this as a general register
+ * compare and nothing special should be done if the register files
+ * mismatch.  Passing LOG_MISMATCHES will log the registers that don't
+ * match.  Passing BAIL_ON_MISMATCH will additionally abort on
+ * mismatch.
+ */
+enum { EXPECT_MISMATCHES = 0, LOG_MISMATCHES, BAIL_ON_MISMATCH };
+int compare_register_files(char* name1, const struct user_regs_struct* reg1,
+			   char* name2, const struct user_regs_struct* reg2,
+			   int mismatch_behavior);
+
 void assert_child_regs_are(struct task* t, const struct user_regs_struct* regs, int event, int state);
 uint64_t str2ull(const char* start, size_t max_size);
 long int str2li(const char* start, size_t max_size);

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -12,8 +12,8 @@
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))
 
-pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-int sockfds[2];
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static int sockfds[2];
 
 void* reader_thread(void* dontcare) {
 	char token = '!';


### PR DESCRIPTION
This is a nontrivial part of #329 that deserves its own commit.  Also packs in an unrelated util.c cleanup.
