### PR TITLE
Remove task.exec_state now that it's subsumed by the event stack.

### DIFF
--- a/src/share/task.c
+++ b/src/share/task.c
@@ -21,6 +21,12 @@ struct sighandlers {
 	} handlers[_NSIG];
 };
 
+int task_may_be_blocked(struct task* t)
+{
+	return (t->ev && EV_SYSCALL == t->ev->type
+		&& PROCESSING_SYSCALL == t->ev->syscall.state);
+}
+
 static const char* event_type_name(int type)
 {
 	switch (type) {

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -276,7 +276,6 @@ struct task {
 	void *scratch_ptr;
 	size_t scratch_size;
 
-	int exec_state;
 	int event;
 	/* Record of the syscall that was interrupted by a desched
 	 * notification.  It's legal to reference this memory /while
@@ -342,6 +341,15 @@ struct task {
 
 	RB_ENTRY(task) entry;
 };
+
+/**
+ * Return nonzero if |t| may not be immediately runnable, i.e.,
+ * resuming execution and then |waitpid()|'ing may block for an
+ * unbounded amount of time.  When the task is in this state, the
+ * tracer must await a |waitpid()| notification that the task is no
+ * longer possibly-blocked before resuming its execution.
+ */
+int task_may_be_blocked(struct task* t);
 
 /**
  * Push/pop pseudo-sig events on the pending stack.  |no| is the enum


### PR DESCRIPTION
Working towards #288 / #293.
