### PR TITLE
Successful nanosleep()s don't write back remaining time.

### DIFF
--- a/src/test/intr_sleep_no_restart.c
+++ b/src/test/intr_sleep_no_restart.c
@@ -48,7 +48,7 @@ static void sighandler(int sig) {
 	++reader_caught_signal;
 
 	PRINT("r: in sighandler level 1 ...\n");
-	intr_sleep(1);
+	intr_sleep(2);
 }
 
 static void sighandler2(int sig) {
@@ -80,7 +80,7 @@ static void* reader_thread(void* dontcare) {
 	pthread_barrier_wait(&barrier);
 
 	puts("r: blocking on sleep, awaiting signal ...");
-	intr_sleep(1);
+	intr_sleep(3);
 
 	return NULL;
 }

--- a/src/test/intr_sleep_no_restart.run
+++ b/src/test/intr_sleep_no_restart.run
@@ -1,5 +1,5 @@
 source `dirname $0`/util.sh intr_sleep_no_restart "$@"
 
-fails "rr seems to be writing back remainder time when requested time has completed (it shouldn't do that)."
+fails "rr doesn't see an EINTR exit from nanosleep() so doesn't know when to write back the remaining time."
 
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
We're trading off one bug here for another, but one step at a time I guess.
