### PR TITLE
Add a fails() helper to mark failing tests, instead of wholesale disabling them.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ install(TARGETS rr rr_syscall_buffer
 #
 # Alphabetical, please.
 set(BASIC_TESTS
-#  abort_nonmain
+  abort_nonmain
   accept
   alarm
   args
@@ -78,7 +78,7 @@ set(BASIC_TESTS
   async_signal_syscalls
   async_usr1
   bad_ip
-#  bad_syscall
+  bad_syscall
   barrier
   block
   breakpoint
@@ -95,22 +95,21 @@ set(BASIC_TESTS
   io
   link
   mmap_private
-#  mmap_shared
+  mmap_shared
   perf_event
   priority
   prw
   rdtsc
   segfault
   sigchld_interrupt_signal
-#  sighandlers
   sigill
   sigprocmask
   sigrt
   sigtrap
   simple
   splice
-#  step_thread
-#  term_nonmain
+  step_thread
+  term_nonmain
   tgkill
   threads
 )
@@ -124,13 +123,13 @@ set(BASIC_TESTS
 # Alphabetical, please.
 set(CUSTOM_TESTS
   break_clock
-#  break_int3
+  break_int3
   break_mmap_private
   break_rdtsc
   break_sync_signal
   break_thread
   break_time_slice
-#  deliver_async_signal_during_syscalls
+  deliver_async_signal_during_syscalls
   get_thread_list
   read_bad_mem
   sanity

--- a/src/test/abort_nonmain.run
+++ b/src/test/abort_nonmain.run
@@ -1,2 +1,5 @@
 source `dirname $0`/util.sh abort_nonmain "$@"
+
+fails "abort() from non-main thread is broken"
+
 compare_test ''

--- a/src/test/bad_syscall.run
+++ b/src/test/bad_syscall.run
@@ -1,2 +1,5 @@
 source `dirname $0`/util.sh bad_syscall "$@"
+
+fails "rr can't encode bad syscall numbers yet"
+
 compare_test EXIT-SUCCESS

--- a/src/test/break_int3.run
+++ b/src/test/break_int3.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh break_int3 "$@"
+
+fails "gdb and rr don't yet agree what should happen when a breakpoint is set on a breakpoint instruction"
+
+record int3
+debug int3 break_int3

--- a/src/test/break_int3.run.disabled
+++ b/src/test/break_int3.run.disabled
@@ -1,6 +1,0 @@
-# This test is disabled because gdb and rr can't agree what should
-# happen when a breakpoint is set on a breakpoint instruction.
-
-source util.sh break_int3 "$@"
-record int3
-debug int3 break_int3

--- a/src/test/deliver_async_signal_during_syscalls.run
+++ b/src/test/deliver_async_signal_during_syscalls.run
@@ -1,8 +1,6 @@
-# Disabled because this test fails pretty frequently when SIGUSR1 is
-# delivered while rr processes a time-slice interrupt.  The test case
-# is pretty extreme, but let's hope this isn't a common occurrence!
+source `dirname $0`/util.sh deliver_async_signal_during_syscalls "$@"
 
-source util.sh deliver_async_signal_during_syscalls "$@"
+fails "SIGUSR1 is often delivered while rr processes a time-slice interrupt, and multiple pending signals are NYI"
 
 # See async_signal_syscalls.run for an explanation.
 skip_if_no_syscall_buf

--- a/src/test/mmap_shared.run
+++ b/src/test/mmap_shared.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh mmap_shared "$@"
+
+fails "rr doesn't handle 'anonymous' shared mappings yet"
+
+compare_test 'done'

--- a/src/test/mmap_shared.run.disabled
+++ b/src/test/mmap_shared.run.disabled
@@ -1,2 +1,0 @@
-source util.sh mmap_shared "$@"
-compare_test 'done'

--- a/src/test/step_thread.run
+++ b/src/test/step_thread.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh step_thread "$@"
+
+fails "Ordering of threads hitting breakpoints is unreliable."
+
+debug_test

--- a/src/test/step_thread.run.disabled
+++ b/src/test/step_thread.run.disabled
@@ -1,2 +1,0 @@
-source util.sh step_thread "$@"
-debug_test

--- a/src/test/term_nonmain.run
+++ b/src/test/term_nonmain.run
@@ -1,2 +1,5 @@
 source `dirname $0`/util.sh term_nonmain "$@"
+
+fails "Terminating signal from non-main thread is broken"
+
 compare_test 'killing ...'

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -121,10 +121,16 @@ echo Using lib arg "'$LIB_ARG'"
 ## testing "API".
 ##
 
+function fails { why=$1;
+    echo NOTE: Skipping "'$TESTNAME'" because it fails: $why
+    passed=y
+    exit 0
+}
+
 # If the test takes too long to run without the syscallbuf enabled,
 # use this to prevent it from running when that's the case.
 function skip_if_no_syscall_buf {
-    if [[ "-n" == "$LIB_ARG" || "" == "$LIB_ARG" ]]; then
+    if [[ "-n" == "$LIB_ARG" ]]; then
 	echo NOTE: Skipping "'$TESTNAME'" because syscallbuf is disabled
         passed=y
 	exit 0
@@ -134,7 +140,7 @@ function skip_if_no_syscall_buf {
 # If the test is causing an unrealistic failure when the syscallbuf is
 # enabled, skip it.  This better be a temporary situation!
 function skip_if_syscall_buf {
-    if [[ "-b" == "$LIB_ARG" ]]; then
+    if [[ "-b" == "$LIB_ARG" || "" == "$LIB_ARG" ]]; then
 	echo NOTE: Skipping "'$TESTNAME'" because syscallbuf is enabled
         passed=y
 	exit 0


### PR DESCRIPTION
With this approach, the source files continue to be compiled (i.e. checked for errors), and the tests themselves provide better documentation to the person running them.
