### PR TITLE
Record unstable tasks exiting using a new UNSTABLE_EXIT event.

### DIFF
--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -164,7 +164,6 @@ struct task* rec_sched_get_active_thread(struct task* t, int* by_waitpid)
 
 		assert(next_t->unstable || task_may_be_blocked(next_t));
 		next_t->status = status;
-		next_t->unstable = 0;
 		*by_waitpid = 1;
 	}
 

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -191,8 +191,10 @@ static void handle_ptrace_event(struct task** tp)
 	}
 
 	case PTRACE_EVENT_EXIT:
-		t->event = USR_EXIT;
-		push_pseudosig(t, EUSR_EXIT, HAS_EXEC_INFO);
+		t->event = t->unstable ? USR_UNSTABLE_EXIT : USR_EXIT;
+		push_pseudosig(t,
+			       t->unstable ? EUSR_UNSTABLE_EXIT : EUSR_EXIT,
+			       HAS_EXEC_INFO);
 		record_event(t);
 		pop_pseudosig(t);
 

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1349,6 +1349,9 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 		step.action = TSTEP_RETIRE;
 		break;
 	}
+	case USR_UNSTABLE_EXIT:
+		t->unstable = 1;
+		/* fall through */
 	case USR_EXIT:
 		rep_sched_deregister_thread(&t);
 		/* Early-return because |t| is gone now. */

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -100,6 +100,7 @@ struct event {
 			       EUSR_SYSCALLBUF_FLUSH,
 			       EUSR_SYSCALLBUF_ABORT_COMMIT,
 			       EUSR_SYSCALLBUF_RESET,
+			       EUSR_UNSTABLE_EXIT,
 			} no;
 			/* When replaying a pseudosignal is expected
 			 * to leave the tracee in the same execution

--- a/src/share/trace.c
+++ b/src/share/trace.c
@@ -147,6 +147,7 @@ static int encode_event(const struct event* ev, int* state)
 			TRANSLATE(USR_SYSCALLBUF_FLUSH);
 			TRANSLATE(USR_SYSCALLBUF_ABORT_COMMIT);
 			TRANSLATE(USR_SYSCALLBUF_RESET);
+			TRANSLATE(USR_UNSTABLE_EXIT);
 		default:
 			fatal("Unknown pseudosig %d", ev->pseudosig.no);
 #undef TRANSLATE

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -33,6 +33,10 @@ enum {
 	USR_SYSCALLBUF_RESET = -1015,
 	USR_ARM_DESCHED,
 	USR_DISARM_DESCHED,
+	/* Like USR_EXIT, but recorded when the task is in an
+	 * "unstable" state in which we're not sure we can
+	 * synchronously wait for it to "really finish". */
+	USR_UNSTABLE_EXIT,
 	/* TODO: this is actually a pseudo-pseudosignal: it will never
 	 * appear in a trace, but is only used to communicate between
 	 * different parts of the recorder code that should be


### PR DESCRIPTION
And be more honest about the fact that we don't know good rules for re-stabilizing tasks.  (Doesn't seem to be needed yet.)
