### PR TITLE
Save interrupted syscalls on the event stack for future reference.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(BASIC_TESTS
   ignored_async_usr1
   int3
   interrupt
+  intr_sleep
   io
   link
   mmap_private
@@ -101,6 +102,7 @@ set(BASIC_TESTS
   rdtsc
   segfault
   sigchld_interrupt_signal
+#  sighandlers
   sigill
   sigprocmask
   sigrt

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -2758,8 +2758,7 @@ void rec_process_syscall(struct task *t, int syscall, struct flags rr_flags)
 	 */
 	SYS_REC0(writev)
 
-	case RRCALL_init_syscall_buffer:
-		t->event = (-syscall | RRCALL_BIT);
+	case SYS_rrcall_init_syscall_buffer:
 		init_syscall_buffer(t, NULL, SHARE_DESCHED_EVENT_FD);
 		break;
 

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -781,11 +781,17 @@ void rep_process_syscall(struct task* t, int redirect_stdio,
 
 	if (STATE_SYSCALL_EXIT == state
 	    && SYSCALL_WILL_RESTART(trace->recorded_regs.eax)) {
-		/* when a syscall exits with a restart "error", it
+		/* When a syscall exits with a restart "error", it
 		 * will be restarted by the kernel with a restart
 		 * syscall (see below). The child process is oblivious
 		 * to this, so in the replay we need to jump directly
-		 * to the exit from the restart_syscall */
+		 * to the exit from the restart_syscall.
+		 *
+		 * Strictly speaking, we don't need to set the
+		 * -ERESTART* value here, but if we don't the register
+		 * state may mismatch the next replayed event for
+		 * |t|. */
+		set_return_value(t);
 		step->action = TSTEP_RETIRE;
 		return;
 	}

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -10,6 +10,8 @@
 
 #include "../replayer/replayer.h" /* for emergency_debug() */
 
+#include "task.h"
+
 /**
  * Useful debug macros.  Define DEBUGRR to enable DEBUG-level
  * messages.
@@ -38,6 +40,7 @@
 				#_cond " failed to hold: " _msg "\n",	\
 				__FILE__, __LINE__, __FUNCTION__,	\
 				clean_errno(), ##__VA_ARGS__);		\
+			log_pending_events(_t);				\
 			emergency_debug(_t);				\
 		}							\
 	} while(0)

--- a/src/share/task.c
+++ b/src/share/task.c
@@ -81,6 +81,12 @@ void pop_syscall(struct task* t)
 	assert(EV_SYSCALL == type);
 }
 
+void pop_interrupted_syscall(struct task* t)
+{
+	int type = pop_event(t);
+	assert(EV_INTERRUPTED_SYSCALL == type);
+}
+
 void log_pending_events(const struct task* t)
 {
 	ssize_t depth = FIXEDSTACK_DEPTH(&t->pending_events);

--- a/src/share/trace.c
+++ b/src/share/trace.c
@@ -110,7 +110,7 @@ const char* strevent(int event)
 	if (0 > event) {
 		return decode_signal_event(event);
 	}
-	if (0 < event) {
+	if (0 <= event) {
 		return syscallname(event);
 	}
 	return "???event";

--- a/src/share/util.c
+++ b/src/share/util.c
@@ -148,6 +148,8 @@ const char* syscallname(int syscall)
 #include "../replayer/syscall_defs.h"
 #undef SYSCALL_DEF
 
+	case SYS_restart_syscall:
+		return "restart_syscall";
 	default:
 		return "???syscall";
 	}

--- a/src/test/intr_sleep.c
+++ b/src/test/intr_sleep.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+static int interrupted_sleep() {
+	struct timespec ts = { .tv_sec = 2 };
+
+	alarm(1);
+	errno = 0;
+	/* The implementation of sleep() is technically allowed to use
+	 * SIGALRM, so we have to use nanosleep() for pedantry. */
+	nanosleep(&ts, NULL);
+	return errno;
+}
+
+static int caught_signal;
+static void handle_signal(int sig) {
+	++caught_signal;
+}
+
+int main(int argc, char *argv[]) {
+	int err;
+
+	signal(SIGALRM, SIG_IGN);
+	err = interrupted_sleep();
+	printf("No sighandler; sleep exits with errno %d\n", err);
+	test_assert(0 == err);
+
+	signal(SIGALRM, handle_signal);
+	err = interrupted_sleep();
+	printf("With sighandler; sleep exits with errno %d\n", err);
+	test_assert(1 == caught_signal);
+	test_assert(EINTR == err);
+
+	puts("EXIT-SUCCESS");
+	return 1;
+}

--- a/src/test/intr_sleep.run
+++ b/src/test/intr_sleep.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh intr_sleep "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Note: this patch keeps around the previous task->last_syscall
machinery for cross-checking purposes.  Otherwise it's subsumed.

Resolves #329.  Also a big chunk of #293.  This code almost certainly has issues with some types of signal "re-entry" and syscall restarts, but we'll cross that bridge with tests in hand for #293.
