### PR TITLE
Centralize test helpers and try to make spurious failures from output interleaving less frequent.

### DIFF
--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -193,15 +193,15 @@ static ssize_t traced_write(int fd, const void* buf, size_t count)
 __attribute__((format(printf, 1, 2)))
 static void logmsg(const char* msg, ...)
 {
-  va_list args;
-  char buf[1024];
-  int len;
+	va_list args;
+	char buf[1024];
+	int len;
 
-  va_start(args, msg);
-  len = vsnprintf(buf, sizeof(buf) - 1, msg, args);
-  va_end(args);
+	va_start(args, msg);
+	len = vsnprintf(buf, sizeof(buf) - 1, msg, args);
+	va_end(args);
 
-  traced_write(STDERR_FILENO, buf, len);
+	traced_write(STDERR_FILENO, buf, len);
 }
 
 #ifndef NDEBUG

--- a/src/test/abort_nonmain.c
+++ b/src/test/abort_nonmain.c
@@ -1,24 +1,21 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <pthread.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 static void* kill_thread(void* dontcare) {
 	kill(getpid(), SIGABRT);
-	puts("FAILED: kill() didn't work");
+	atomic_puts("FAILED: kill() didn't work");
 	return NULL;		/* not reached */
 }
 
 int main(int argc, char *argv[]) {
 	pthread_t t;
 
-	setvbuf(stdout, NULL, _IONBF, 0);
-
 	pthread_create(&t, NULL, kill_thread, NULL);
 	pthread_join(t, NULL);
-	puts("FAILED: joined thread that should have died");
+	atomic_puts("FAILED: joined thread that should have died");
 	return 0;
 }

