### PR TITLE
Properly deliver signals at descheduled syscalls.

### DIFF
--- a/src/share/task.h
+++ b/src/share/task.h
@@ -318,6 +318,17 @@ struct task {
 	 * next available slow (taking |desched| into
 	 * consideration). */
 	int flushed_syscallbuf;
+	/* This bit is set when code wants to prevent the syscall
+	 * record buffer from being reset when it normally would be.
+	 * Currently, the desched'd syscall code uses this. */
+	int delay_syscallbuf_reset;
+	/* This bit is set when code wants the syscallbuf to be
+	 * "synthetically empty": even if the record counter is
+	 * nonzero, it should not be flushed.  Currently, the
+	 * desched'd syscall code uses this along with
+	 * |delay_syscallbuf_reset| above to keep the syscallbuf
+	 * intact during possibly many "reentrant" events. */
+	int delay_syscallbuf_flush;
 
 	/* The child's desched counter event fd number, and our local
 	 * dup. */

--- a/src/share/trace.c
+++ b/src/share/trace.c
@@ -449,7 +449,8 @@ static void record_inst_register_file(struct task *t)
 static void maybe_flush_syscallbuf(struct task *t)
 {
 	if (!t || !t->syscallbuf_hdr
-	    || 0 == t->syscallbuf_hdr->num_rec_bytes) {
+	    || 0 == t->syscallbuf_hdr->num_rec_bytes 
+	    || t->delay_syscallbuf_flush) {
 		/* No context, no syscallbuf, or no records.  Nothing
 		 * to do. */
 		return;
@@ -466,7 +467,9 @@ static void maybe_flush_syscallbuf(struct task *t)
 
 	/* Reset header. */
 	assert(!t->syscallbuf_hdr->abort_commit);
-	memset(t->syscallbuf_hdr, 0, sizeof(*t->syscallbuf_hdr));
+	if (!t->delay_syscallbuf_reset) {
+		t->syscallbuf_hdr->num_rec_bytes = 0;
+	}
 	t->flushed_syscallbuf = 1;
 }
 

--- a/src/test/intr_read_no_restart.c
+++ b/src/test/intr_read_no_restart.c
@@ -54,6 +54,7 @@ static void sighandler2(int sig) {
 
 static void* reader_thread(void* dontcare) {
 	struct sigaction act;
+	struct timeval ts;
 	int readsock = sockfds[1];
 	char c = sentinel_token;
 	int flags = 0;
@@ -71,6 +72,9 @@ static void* reader_thread(void* dontcare) {
 	sigaction(SIGUSR2, &act, NULL);
 
 	pthread_barrier_wait(&barrier);
+
+	/* (Put another record in the syscallbuf.) */
+	gettimeofday(&ts, NULL);
 
 	atomic_puts("r: blocking on read, awaiting signal ...");
 

--- a/src/test/intr_read_no_restart.run
+++ b/src/test/intr_read_no_restart.run
@@ -1,9 +1,2 @@
 source `dirname $0`/util.sh intr_read_no_restart "$@"
-
-# TODO: the signal interrupts a buffered syscall, and rr tries to
-# single-step the tracee to a safe point.  But because the tracee is
-# blocked on the read(), it can't single-step, and rr hangs on the
-# waitpid() following the stuck singlestep.
-skip_if_syscall_buf
-
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
We _deliver_ the signals properly now, but we don't (yet) handle _restarted_ descheduled syscalls.  This gets us probably 90% of the way to #363 though; the restart handling should be simple with this framework in place.
