### PR TITLE
Don't record scratch-fudged registers at an interrupted syscall, because they won't be replayed.

### DIFF
--- a/src/share/util.c
+++ b/src/share/util.c
@@ -1239,6 +1239,17 @@ struct sigaction * get_sig_handler(pid_t tid, unsigned int signum){
 	return sig_handler_table[tid][signum];
 }
 
+void copy_syscall_arg_regs(struct user_regs_struct* to,
+			   const struct user_regs_struct* from)
+{
+	to->ebx = from->ebx;
+	to->ecx = from->ecx;
+	to->edx = from->edx;
+	to->esi = from->esi;
+	to->edi = from->edi;
+	to->ebp = from->ebp;
+}
+
 int is_desched_event_syscall(struct task* t,
 			     const struct user_regs_struct* regs)
 {

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -125,6 +125,13 @@ int inject_and_execute_syscall(struct task * t, struct user_regs_struct * call_r
 void mprotect_child_region(struct task * t, void * addr, int prot);
 
 /**
+ * Copy the registers used for syscall arguments (not including
+ * syscall number) from |from| to |to|.
+ */
+void copy_syscall_arg_regs(struct user_regs_struct* to,
+			   const struct user_regs_struct* from);
+
+/**
  * Return nonzero if |t|'s current registers |regs| indicate that
  * |t| is at an arm-desched-event or disarm-desched-event syscall.
  */

--- a/src/test/intr_poll.run
+++ b/src/test/intr_poll.run
@@ -1,5 +1,2 @@
 source `dirname $0`/util.sh intr_poll "$@"
-
-fails "We record delivery of the signal with the fudged registers, but we replay with non-fudged registers and so never find the right delivery point."
-
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #329.  May require another round of whack-a-mole with syscalls restarted after rr declines to deliver a signal, since the [semantics](https://github.com/cgjones/rr/wiki/Linux-signals#restart-semantics) are different than for SA_RESTART/SIG_IGN restarts.  But one step at a time.
