### PR TITLE
Add an assert_exec() helper to remove verbose copypasta.

### DIFF
--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -9,15 +9,11 @@
 void replay(struct flags rr_flags);
 
 /**
- * Open a temporary debugging connection for |t| and service
- * requests until the user quits or requests execution to resume.  Use
- * this when a target enters an illegal state and can't continue, for
- * example
+ * Open a temporary debugging connection for |t| and service requests
+ * until the user quits or requests execution to resume.
  *
- *  if (recorded_state != replay_state) {
- *	 log_err("Bad state ...");
- *	 emergency_debug(t);
- *  }
+ * You probably don't want to use this directly; instead, use
+ * |assert_exec()| from dbg.h.
  *
  * This function does not return.
  */

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -21,7 +21,6 @@
 #include "dbg.h"
 #include "ipc.h"
 #include "../recorder/rec_sched.h"
-#include "../replayer/replayer.h" /* for emergency_debug() */
 #include "task.h"
 #include "trace.h"
 #include "util.h"
@@ -285,10 +284,9 @@ void goto_next_event(struct task *t)
 	sys_waitpid(t->tid, &t->status);
 
 	t->child_sig = signal_pending(t->status);
-	if (t->child_sig == SIGTRAP) {
-		log_err("Caught unexpected SIGTRAP while going to next event");
-		emergency_debug(t);
-	}
+	assert_exec(t, t->child_sig != SIGTRAP,
+		    "Caught unexpected SIGTRAP while going to next event");
+
 	t->event = read_child_orig_eax(t->tid);
 }
 

--- a/src/share/util.c
+++ b/src/share/util.c
@@ -693,15 +693,18 @@ void assert_child_regs_are(struct task* t,
 			   int event, int state)
 {
 	pid_t tid = t->tid;
-	struct user_regs_struct cur_regs;
+	int regs_are_equal;
 
-	read_child_registers(tid, &cur_regs);
-	if (compare_register_files("replaying", &cur_regs, "recorded", regs,
-				   LOG_MISMATCHES)) {
+	read_child_registers(tid, &t->regs);
+	regs_are_equal = (0 == compare_register_files("replaying", &t->regs,
+						      "recorded", regs,
+						      LOG_MISMATCHES));
+	if (!regs_are_equal) {
 		print_process_mmap(tid);
-		log_err("[%s in state %d, trace file line %d]",
-			strevent(event), state, get_trace_file_lines_counter());
-		emergency_debug(t);
+		assert_exec(t, regs_are_equal,
+			    "[%s in state %d, trace file line %d]",
+			    strevent(event), state,
+			    get_trace_file_lines_counter());
 	}
 	/* TODO: add perf counter validations (hw int, page faults, insts) */
 }


### PR DESCRIPTION
Quick detour for cleanup.
