### PR TITLE
Remove the now-redundant last_syscall field.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -229,13 +229,6 @@ static int try_handle_desched_event(struct task* t, const siginfo_t* si,
 	debug("  resuming (and probably switching out) blocked `%s'",
 	      syscallname(call));
 
-	if (SYS_restart_syscall == regs->orig_eax) {
-		/* If we'll be resuming this as a "restart syscall",
-		 * then note that the last started syscall was the one
-		 * interrupted by desched. */
-		t->last_syscall = call;
-	}
-
 	return call;
 }
 

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -297,12 +297,11 @@ struct task {
 	 * consideration). */
 	int flushed_syscallbuf;
 
-	int last_syscall;
-	/* Nonzero when the current syscall (saved to |last_syscall|
-	 * above) will restart.  When this is the case, we have to
-	 * advance to the syscall "entry" point using PTRACE_SYSCALL;
-	 * PTRACE_CONT has been observed to miss the syscall re-entry
-	 * point, for not-well-understand reasons. */
+	/* Nonzero when the current syscall may restart.  When this is
+	 * the case, we have to advance to the syscall "entry" point
+	 * using PTRACE_SYSCALL; PTRACE_CONT has been observed to miss
+	 * the syscall re-entry point, for not-well-understand
+	 * reasons. */
 	int will_restart;
 
 	/* The child's desched counter event fd number, and our local


### PR DESCRIPTION
Getting in the way of the work required for #363.
