### PR TITLE
Give "modules" the ability to add a debug-log tag, and prepare common ones.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "Signal"
+
 #include "handle_signal.h"
 
 #include <assert.h>

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "ProcessSyscallRec"
+
 #include "rec_process_event.h"
 
 #define _GNU_SOURCE
@@ -692,7 +694,7 @@ void rec_process_syscall(struct task *t)
 	read_child_registers(tid, &regs);
 
 	debug("%d: processing syscall: %s(%d) -- time: %u  status: %x",
-	      tid, syscallname(syscall), get_global_time(),
+	      tid, syscallname(syscall), syscall, get_global_time(),
 	      t->exec_state);
 
 	if (t->desched_rec) {

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "Sched"
+
 #include "rec_sched.h"
 
 #include <assert.h>

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "Recorder"
+
 #define _GNU_SOURCE
 
 #include "recorder.h"

--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "gdb"
+
 /**
  * Much of this implementation is based on the documentation at
  *
@@ -212,7 +214,7 @@ static void write_flush(struct dbg_context* dbg)
 {
 	ssize_t write_index = 0;
 
-#ifdef DEBUGRR
+#ifdef DEBUGTAG
 	dbg->outbuf[dbg->outlen] = '\0';
 	debug("write_flush: '%s'", dbg->outbuf);
 #endif

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "ProcessSyscallRep"
+
 #include "rep_process_event.h"
 
 #define _GNU_SOURCE

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
+//#define DEBUGTAG "Replayer"
+
 #define _GNU_SOURCE
 
 #include "replayer.h"

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -13,14 +13,18 @@
 #include "task.h"
 
 /**
- * Useful debug macros.  Define DEBUGRR to enable DEBUG-level
- * messages.
+ * Useful debug macros.  Define DEBUGTAG with a "module name" to
+ * enable DEBUG-level messages.  For example,
+ *
+ *  #define DEBUGTAG "Sched"
+ *  ...
+ *  #include "dbg.h"
  */
 
-#ifdef DEBUGRR
+#ifdef DEBUGTAG
 # define debug(M, ...)							\
 	do {								\
-		fprintf(stderr, "[DEBUG] " M "\n", ##__VA_ARGS__);	\
+		fprintf(stderr, "[" DEBUGTAG "] " M "\n", ##__VA_ARGS__); \
 	} while(0)
 #else
 # define debug(M, ...)				\


### PR DESCRIPTION
Filed into the category of one-papercut-too-many.
