### PR TITLE
Enable tests fixed by 0de9292d78a26d614007252e99af1b994a42abc8.

### DIFF
--- a/src/test/intr_futex_wait_restart.run
+++ b/src/test/intr_futex_wait_restart.run
@@ -1,9 +1,2 @@
 source `dirname $0`/util.sh intr_futex_wait_restart "$@"
-
-# TODO: the signal interrupts a buffered syscall, and rr tries to
-# single-step the tracee to a safe point.  But because the tracee is
-# blocked on the read(), it can't single-step, and rr hangs on the
-# waitpid() following the stuck singlestep.
-skip_if_syscall_buf
-
 compare_test EXIT-SUCCESS

--- a/src/test/intr_ptrace_decline.run
+++ b/src/test/intr_ptrace_decline.run
@@ -2,11 +2,4 @@
 RECORD_ARGS="-i10"
 
 source `dirname $0`/util.sh intr_ptrace_decline "$@"
-
-# TODO: the signal interrupts a buffered syscall, and rr tries to
-# single-step the tracee to a safe point.  But because the tracee is
-# blocked on the read(), it can't single-step, and rr hangs on the
-# waitpid() following the stuck singlestep.
-skip_if_syscall_buf
-
 compare_test EXIT-SUCCESS

--- a/src/test/intr_read_restart.run
+++ b/src/test/intr_read_restart.run
@@ -1,9 +1,2 @@
 source `dirname $0`/util.sh intr_read_restart "$@"
-
-# TODO: the signal interrupts a buffered syscall, and rr tries to
-# single-step the tracee to a safe point.  But because the tracee is
-# blocked on the read(), it can't single-step, and rr hangs on the
-# waitpid() following the stuck singlestep.
-skip_if_syscall_buf
-
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #363.

Darnit, 0de9292d78a26d614007252e99af1b994a42abc8 included the cherry-on-top tiny patch that fixed the rest of the bugs

<pre>
diff --git a/src/recorder/handle_signal.c b/src/recorder/handle_signal.c
index f8e1d10..dad9c0c 100644
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -243,6 +243,12 @@ static int try_handle_desched_event(struct task* t, const siginfo_t* si,
     * we've unblocked the reset. */
    t->delay_syscallbuf_flush = 1;
 
+   /* The descheduled syscall was interrupted by a signal, like
+    * all other may-restart syscalls, with the exception that
+    * this one has already been restarted (which we'll detect
+    * back in the main loop). */
+   push_syscall_interruption(t, call, regs);
+
    debug("  resuming (and probably switching out) blocked `%s'",
          syscallname(call));
 </pre>
