### PR TITLE
Ignore the RESUME_FLAG bit when comparing eflags registers, because replay may interrupt at a debugger exception not seen during recording.

### DIFF
--- a/src/test/async_signal_syscalls.c
+++ b/src/test/async_signal_syscalls.c
@@ -16,15 +16,23 @@ static void handle_usr1(int sig) {
 	atomic_puts("caught usr1");
 }
 
-int main() {
+int main(int argc, char** argv) {
 	struct timespec ts;
 	struct timeval tv;
+	int num_its;
 	int i;
+
+	test_assert(argc == 2);
+	num_its = atoi(argv[1]);
+	test_assert(num_its > 0);
+
+	atomic_printf("Running %d iterations", num_its);
 
 	signal(SIGUSR1, handle_usr1);
 
-	/* XXX arbitrarily chosen to take ~3s on a fast machine */
-	for (i = 0; i < 1 << 17; ++i) {
+	/* Driver scripts choose the number of iterations based on
+	 * their needs. */
+	for (i = 0; i < 1 << num_its; ++i) {
 		/* The odds of the signal being caught in the library
 		 * implementing these syscalls is very high.  But even
 		 * if it's not caught there, this test will pass. */

--- a/src/test/async_signal_syscalls.run
+++ b/src/test/async_signal_syscalls.run
@@ -5,7 +5,8 @@ source `dirname $0`/util.sh $testname "$@"
 # syscalls in this test is impractical.
 skip_if_no_syscall_buf
 
-record $testname
+# 17 iterations is arbitrarily chosen to take ~3s on a fast machine
+record $testname 17
 
 # Because of issue #184, replay takes longer than practical.  So for
 # now we'll skip it and hope other tests exercise the relevant code

--- a/src/test/async_signal_syscalls_1000.run
+++ b/src/test/async_signal_syscalls_1000.run
@@ -1,0 +1,11 @@
+# Ensure that the test records some USR_SCHED interrupt events.
+timeslice=1000
+RECORD_ARGS="-c$timeslice"
+
+source `dirname $0`/util.sh async_signal_syscalls_$timeslice "$@"
+
+# 9 iterations is arbitrarily chosen to record and replay < 15s, both
+# with and without the syscallbuf, on a fast machine.
+record async_signal_syscalls 9
+replay
+check 'EXIT-SUCCESS'

--- a/src/test/deliver_async_signal_during_syscalls.run
+++ b/src/test/deliver_async_signal_during_syscalls.run
@@ -4,8 +4,9 @@ source `dirname $0`/util.sh $testname "$@"
 # See async_signal_syscalls.run for an explanation.
 skip_if_no_syscall_buf
 
-# SIGUSR1, wait 0.5s
-record_async_signal 10 0.5 async_signal_syscalls
+# SIGUSR1, wait 0.5s; 17 iterations is arbitrarily chosen to take ~3s
+# on a fast machine
+record_async_signal 10 0.5 async_signal_syscalls 17
 # Because of issue #184, replay takes longer than practical.  So for
 # now we'll skip it and hope other tests exercise the relevant code
 # well enough.

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -155,9 +155,9 @@ function record { exe=$1; exeargs=$2;
 #  record_async_signal <signal> <delay-secs> <test>
 #
 # Record $test, delivering $signal to it after $delay-secs.
-function record_async_signal { sig=$1; delay_secs=$2; exe=$3;
+function record_async_signal { sig=$1; delay_secs=$2; exe=$3; exeargs=$4;
     delay_kill $sig $delay_secs $exe-$nonce &
-    record $exe
+    record $exe $exeargs
     wait
 }
 


### PR DESCRIPTION
Resolves #411.
