### PR TITLE
Compute may-restart-ness from event stack, and fix terminology.

### DIFF
--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -794,12 +794,12 @@ void rep_process_syscall(struct task* t, struct rep_trace_step* step)
 	int state = trace->state;
 
 	if (STATE_SYSCALL_EXIT == state
-	    && SYSCALL_WILL_RESTART(trace->recorded_regs.eax)) {
-		/* When a syscall exits with a restart "error", it
-		 * will be restarted by the kernel with a restart
-		 * syscall (see below). The child process is oblivious
-		 * to this, so in the replay we need to jump directly
-		 * to the exit from the restart_syscall.
+	    && SYSCALL_MAY_RESTART(trace->recorded_regs.eax)) {
+		/* When a syscall exits with a restart "error", it may
+		 * be restarted by the kernel with a restart syscall
+		 * (see below). The child process is oblivious to
+		 * this, so in the replay we need to jump directly to
+		 * the exit from the restart_syscall.
 		 *
 		 * Strictly speaking, we don't need to set the
 		 * -ERESTART* value here, but if we don't the register

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -296,13 +296,6 @@ struct task {
 	 * consideration). */
 	int flushed_syscallbuf;
 
-	/* Nonzero when the current syscall may restart.  When this is
-	 * the case, we have to advance to the syscall "entry" point
-	 * using PTRACE_SYSCALL; PTRACE_CONT has been observed to miss
-	 * the syscall re-entry point, for not-well-understand
-	 * reasons. */
-	int will_restart;
-
 	/* The child's desched counter event fd number, and our local
 	 * dup. */
 	int desched_fd, desched_fd_child;

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -19,7 +19,7 @@ struct trace_frame;
 	((0xFF0000 & status) >> 16)
 #define SYSCALL_FAILED(eax) \
 	(-ERANGE <= (int)(eax) && (int)(eax) < 0)
-#define SYSCALL_WILL_RESTART(eax) \
+#define SYSCALL_MAY_RESTART(eax) \
 	(-ERESTART_RESTARTBLOCK == (eax) || -ERESTARTNOINTR == (eax))
 
 #ifndef PTRACE_EVENT_SECCOMP


### PR DESCRIPTION
Cleanup for #363.  An -ERESTART_\* return value doesn't mean the syscall _will_ restart, just that it _may_.
