### PR TITLE
Don't write back stomped syscallbuf data to callers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(BASIC_TESTS
   simple
   splice
   step_thread
+  switch_read
   term_nonmain
   tgkill
   threads

--- a/src/test/switch_read.c
+++ b/src/test/switch_read.c
@@ -1,0 +1,71 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <string.h>
+#include <syscall.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+static const char start_token = '!';
+static const char sentinel_token = ' ';
+
+static pthread_t reader;
+static pthread_barrier_t barrier;
+
+static int sockfds[2];
+
+static void* reader_thread(void* dontcare) {
+	int readsock = sockfds[1];
+	char c = sentinel_token;
+	struct timeval tv;
+
+	pthread_barrier_wait(&barrier);
+
+	atomic_puts("r: blocking on read ...");
+
+	test_assert(1 == read(readsock, &c, sizeof(c)));
+
+	gettimeofday(&tv, NULL);
+
+	atomic_printf("r: ... read '%c'\n", c);
+	test_assert(c == start_token);
+
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	char token = start_token;
+	struct timeval ts;
+
+	/* (Kick on the syscallbuf if it's enabled.) */
+	gettimeofday(&ts, NULL);
+
+	socketpair(AF_LOCAL, SOCK_STREAM, 0, sockfds);
+
+	pthread_barrier_init(&barrier, NULL, 2);
+	pthread_create(&reader, NULL, reader_thread, NULL);
+
+	pthread_barrier_wait(&barrier);
+
+	/* Force a blocked read() that's interrupted by a SIGUSR1,
+	 * which then itself blocks on read() and succeeds. */
+	atomic_puts("M: sleeping ...");
+	usleep(500000);
+	atomic_printf("M: finishing reader by writing '%c' to socket ...\n",
+		      token);
+	write(sockfds[0], &token, sizeof(token));
+	++token;
+
+	atomic_puts("M:   ... done");
+
+	pthread_join(reader, NULL);
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/switch_read.run
+++ b/src/test/switch_read.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh switch_read "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #365.
