### PR TITLE
Enable the ADDR_COMPAT_LAYOUT bit to guard against differences in environment between record/replay.

### DIFF
--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -137,7 +137,8 @@ static void set_up_process()
 	if (0 > (orig_pers = personality(0xffffffff))) {
 		fatal("error getting personaity");
 	}
-	if (0 > personality(orig_pers | ADDR_NO_RANDOMIZE)) {
+	if (0 > personality(orig_pers | ADDR_NO_RANDOMIZE |
+			    ADDR_COMPAT_LAYOUT)) {
 		fatal("error disabling randomization");
 	}
 	if (0 > prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0)) {


### PR DESCRIPTION
Resolves #122.  Sorta ...
