### PR TITLE
Push a "placeholder" event to simplify code that deals with events.

### DIFF
--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -293,7 +293,7 @@ static int maybe_restart_syscall(struct task* t)
 		/* This is a special case because SYS_restart_syscall
 		 * *must* restart a syscall.  Otherwise we don't know
 		 * which syscall's exit we're about to record. */
-		assert_exec(t, (t->ev && EV_SYSCALL_INTERRUPTION == t->ev->type
+		assert_exec(t, (EV_SYSCALL_INTERRUPTION == t->ev->type
 				&& t->ev->syscall.is_restart),
 			    "Must have interrupted syscall to advance");
 
@@ -759,11 +759,11 @@ void record()
 				continue;
 			}
 		}
-		if (t->ev && EV_SYSCALL == t->ev->type) {
+		if (EV_SYSCALL == t->ev->type) {
 			syscall_state_changed(t, by_waitpid);
 			continue;
 		}
-		if (t->ev && EV_SIGNAL_DELIVERY == t->ev->type) {
+		if (EV_SIGNAL_DELIVERY == t->ev->type) {
 			int unstable = signal_state_changed(t, by_waitpid);
 			if (unstable) {
 				rec_sched_set_tasks_unstable();

--- a/src/replayer/rep_sched.c
+++ b/src/replayer/rep_sched.c
@@ -52,6 +52,7 @@ struct task* rep_sched_register_thread(pid_t my_tid, pid_t rec_tid)
 	t->tid = my_tid;
 	t->rec_tid = rec_tid;
 	t->child_mem_fd = sys_open_child_mem(my_tid);
+	push_placeholder_event(t);
 
 	//read_open_inst_dump(t);
 	num_threads++;

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -216,8 +216,11 @@ struct task {
 	/*refcounted*/struct sighandlers* sighandlers;
 
 	/* For convenience, the current top of |pending_events| if
-	 * there are any, or NULL.  Never reassign this pointer
-	 * directly; use the push_*()/pop_*() helpers below. */
+	 * there are any.  If there aren't any pending, the top of the
+	 * stack will be a placeholder event of type EV_NONE.
+	 *
+	 * Never reassign this pointer directly; use the
+	 * push_*()/pop_*() helpers below. */
 	struct event* ev;
 	/* The current stack of events being processed. */
 	FIXEDSTACK_DECL(, struct event, 16) pending_events;
@@ -352,6 +355,11 @@ struct task {
  * longer possibly-blocked before resuming its execution.
  */
 int task_may_be_blocked(struct task* t);
+
+/* (This function is an implementation detail that should go away in
+ * favor of a |task_init()| pseudo-constructor that initializes state
+ * shared across record and replay.) */
+void push_placeholder_event(struct task* t);
 
 /**
  * Push/pop pseudo-sig events on the pending stack.  |no| is the enum


### PR DESCRIPTION
Wrote one too many `if (t->ev...` checks while working on #363.  Small cleanup.
