### PR TITLE
Put the framework in place for handling syscall "pseudo-exits" from sigreturn.

### DIFF
--- a/src/recorder/rec_process_event.h
+++ b/src/recorder/rec_process_event.h
@@ -11,10 +11,19 @@
 #include "../share/util.h"
 
 /**
- * Prepare |t| to enter |syscallno|.  Return nonzero if a
- * context-switch is allowed for |t|, 0 if not.
+ * Prepare |t| to enter its current syscall event.  Return nonzero if
+ * a context-switch is allowed for |t|, 0 if not.
  */
-int rec_prepare_syscall(struct task* t, int syscallno);
-void rec_process_syscall(struct task* t, int syscall);
+int rec_prepare_syscall(struct task* t);
+/**
+ * Prepare |t| for its current syscall event to be interrupted and
+ * possibly restarted.
+ */
+void rec_prepare_restart_syscall(struct task* t);
+/**
+ * Restore any argument registers fudged for |t|'s current syscall and
+ * store any nondeterministic outparam data.
+ */
+void rec_process_syscall(struct task* t);
 
 #endif /* PROCESS_SYSCALL_H_ */

--- a/src/test/intr_sleep_no_restart.run
+++ b/src/test/intr_sleep_no_restart.run
@@ -1,5 +1,2 @@
 source `dirname $0`/util.sh intr_sleep_no_restart "$@"
-
-fails "rr doesn't see an EINTR exit from nanosleep() so doesn't know when to write back the remaining time."
-
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
Fixes the last of the interrupted-syscall issues I know of that aren't related to the syscallbuf.  If I never see a sigreturn again I'll be a happy man.
