### PR TITLE
Test that prctl() fix worked correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(BASIC_TESTS
   mmap_private
   mmap_shared
   perf_event
+  prctl
   priority
   prw
   rdtsc

--- a/src/test/prctl.c
+++ b/src/test/prctl.c
@@ -1,0 +1,20 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#include <string.h>
+#include <sys/prctl.h>
+
+int main(int argc, char *argv[]) {
+	char setname[16] = "prctl-test";
+	char getname[16];
+
+	prctl(PR_SET_NAME, setname);
+
+	prctl(PR_GET_NAME, getname);
+	atomic_printf("set name `%s'; got name `%s'\n", setname, getname);
+	test_assert(!strcmp(getname, setname));
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/prctl.run
+++ b/src/test/prctl.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh prctl "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Fixed by #282; this is the missing `prctl` test to prove it.  Resolves #50.
