### PR TITLE
Don't accidentally step over and actually execute a side-effect-y instruction when emulating sigreturn.

### DIFF
--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -1088,10 +1088,10 @@ void rep_process_syscall(struct task* t, struct rep_trace_step* step)
 	case SYS_rt_sigreturn:
 		if (state == STATE_SYSCALL_ENTRY) {
 			enter_syscall_emu(t, syscall);
+			finish_syscall_emu(t);
 		} else {
 			write_child_main_registers(t->tid,
 						   &trace->recorded_regs);
-			finish_syscall_emu(t);
 		}
 		break;
 

--- a/src/test/alarm.c
+++ b/src/test/alarm.c
@@ -14,7 +14,7 @@ void catcher(int signum , siginfo_t *siginfo_ptr, void *ucontext_ptr) {
 
 int main(int argc, char **argv) {
     struct sigaction sact;
-    int counter = 0;
+    int counter;
 
     sigemptyset(&sact.sa_mask);
     sact.sa_flags = 0;
@@ -23,11 +23,11 @@ int main(int argc, char **argv) {
 
     alarm(1);  /* timer will pop in 1 second */
 
-    for (counter=0; counter >= 0 && !stop; counter++)
+    for (counter = 0; counter >= 0 && !stop; counter++)
 	    if (counter % 100000 == 0)
 		    write(STDOUT_FILENO, ".", 1);
 
-    atomic_printf("\nSignal caught, Counter is %d\n", counter );
+    atomic_printf("\nSignal caught, Counter is %d\n", counter);
 
     return 0;
 }


### PR DESCRIPTION
Resolves #31.  Was surprisingly hard to get the sysemu dance right, although the patch is extremely simple.

Last of the VM intermittent failures, leaving only very rare #401 on bare metal.