--- a/src/test/accept.c
+++ b/src/test/accept.c
@@ -1,13 +1,10 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static void client(const struct sockaddr_un* addr) {
 	int clientfd;
@@ -44,7 +41,7 @@ static void server() {
 
 	unlink(addr.sun_path);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 }
 
 int main(int argc, char *argv[]) {

--- a/src/test/alarm.c
+++ b/src/test/alarm.c
@@ -1,10 +1,10 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <signal.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <string.h>
+#include "rrutil.h"
+
 #include <errno.h>
+#include <signal.h>
+#include <string.h>
 
 int stop = 0;
 
@@ -12,24 +12,22 @@ void catcher(int signum , siginfo_t *siginfo_ptr, void *ucontext_ptr) {
 	stop = 1;
 }
 
-int main( int argc, char *argv[] )  {
+int main(int argc, char **argv) {
     struct sigaction sact;
     int counter = 0;
 
-    sigemptyset( &sact.sa_mask );
+    sigemptyset(&sact.sa_mask);
     sact.sa_flags = 0;
     sact.sa_sigaction = catcher;
-    sigaction( SIGALRM, &sact, NULL );
+    sigaction(SIGALRM, &sact, NULL);
 
     alarm(1);  /* timer will pop in 1 second */
 
-    for( counter=0; counter >= 0 && !stop ; counter++ )
-		if (counter % 100000 == 0)
-			write(1,".",1);
+    for (counter=0; counter >= 0 && !stop; counter++)
+	    if (counter % 100000 == 0)
+		    write(STDOUT_FILENO, ".", 1);
 
-    char buf[128];
-    sprintf(buf, "\nSignal caught, Counter is %d\n", counter );
-    write(1,buf,strlen(buf));
+    atomic_printf("\nSignal caught, Counter is %d\n", counter );
 
-    return( 0 );
+    return 0;
 }

--- a/src/test/args.c
+++ b/src/test/args.c
@@ -1,10 +1,8 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <string.h>
 
 int main(int argc, char *argv[]) {
 	test_assert(6 == argc);
@@ -14,6 +12,6 @@ int main(int argc, char *argv[]) {
 	test_assert(!strcmp("1000", argv[4]));
 	test_assert(!strcmp("hello", argv[5]));
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/async_segv.c
+++ b/src/test/async_segv.c
@@ -1,15 +1,13 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <signal.h>
+#include <stdlib.h>
 
 static void handle_segv(int sig) {
 	test_assert(SIGSEGV == sig);
-	puts("caught segv, goodbye");
+	atomic_puts("caught segv, goodbye");
 	exit(0);
 }
 

--- a/src/test/async_signal_syscalls.c
+++ b/src/test/async_signal_syscalls.c
@@ -1,21 +1,19 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static sig_atomic_t caught_usr1;
 
 static void handle_usr1(int sig) {
 	test_assert(SIGUSR1 == sig);
 	caught_usr1 = 1;
-	puts("caught usr1");
+	atomic_puts("caught usr1");
 }
 
 int main() {
@@ -40,6 +38,6 @@ int main() {
 		gettimeofday(&tv, NULL);
 	}
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/async_usr1.c
+++ b/src/test/async_usr1.c
@@ -1,18 +1,16 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <signal.h>
+#include <stdlib.h>
 
 static sig_atomic_t caught_usr1;
 
 static void handle_usr1(int sig) {
 	test_assert(SIGUSR1 == sig);
 	caught_usr1 = 1;
-	puts("caught usr1");
+	atomic_puts("caught usr1");
 }
 
 static void breakpoint() {
@@ -32,6 +30,6 @@ int main(int argc, char *argv[]) {
 	}
 	test_assert(caught_usr1);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/async_usr1.run
+++ b/src/test/async_usr1.run
@@ -1,5 +1,9 @@
 testname=async_usr1
 source `dirname $0`/util.sh $testname "$@"
+
+# TODO: a sigreturn can flush the syscallbuf
+skip_if_syscall_buf
+
 # SIGUSR1, wait 0.5s
 record_async_signal 10 0.5 $testname
 replay

--- a/src/test/bad_ip.c
+++ b/src/test/bad_ip.c
@@ -1,16 +1,14 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 static void sighandler(int sig, siginfo_t* si, void* utp) {
-	assert(SIGSEGV == sig && si->si_addr == (void*)0x42);
+	test_assert(SIGSEGV == sig && si->si_addr == (void*)0x42);
 
-	puts("caught segfault @0x42");
-	fflush(stdout);
+	atomic_puts("caught segfault @0x42");
 	_exit(0);
 }
 

--- a/src/test/bad_syscall.c
+++ b/src/test/bad_syscall.c
@@ -1,13 +1,12 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <errno.h>
-#include <stdio.h>
 #include <syscall.h>
-#include <unistd.h>
 
 int main(int argc, char *argv[]) {
 	int ret = syscall(-10);
-	assert(-1 == ret && ENOSYS == errno);
+	test_assert(-1 == ret && ENOSYS == errno);
 	return 0;
 }

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <pthread.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <sys/time.h>
 
 #define ALEN(_a) (sizeof(_a) / sizeof(_a[0]))
@@ -19,11 +19,11 @@ static void hit_barrier() {
 static void* thread(void* barp) {
 	pthread_barrier_t* bar = barp;
 
-	puts("thread launched");
+	atomic_puts("thread launched");
 	breakpoint();
 	pthread_barrier_wait(bar);
 	pthread_barrier_wait(bar);
-	puts("thread done");
+	atomic_puts("thread done");
 	return NULL;
 }
 
@@ -47,12 +47,12 @@ int main(int argc, char *argv[]) {
 	hit_barrier();
 
 	pthread_barrier_wait(&bar);
-	puts("main done");
+	atomic_puts("main done");
 
 	for (i = 0; i < ALEN(threads); ++i) {
 		pthread_join(threads[i], NULL);
 	}
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -1,16 +1,12 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <poll.h>
-#include <pthread.h>
-#include <stdio.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static int sockfds[2];
@@ -23,35 +19,35 @@ void* reader_thread(void* dontcare) {
 
 	gettimeofday(&ts, NULL);
 
-	puts("r: acquiring mutex ...");
+	atomic_puts("r: acquiring mutex ...");
 	pthread_mutex_lock(&lock);
-	puts("r:   ... releasing mutex");
+	atomic_puts("r:   ... releasing mutex");
 	pthread_mutex_unlock(&lock);
 
-	puts("r: reading socket ...");
+	atomic_puts("r: reading socket ...");
 	gettimeofday(&ts, NULL);
 	test_assert(1 == read(readsock, &c, sizeof(c)));
-	printf("r:   ... read '%c'\n", c);
+	atomic_printf("r:   ... read '%c'\n", c);
 	test_assert(c == token);
 	++token;
 
-	puts("r: recv'ing socket ...");
+	atomic_puts("r: recv'ing socket ...");
 	gettimeofday(&ts, NULL);
 	test_assert(1 == recv(readsock, &c, sizeof(c), 0));
-	printf("r:   ... recv'd '%c'\n", c);
+	atomic_printf("r:   ... recv'd '%c'\n", c);
 	test_assert(c == token);
 	++token;
 	{
 		struct pollfd pfd;
 
-		puts("r: polling socket ...");
+		atomic_puts("r: polling socket ...");
 		pfd.fd = readsock;
 		pfd.events = POLLIN;
 		gettimeofday(&ts, NULL);
 		poll(&pfd, 1, -1);
-		puts("r:   ... done, doing nonblocking read ...");
+		atomic_puts("r:   ... done, doing nonblocking read ...");
 		test_assert(1 == read(readsock, &c, sizeof(c)));
-		printf("r:   ... read '%c'\n", c);
+		atomic_printf("r:   ... read '%c'\n", c);
 		test_assert(c == token);
 		++token;
 	}
@@ -59,7 +55,7 @@ void* reader_thread(void* dontcare) {
 		int epfd;
 		struct epoll_event ev;
 
-		puts("r: epolling socket ...");
+		atomic_puts("r: epolling socket ...");
 		test_assert(0 <= (epfd = epoll_create(1/*num events*/)));
 		ev.events = EPOLLIN;
 		ev.data.fd = readsock;
@@ -67,17 +63,17 @@ void* reader_thread(void* dontcare) {
 		test_assert(0 == epoll_ctl(epfd, EPOLL_CTL_ADD, ev.data.fd,
 					   &ev));
 		test_assert(1 == epoll_wait(epfd, &ev, 1, -1));
-		puts("r:   ... done, doing nonblocking read ...");
+		atomic_puts("r:   ... done, doing nonblocking read ...");
 		test_assert(readsock == ev.data.fd);
 		test_assert(1 == read(readsock, &c, sizeof(c)));
-		printf("r:   ... read '%c'\n", c);
+		atomic_printf("r:   ... read '%c'\n", c);
 		test_assert(c == token);
 		++token;
 
 		close(epfd);
 	}
 	/* Make the main thread wait on our join() */
-	puts("r: sleeping ...");
+	atomic_puts("r: sleeping ...");
 	usleep(500000);
 
 	return NULL;
@@ -88,7 +84,6 @@ int main(int argc, char *argv[]) {
 	struct timeval ts;
 	pthread_t reader;
 
-	setvbuf(stdout, NULL, _IONBF, 0);
 
 	gettimeofday(&ts, NULL);
 
@@ -99,46 +94,46 @@ int main(int argc, char *argv[]) {
 	pthread_create(&reader, NULL, reader_thread, NULL);
 
 	/* Make the reader thread wait on its pthread_mutex_lock() */
-	puts("M: sleeping ...");
+	atomic_puts("M: sleeping ...");
 	usleep(500000);
-	puts("M: unlocking mutex ...");
+	atomic_puts("M: unlocking mutex ...");
 	pthread_mutex_unlock(&lock);
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	/* Force a wait on read() */
-	puts("M: sleeping again ...");
+	atomic_puts("M: sleeping again ...");
 	usleep(500000);
-	printf("M: writing '%c' to socket ...\n", token);
+	atomic_printf("M: writing '%c' to socket ...\n", token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	/* Force a wait on recv() */
-	puts("M: sleeping again ...");
+	atomic_puts("M: sleeping again ...");
 	usleep(500000);
-	printf("M: sending '%c' to socket ...\n", token);
+	atomic_printf("M: sending '%c' to socket ...\n", token);
 	send(sockfds[0], &token, sizeof(token), 0);
 	++token;
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	/* Force a wait on poll() */
-	puts("M: sleeping again ...");
+	atomic_puts("M: sleeping again ...");
 	usleep(500000);
-	printf("M: writing '%c' to socket ...\n", token);
+	atomic_printf("M: writing '%c' to socket ...\n", token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	/* Force a wait on epoll_wait() */
-	puts("M: sleeping again ...");
+	atomic_puts("M: sleeping again ...");
 	usleep(500000);
-	printf("M: writing '%c' to socket ...\n", token);
+	atomic_printf("M: writing '%c' to socket ...\n", token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	pthread_join(reader, NULL);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/breakpoint.c
+++ b/src/test/breakpoint.c
@@ -1,29 +1,27 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
+#include "rrutil.h"
 
 static void C() {
-	puts("in C");
+	atomic_puts("in C");
 }
 
 static void B() {
-	puts("calling C");
+	atomic_puts("calling C");
 	C();
-	puts("finished C");
+	atomic_puts("finished C");
 }
 
 static void A() {
-	puts("calling B");
+	atomic_puts("calling B");
 	B();
-	puts("finished B");
+	atomic_puts("finished B");
 }
 
 int main() {
-	setvbuf(stdout, NULL, _IONBF, 0);
 
-	puts("calling A");
+	atomic_puts("calling A");
 	A();
-	puts("finished A");
-	fflush(stdout);
+	atomic_puts("finished A");
 	return 0;
 }

--- a/src/test/chew_cpu.c
+++ b/src/test/chew_cpu.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
+#include "rrutil.h"
 
 #define NUM_ITERATIONS (1 << 30)
 
@@ -12,7 +12,7 @@ static void breakpoint() {
 int spin() {
 	int i, dummy = 0;
 
-	puts("spinning");
+	atomic_puts("spinning");
 	/* NO SYSCALLS AFTER HERE: the point of this test is to hit
 	 * hpc interrupts to exercise the nonvoluntary interrupt
 	 * scheduler. */
@@ -27,8 +27,7 @@ int spin() {
 }
 
 int main(int argc, char *argv[]) {
-	setvbuf(stdout, NULL, _IONBF, 0);
 
-	printf("EXIT-SUCCESS dummy=%d\n", spin());
+	atomic_printf("EXIT-SUCCESS dummy=%d\n", spin());
 	return 0;
 }

--- a/src/test/clock.c
+++ b/src/test/clock.c
@@ -1,13 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static void breakpoint() {
 	int break_here = 1;
@@ -20,7 +18,7 @@ int main() {
 	int i;
 
 	clock_getres(CLOCK_MONOTONIC, &ts);
-	printf("Clock resolution is >= %g us\n", ((double) ts.tv_nsec) / 1.0e3);
+	atomic_printf("Clock resolution is >= %g us\n", ((double) ts.tv_nsec) / 1.0e3);
 
 	memset(&ts, 0, sizeof(ts));
 	memset(&tv, 0, sizeof(tv));
@@ -49,12 +47,12 @@ int main() {
 				&& tv.tv_usec <= tv_now.tv_usec));
 		tv = tv_now;
 
-		printf("cg: %g %llu, gtod: %g %llu\n",
+		atomic_printf("cg: %g %llu, gtod: %g %llu\n",
 		       (double) ts.tv_sec, (long long int) ts.tv_nsec,
 		       (double) tv.tv_sec, (long long int) tv.tv_usec);
 	}
 	breakpoint();
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/exit_group.c
+++ b/src/test/exit_group.c
@@ -1,8 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <pthread.h>
-#include <stdio.h>
-#include <unistd.h>
+#include "rrutil.h"
+
 
 pthread_barrier_t bar;
 
@@ -22,8 +21,7 @@ int main(int argc, char *argv[]) {
 
 	pthread_barrier_wait(&bar);
 
-	puts("_exit()ing");
-	fflush(stdout);
+	atomic_puts("_exit()ing");
 
 	_exit(0);
 	return 0;		/* not reached */

--- a/src/test/fadvise.c
+++ b/src/test/fadvise.c
@@ -1,9 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "rrutil.h"
+
 #include <fcntl.h>
-#include <stdio.h>
-#include <sys/syscall.h>
-#include <unistd.h>
+#include <syscall.h>
 
 int main(int argc, char *argv[]) {
 	/* There's not a (simple) way to meaningfully test fadvise,
@@ -13,6 +13,6 @@ int main(int argc, char *argv[]) {
 	syscall(SYS_fadvise64, -1, 0, 0, POSIX_FADV_NORMAL);
 	syscall(SYS_fadvise64_64, -1, POSIX_FADV_NORMAL, 0, 0);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/fork_syscalls.c
+++ b/src/test/fork_syscalls.c
@@ -1,16 +1,13 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <time.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static void syscalls(int num) {
 	struct timespec ts;
@@ -30,7 +27,7 @@ int main() {
 
 	if (0 == (child = fork())) {
 		syscalls(10);
-		printf("CHILD-EXIT ");
+		atomic_printf("CHILD-EXIT ");
 		exit(0);
 	}
 
@@ -38,6 +35,6 @@ int main() {
 
 	waitpid(child, NULL, 0);
 
-	puts("PARENT-EXIT");
+	atomic_puts("PARENT-EXIT");
 	return 0;
 }

--- a/src/test/hello.c
+++ b/src/test/hello.c
@@ -1,9 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
+#include "rrutil.h"
 
 int main() {
-	printf("Hi\n");
+	atomic_puts("Hi");
 	return 0;
 }
 

--- a/src/test/ignored_async_usr1.c
+++ b/src/test/ignored_async_usr1.c
@@ -1,7 +1,8 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 
 int main(int argc, char *argv[]) {
 	int dummy, i;
@@ -15,6 +16,6 @@ int main(int argc, char *argv[]) {
 		dummy += (dummy + i) % 9735;
 	}
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/int3.c
+++ b/src/test/int3.c
@@ -5,24 +5,19 @@ static void breakpoint() {
 	 * Tests rely on that. */
 }
 
-#include <assert.h>
-#include <stdio.h>
-#include <signal.h>
-#include <unistd.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <signal.h>
 
 static void handle_sigtrap(int sig) {
-	puts("caught SIGTRAP!");
-	fflush(stdout);
+	atomic_puts("caught SIGTRAP!");
 	_exit(0);
 }
 
 int main(int argc, char *argv[]) {
 	signal(SIGTRAP, handle_sigtrap);
 
-	puts("raising SIGTRAP ...");
-	fflush(stdout);
+	atomic_puts("raising SIGTRAP ...");
 
 	breakpoint();
 

--- a/src/test/interrupt.c
+++ b/src/test/interrupt.c
@@ -1,25 +1,24 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
+#include "rrutil.h"
 
 void spin() {
 	int i;
 
-	puts("spinning");
+	atomic_puts("spinning");
 	for (i = 1; i < (1 << 30); ++i) {
 		if (0 == i % (1 << 20)) {
-			putc('.', stdout);
+			write(STDOUT_FILENO, ".", 1);
 		}
 		if (0 == i % (79 * (1 << 20))) {
-			putc('\n', stdout);
+			write(STDOUT_FILENO, "\n", 1);
 		}
 	}
 }
 
 int main(int argc, char *argv[]) {
-	setvbuf(stdout, NULL, _IONBF, 0);
 
 	spin();
-	puts("done");
+	atomic_puts("done");
 	return 0;
 }

--- a/src/test/intr_poll.c
+++ b/src/test/intr_poll.c
@@ -1,14 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <errno.h>
 #include <poll.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int pipefds[2];
 static int poll_pipe(int timeout_ms) {
@@ -31,15 +28,15 @@ int main(int argc, char *argv[]) {
 
 	signal(SIGALRM, SIG_IGN);
 	alarm(1);
-	puts("ignoring SIGALRM, going into poll ...");
+	atomic_puts("ignoring SIGALRM, going into poll ...");
 	test_assert(0 == poll_pipe(1500) && 0 == errno);
 
 	signal(SIGALRM, handle_signal);
 	alarm(1);
-	puts("handling SIGALRM, going into poll ...");
+	atomic_puts("handling SIGALRM, going into poll ...");
 	test_assert(-1 == poll_pipe(-1) && EINTR == errno);
 	test_assert(1 == caught_signal);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 1;
 }

--- a/src/test/intr_read_restart.c
+++ b/src/test/intr_read_restart.c
@@ -1,20 +1,16 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <errno.h>
 #include <poll.h>
-#include <pthread.h>
 #include <signal.h>
-#include <stdio.h>
 #include <string.h>
 #include <syscall.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';
@@ -30,20 +26,16 @@ static pid_t sys_gettid() {
 	return syscall(SYS_gettid);
 }
 
-#define PRINT(_msg) write(STDOUT_FILENO, _msg, sizeof(_msg) - 1)
-
 static void sighandler(int sig) {
 	char c = sentinel_token;
 
 	test_assert(sys_gettid() == reader_tid);
 	++reader_caught_signal;
 
-	PRINT("r: in sighandler level 1 ...\n");
+	atomic_puts("r: in sighandler level 1 ...");
 
 	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
-	PRINT("r: ... read level 1 '");
-	write(STDOUT_FILENO, &c, 1);
-	PRINT("'\n");
+	atomic_printf("r: ... read level 1 '%c'\n", c);
 	test_assert(c == start_token + 1);
 }
 
@@ -53,16 +45,12 @@ static void sighandler2(int sig) {
 	test_assert(sys_gettid() == reader_tid);
 	++reader_caught_signal;
 
-	PRINT("r: in sighandler level 2 ...\n");
+	atomic_puts("r: in sighandler level 2 ...");
 
 	test_assert(1 == read(sockfds[1], &c, sizeof(c)));
-	PRINT("r: ... read level 2 '");
-	write(STDOUT_FILENO, &c, 1);
-	PRINT("'\n");
+	atomic_printf("r: ... read level 2 '%c'\n", c);
 	test_assert(c == start_token);
 }
-
-#undef PRINT
 
 static void* reader_thread(void* dontcare) {
 	char token = start_token;
@@ -87,13 +75,13 @@ static void* reader_thread(void* dontcare) {
 
 	pthread_barrier_wait(&barrier);
 
-	puts("r: blocking on read, awaiting signal ...");
+	atomic_puts("r: blocking on read, awaiting signal ...");
 
 	test_assert(1 == read(readsock, &c, sizeof(c)));
 	test_assert(2 == reader_caught_signal);
 	token += reader_caught_signal;
 	
-	printf("r: ... read level 0 '%c'\n", c);
+	atomic_printf("r: ... read level 0 '%c'\n", c);
 	test_assert(c == token);
 
 	return NULL;
@@ -103,7 +91,6 @@ int main(int argc, char *argv[]) {
 	char token = start_token;
 	struct timeval ts;
 
-	setvbuf(stdout, NULL, _IONBF, 0);
 
 	/* (Kick on the syscallbuf if it's enabled.) */
 	gettimeofday(&ts, NULL);
@@ -117,41 +104,41 @@ int main(int argc, char *argv[]) {
 
 	/* Force a blocked read() that's interrupted by a SIGUSR1,
 	 * which then itself blocks on read() and succeeds. */
-	puts("M: sleeping ...");
+	atomic_puts("M: sleeping ...");
 	usleep(500000);
 
-	puts("M: killing reader ...");
+	atomic_puts("M: killing reader ...");
 	pthread_kill(reader, SIGUSR1);
-	puts("M:   (quick nap)");
+	atomic_puts("M:   (quick nap)");
 	usleep(100000);
 
-	puts("M: killing reader again ...");
+	atomic_puts("M: killing reader again ...");
 	pthread_kill(reader, SIGUSR2);
 
-	puts("M:   (longer nap)");
+	atomic_puts("M:   (longer nap)");
 
 	usleep(500000);
-	printf("M: finishing level 2 reader by writing '%c' to socket ...\n",
+	atomic_printf("M: finishing level 2 reader by writing '%c' to socket ...\n",
 		token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
 
 	usleep(500000);
-	printf("M: finishing level 1 reader by writing '%c' to socket ...\n",
+	atomic_printf("M: finishing level 1 reader by writing '%c' to socket ...\n",
 		token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
 
 	usleep(500000);
-	printf("M: finishing original reader by writing '%c' to socket ...\n",
+	atomic_printf("M: finishing original reader by writing '%c' to socket ...\n",
 		token);
 	write(sockfds[0], &token, sizeof(token));
 	++token;
 
-	puts("M:   ... done");
+	atomic_puts("M:   ... done");
 
 	pthread_join(reader, NULL);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/intr_sleep.c
+++ b/src/test/intr_sleep.c
@@ -1,14 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <errno.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int interrupted_sleep() {
 	struct timespec ts = { .tv_sec = 2 };
@@ -31,15 +28,15 @@ int main(int argc, char *argv[]) {
 
 	signal(SIGALRM, SIG_IGN);
 	err = interrupted_sleep();
-	printf("No sighandler; sleep exits with errno %d\n", err);
+	atomic_printf("No sighandler; sleep exits with errno %d\n", err);
 	test_assert(0 == err);
 
 	signal(SIGALRM, handle_signal);
 	err = interrupted_sleep();
-	printf("With sighandler; sleep exits with errno %d\n", err);
+	atomic_printf("With sighandler; sleep exits with errno %d\n", err);
 	test_assert(1 == caught_signal);
 	test_assert(EINTR == err);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 1;
 }

--- a/src/test/io.c
+++ b/src/test/io.c
@@ -1,7 +1,6 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
-#include <unistd.h>
+#include "rrutil.h"
 
 int main(int argc, char *argv[]) {
 	char buf[32];
@@ -9,6 +8,6 @@ int main(int argc, char *argv[]) {
 
 	read(garbage_fd, buf, sizeof(buf));
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/link.c
+++ b/src/test/link.c
@@ -1,10 +1,10 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "rrutil.h"
+
 #include <fcntl.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define TOKEN "ABC"
 #define TOKEN_SIZE sizeof(TOKEN)
@@ -18,10 +18,10 @@ void verify_token(int fd) {
 
 	len = read(fd, buf, sizeof(buf));
 	if (len != TOKEN_SIZE || strcmp(buf, TOKEN)) {
-		puts("Internal error: FAILED: splice wrote the wrong data");
+		atomic_puts("Internal error: FAILED: splice wrote the wrong data");
 		exit(1);
 	}
-	puts("Got expected token " TOKEN);
+	atomic_puts("Got expected token " TOKEN);
 }
 
 int main() {
@@ -32,7 +32,7 @@ int main() {
 	close(fd);
 
 	if (link(token_file, link_name)) {
-		puts("Internal error: FAILED: link not created");
+		atomic_puts("Internal error: FAILED: link not created");
 		exit(1);
 	}
 
@@ -48,6 +48,6 @@ int main() {
 
 	unlink(link_name);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/mmap_private.c
+++ b/src/test/mmap_private.c
@@ -1,14 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <fcntl.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/types.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static void breakpoint() {
 	int break_here = 1;
@@ -44,11 +41,11 @@ int main(int argc, char *argv[]) {
 		magic = rpage[i] * 31 + 3;
 		wpage[i] = magic;
 
-		assert(rpage[i] != magic && wpage[i] == magic);
-		printf("%d:%d,", rpage[i], wpage[i]);
+		test_assert(rpage[i] != magic && wpage[i] == magic);
+		atomic_printf("%d:%d,", rpage[i], wpage[i]);
 	}
 
-	puts(" done");
+	atomic_puts(" done");
 
 	return 0;
 }

--- a/src/test/mmap_shared.c
+++ b/src/test/mmap_shared.c
@@ -1,12 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <stdlib.h>
 #include <sys/mman.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int create_segment(size_t num_bytes) {
 	char filename[] = "/dev/shm/rr-test-XXXXXX";
@@ -30,10 +27,10 @@ int main(int argc, char *argv[]) {
 	for (i = 0; i < num_bytes / sizeof(int); ++i) {
 		wpage[i] = i;
 		test_assert(rpage[i] == i);
-		printf("%d,", rpage[i]);
+		atomic_printf("%d,", rpage[i]);
 	}
 
-	puts(" done");
+	atomic_puts(" done");
 
 	return 0;
 }

--- a/src/test/perf_event.c
+++ b/src/test/perf_event.c
@@ -1,15 +1,12 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <linux/perf_event.h>
 #include <sched.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/syscall.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int counter_fd;
 
@@ -40,12 +37,12 @@ int main(int argc, char *argv[]) {
 		sys_perf_event_open(&attr, 0/*self*/, -1/*any cpu*/, -1, 0);
 	test_assert(0 <= counter_fd);
 
-	printf("num descheds: %llu\n", get_desched());
+	atomic_printf("num descheds: %llu\n", get_desched());
 	for (i = 0; i < 5; ++i) {
 		sched_yield();
-		printf("after yield: %llu\n", get_desched());
+		atomic_printf("after yield: %llu\n", get_desched());
 	}
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/priority.c
+++ b/src/test/priority.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <sys/time.h>
 #include <sys/resource.h>
 
@@ -9,7 +9,7 @@ int main() {
 	int prio1, prio2;
 
 	prio1 = getpriority(PRIO_PROCESS, 0);
-	printf("Current process priority: %d\n", prio1);
+	atomic_printf("Current process priority: %d\n", prio1);
 	if (prio1 < 19) {
 		/* If it's less than 19, we can decrease the
 		 * priority. */
@@ -19,8 +19,8 @@ int main() {
 	setpriority(PRIO_PROCESS, 0, prio1);
 
 	prio2 = getpriority(PRIO_PROCESS, 0);
-	assert(prio1 == prio2);
-	printf("Now priority is: %d\n", prio2);
-	puts("EXIT-SUCCESS");
+	test_assert(prio1 == prio2);
+	atomic_printf("Now priority is: %d\n", prio2);
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/prw.c
+++ b/src/test/prw.c
@@ -1,12 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <fcntl.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 int main(int argc, char *argv[]) {
 	int fd = open("prw.txt", O_CREAT | O_RDWR, 0600);
@@ -16,18 +15,18 @@ int main(int argc, char *argv[]) {
 
 	memset(buf, '?', sizeof(buf));
 	nr = write(fd, buf, sizeof(buf));
-	assert(nr == sizeof(buf));
+	test_assert(nr == sizeof(buf));
 	nr = write(fd, buf, 10);
-	assert(nr == 10);
+	test_assert(nr == 10);
 
 	nr = pwrite(fd, content, sizeof(content), 10);
-	assert(nr == sizeof(content));
-	printf("Wrote ```%s'''\n", content);
+	test_assert(nr == sizeof(content));
+	atomic_printf("Wrote ```%s'''\n", content);
 
 	nr = pread(fd, buf, sizeof(buf), 10);
-	assert(nr == sizeof(content));
-	printf("Read ```%s'''\n", buf);
+	test_assert(nr == sizeof(content));
+	atomic_printf("Read ```%s'''\n", buf);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/rdtsc.c
+++ b/src/test/rdtsc.c
@@ -1,11 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <inttypes.h>
 #include <stdint.h>
-#include <stdio.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static uint64_t rdtsc(void) {
 	uint32_t hi, lo;
@@ -30,10 +28,10 @@ int main(int argc, char *argv[]) {
 		 * replay must be rdtsc */
 		tsc = rdtsc();
 		test_assert(last_tsc < tsc);
-		printf("%" PRIu64 ",", tsc);
+		atomic_printf("%" PRIu64 ",", tsc);
 		last_tsc = tsc;
 	}
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -1,0 +1,70 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#ifndef RRUTIL_H
+#define RRUTIL_H
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define test_assert(cond)  assert("FAILED if not: " && (cond))
+
+#if (defined(__linux__) && (defined(__i386__) || defined(__x86_64__)) \
+     && defined(_BITS_PTHREADTYPES_H))
+# define PTHREAD_SPINLOCK_INITIALIZER (1)
+#else
+# error "Sorry, pthread_spinlock_t initializer unknown for this arch."
+#endif
+
+static pthread_spinlock_t printf_lock = PTHREAD_SPINLOCK_INITIALIZER;
+
+/**
+ * Print the printf-like arguments to stdout as atomic-ly as we can
+ * manage.  Async-signal-safe.  Does not flush stdio buffers (doing so
+ * isn't signal safe).
+ */
+__attribute__((format(printf, 1, 2)))
+inline static int atomic_printf(const char* fmt, ...) {
+	va_list args;
+	char buf[1024];
+	int len;
+	ssize_t ret;
+
+	va_start(args, fmt);
+	len = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
+	va_end(args);
+	{
+		/* NBB: this spin lock isn't strictly signal-safe.
+		 * However, we're trading one class of fairly frequent
+		 * spurious failures with stdio for what (should!) be
+		 * a less frequent class of failures with this
+		 * non-reentrant spinlock.
+		 *
+		 * If your test mysteriously hangs with 100% CPU
+		 * usage, this is a potential suspect.
+		 *
+		 * TODO: it's possible to fix this bug, but not
+		 * trivial.  Play it by ear. */
+		pthread_spin_lock(&printf_lock);
+		ret = write(STDOUT_FILENO, buf, len);
+		pthread_spin_unlock(&printf_lock);
+	}
+	return ret;
+}
+
+/**
+ * Write |str| on its own line to stdout as atomic-ly as we can
+ * manage.  Async-signal-safe.  Does not flush stdio buffers (doing so
+ * isn't signal safe).
+ */
+inline static int atomic_puts(const char* str) {
+	return atomic_printf("%s\n", str);
+}
+
+#define fprintf(...) USE_dont_write_stderr
+#define printf(...) USE_atomic_printf_INSTEAD
+#define puts(...) USE_atomic_puts_INSTEAD
+
+#endif /* RRUTIL_H */

--- a/src/test/segfault.c
+++ b/src/test/segfault.c
@@ -1,12 +1,11 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
-#include <unistd.h>
 
 static void sighandler(int sig) {
-	printf("caught signal %d, exiting\n", sig);
-	fflush(stdout);
+	atomic_printf("caught signal %d, exiting\n", sig);
 	_exit(0);
 }
 

--- a/src/test/sigchld_interrupt_signal.c
+++ b/src/test/sigchld_interrupt_signal.c
@@ -1,26 +1,23 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 int main(int argc, char *argv[]) {
 	pid_t c;
 	int dummy, i;
 	int status;
 
-	puts("forking child");
+	atomic_puts("forking child");
 
 	if (0 == (c = fork())) {
 		usleep(10000);
-		puts("child exiting");
+		atomic_puts("child exiting");
 		exit(0);
 	}
 
@@ -32,6 +29,6 @@ int main(int argc, char *argv[]) {
 	test_assert(c == waitpid(c, &status, 0));
 	test_assert(WIFEXITED(status) && 0 == WEXITSTATUS(status));
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/sigill.c
+++ b/src/test/sigill.c
@@ -1,21 +1,19 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
-#include <unistd.h>
 
 static void sighandler(int sig) {
-	printf("caught signal %d, exiting\n", sig);
-	fflush(stdout);
+	atomic_printf("caught signal %d, exiting\n", sig);
 	_exit(0);
 }
 
 int main(int argc, char *argv[]) {
 	signal(SIGILL, sighandler);
 
-	puts("running undefined instruction ...");
+	atomic_puts("running undefined instruction ...");
 	__asm__ ("ud2");
-	assert("should have terminated!" && 0);
+	test_assert("should have terminated!" && 0);
 	return 0;
 }

--- a/src/test/sigprocmask.c
+++ b/src/test/sigprocmask.c
@@ -1,18 +1,15 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int signals_unblocked;
 
 static void handle_usr1(int sig) {
-	puts("Caught usr1");
+	atomic_puts("Caught usr1");
 	test_assert(signals_unblocked);
 }
 
@@ -36,6 +33,6 @@ int main(int argc, char *argv[]) {
 	signals_unblocked = 1;
 	syscall(SYS_sigprocmask, SIG_SETMASK, &oldmask, NULL);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/sigprocmask.run
+++ b/src/test/sigprocmask.run
@@ -1,2 +1,6 @@
 source `dirname $0`/util.sh sigprocmask "$@"
+
+# TODO: a sigreturn can flush the syscallbuf
+skip_if_syscall_buf
+
 compare_test EXIT-SUCCESS

--- a/src/test/sigrt.c
+++ b/src/test/sigrt.c
@@ -1,17 +1,14 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <signal.h>
+#include <stdlib.h>
 
 static int num_signals_caught;
 
 static void handle_sigrt(int sig) {
-	printf("Caught signal %d\n", sig);
-	fflush(stdout);
+	atomic_printf("Caught signal %d\n", sig);
 
 	++num_signals_caught;
 }
@@ -24,10 +21,10 @@ int main(int argc, char *argv[]) {
 		raise(i);
 	}
 
-	printf("caught %d signals; expected %d\n", num_signals_caught,
+	atomic_printf("caught %d signals; expected %d\n", num_signals_caught,
 	       SIGRTMAX - SIGRTMIN);
 	test_assert(1 + SIGRTMAX - SIGRTMIN == num_signals_caught);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/sigrt.run
+++ b/src/test/sigrt.run
@@ -1,2 +1,6 @@
 source `dirname $0`/util.sh sigrt "$@"
+
+# TODO: a sigreturn can flush the syscallbuf
+skip_if_syscall_buf
+
 compare_test EXIT-SUCCESS

--- a/src/test/sigtrap.c
+++ b/src/test/sigtrap.c
@@ -1,21 +1,18 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <unistd.h>
 
 static void handle_sigtrap(int sig) {
-	puts("caught SIGTRAP!");
-	fflush(stdout);
+	atomic_puts("caught SIGTRAP!");
 	_exit(0);
 }
 
 int main(int argc, char *argv[]) {
 	signal(SIGTRAP, handle_sigtrap);
 
-	puts("raising SIGTRAP ...");
-	fflush(stdout);
+	atomic_puts("raising SIGTRAP ...");
 
 	raise(SIGTRAP);
 

--- a/src/test/simple.c
+++ b/src/test/simple.c
@@ -1,8 +1,8 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <stdio.h>
+#include "rrutil.h"
 
 int main(int argc, char *argv[]) {
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/splice.c
+++ b/src/test/splice.c
@@ -2,11 +2,11 @@
 
 #define _GNU_SOURCE
 
+#include "rrutil.h"
+
 #include <fcntl.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define TOKEN "ABC"
 #define TOKEN_SIZE sizeof(TOKEN)
@@ -19,10 +19,10 @@ void verify_token(int fd) {
 
 	len = read(fd, buf, sizeof(buf));
 	if (len != TOKEN_SIZE || strcmp(buf, TOKEN)) {
-		puts("Internal error: FAILED: splice wrote the wrong data");
+		atomic_puts("Internal error: FAILED: splice wrote the wrong data");
 		exit(1);
 	}
-	puts("Got expected token " TOKEN);
+	atomic_puts("Got expected token " TOKEN);
 }
 
 int main() {
@@ -48,7 +48,7 @@ int main() {
 	 * before this. */
 	unlink(token_file);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 
 	return 0;
 }

--- a/src/test/step_thread.c
+++ b/src/test/step_thread.c
@@ -1,19 +1,19 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <pthread.h>
-#include <stdio.h>
+#include "rrutil.h"
+
 
 pthread_barrier_t bar;
 
 /* NB: these must *not* be macros so that debugger step-next works as
  * expected per the program source. */
 void A() {
-	puts("entered A");
+	atomic_puts("entered A");
 	pthread_barrier_wait(&bar);
 	pthread_barrier_wait(&bar);
 }
 void B() {
-	puts("entered B");
+	atomic_puts("entered B");
 	pthread_barrier_wait(&bar);
 	pthread_barrier_wait(&bar);
 }
@@ -28,12 +28,12 @@ void* threadB(void* unused) {
 }
 
 void C() {
-	puts("entered C");
+	atomic_puts("entered C");
 	pthread_barrier_wait(&bar);
 }
 
 void hit_barrier() {
-	puts("hit barrier");
+	atomic_puts("hit barrier");
 }
 
 int main() {

--- a/src/test/term_nonmain.c
+++ b/src/test/term_nonmain.c
@@ -1,24 +1,21 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <pthread.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 static void* kill_thread(void* dontcare) {
 	kill(getpid(), SIGTERM);
-	puts("FAILED: kill() didn't work");
+	atomic_puts("FAILED: kill() didn't work");
 	return NULL;		/* not reached */
 }
 
 int main(int argc, char *argv[]) {
 	pthread_t t;
 
-	setvbuf(stdout, NULL, _IONBF, 0);
-
 	pthread_create(&t, NULL, kill_thread, NULL);
 	pthread_join(t, NULL);
-	puts("FAILED: joined thread that should have died");
+	atomic_puts("FAILED: joined thread that should have died");
 	return 0;
 }

--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -1,13 +1,10 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
+#include "rrutil.h"
+
 #include <signal.h>
-#include <stdio.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <unistd.h>
-
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
 
 static int num_signals_caught;
 
@@ -20,7 +17,7 @@ static int tgkill(int tgid, int tid, int sig) {
 }
 
 static void sighandler(int sig) {
-	printf("Task %d got signal %d\n", gettid(), sig);
+	atomic_printf("Task %d got signal %d\n", gettid(), sig);
 	++num_signals_caught;
 }
 
@@ -32,6 +29,6 @@ int main(int argc, char *argv[]) {
 
 	test_assert(2 == num_signals_caught);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }

--- a/src/test/tgkill.run
+++ b/src/test/tgkill.run
@@ -1,2 +1,6 @@
 source `dirname $0`/util.sh tgkill "$@"
+
+# TODO: a sigreturn can flush the syscallbuf
+skip_if_syscall_buf
+
 compare_test EXIT-SUCCESS

--- a/src/test/threads.c
+++ b/src/test/threads.c
@@ -1,20 +1,18 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+#include "rrutil.h"
+
 #include <errno.h>
-#include <pthread.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
-#include <unistd.h>
 
 long int counter = 0;
 
 void catcher(int sig) {
-	printf("Signal caught, Counter is %ld\n", counter);
-	puts("EXIT-SUCCESS");
-	fflush(stdout);
+	atomic_printf("Signal caught, Counter is %ld\n", counter);
+	atomic_puts("EXIT-SUCCESS");
 	_exit(0);
 }
 

--- a/src/test/user_ignore_sig.c
+++ b/src/test/user_ignore_sig.c
@@ -1,11 +1,9 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "rrutil.h"
 
-#define test_assert(cond)  assert("FAILED if not: " && (cond))
+#include <signal.h>
+#include <stdlib.h>
 
 static void handle_usr1(int sig) {
 	test_assert("Shouldn't have caught SIGUSR1" && 0);
@@ -19,6 +17,6 @@ int main(int argc, char *argv[]) {
 	signal(SIGUSR1, handle_usr1);
 	raise(SIGUSR1);
 
-	puts("EXIT-SUCCESS");
+	atomic_puts("EXIT-SUCCESS");
 	return 0;
 }


### PR DESCRIPTION
The "atomic_print*" helpers aren't actually atomic, but they should do better than the mixed stdio/direct-write.  If intermittent failures become a problem again we should be able to make the helpers actually atomic.  Or more so.

Resolves #343.
