### PR TITLE
Track what linux calls "thread groups".

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -180,7 +180,7 @@ static void start(int argc, char* argv[], char** envp)
 			init_libpfm();
 
 			/* register thread at the scheduler and start the HPC */
-			rec_sched_register_thread(0, pid, COPY_SIGHANDLERS);
+			rec_sched_register_thread(0, pid, DEFAULT_COPY);
 
 			/* perform the action recording */
 			log_info("Start recording...");


### PR DESCRIPTION
Hoped we could avoid doing this, but seems to be needed for #386.  Luckily, pretty simple though.
