### PR TITLE
Fix syscallbuf initialization.

### DIFF
--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -78,9 +78,6 @@ static void status_changed(struct task* t)
 {
 	read_child_registers(t->tid, &t->regs);
 	t->event = t->regs.orig_eax;
-	if (t->event == RRCALL_init_syscall_buffer) {
-		t->event = (-t->event | RRCALL_BIT);
-	}
 	handle_signal(t);
 }
 
@@ -431,13 +428,11 @@ static void syscall_state_changed(struct task* t, int by_waitpid)
 		}
 		retval = t->regs.eax;
 
-		assert_exec(t, (syscallno == t->event
-				|| (SYS_rrcall_init_syscall_buffer == syscallno
-				    && RRCALL_init_syscall_buffer == t->event)),
+		assert_exec(t, syscallno == t->event,
 			    "Event stack and current event must be in sync.");
 		assert_exec(t, (-ENOSYS != retval
 				|| (0 > syscallno
-				    || RRCALL_init_syscall_buffer == t->event
+				    || SYS_rrcall_init_syscall_buffer == t->event
 				    || SYS_clone == syscallno
 				    || SYS_exit_group == syscallno
 				    || SYS_exit == syscallno)),

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -745,7 +745,7 @@ static void process_init_syscall_buffer(struct task* t, int exec_state,
 	step->action = TSTEP_RETIRE;
 
 	/* Proceed to syscall exit so we can run our own syscalls. */
-	exit_syscall_emu(t, RRCALL_init_syscall_buffer, 0);
+	exit_syscall_emu(t, SYS_rrcall_init_syscall_buffer, 0);
 	rec_child_map_addr = (void*)t->trace.recorded_regs.eax;
 
 	/* We don't want the desched event fd during replay, because

--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -295,8 +295,8 @@ static void* rrcall_init_syscall_buffer(void* untraced_syscall_ip,
 					struct msghdr* msg, int* fdptr,
 					struct socketcall_args* args_vec)
 {
-	return (void*)syscall(RRCALL_init_syscall_buffer, untraced_syscall_ip,
-			      addr, msg, fdptr, args_vec);
+	return (void*)syscall(SYS_rrcall_init_syscall_buffer,
+			      untraced_syscall_ip, addr, msg, fdptr, args_vec);
 }
 
 /**

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -23,9 +23,15 @@
 #define SYSCALLBUF_BUFFER_SIZE (1 << 20)
 
 /* "Magic" (rr-implemented) syscall that we use to initialize the
- * syscallbuf. */
-#define RRCALL_init_syscall_buffer -42
-#define __NR_rrcall_init_syscall_buffer (42 | RRCALL_BIT)
+ * syscallbuf.
+ *
+ * NB: magic syscalls must be positive, because with at least linux
+ * 3.8.0 / eglibc 2.17, rr only gets a trap for the *entry* of invalid
+ * syscalls, not the exit.  rr can't handle that yet. */
+/* TODO: static_assert(LAST_SYSCALL < FIRST_RRCALL) */
+#define FIRST_RRCALL 400
+
+#define __NR_rrcall_init_syscall_buffer 442
 #define SYS_rrcall_init_syscall_buffer __NR_rrcall_init_syscall_buffer
 
 /**

--- a/src/share/trace.c
+++ b/src/share/trace.c
@@ -170,9 +170,6 @@ static int encode_event(const struct event* ev, int* state)
 
 		assert(ev->syscall.state != PROCESSING_SYSCALL);
 
-		if (RRCALL_init_syscall_buffer == event) {
-			event = (-event | RRCALL_BIT);
-		}
 		*state = (ev->syscall.state == ENTERING_SYSCALL) ?
 			 STATE_SYSCALL_ENTRY : STATE_SYSCALL_EXIT;
 		return event;

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -59,15 +59,6 @@ enum {
 	LAST_ASYNC_SIGNAL = -1,
 };
 
-enum {
-	/* "Magic" syscalls (traps initiated by rr code running in a
-	 * tracee) are negative numbers to distinguish them from real
-	 * syscalls.  However, to avoid colliding with the signal
-	 * "namespace" in the event encoding, they're recorded as
-	 * (-syscallno | RRCALL_BIT). */
-	RRCALL_BIT = 0x8000
-};
-
 /**
  * A trace_frame is one "trace event" from a complete trace.  During
  * recording, a trace_frame is recorded upon each significant event,


### PR DESCRIPTION
This includes two separate changes.  First, we switch to using
positive invalid syscall numbers for the magic "rrcalls".  rr doesn't
see traps for the exit of negative syscall numbers on (at least) linux
3.8.0 / eglibc 2.17, so it wasn't able to process the old negative
init-syscallbuf rrcall.

And second, we stop assuming that the members of the msghdr that rr
touches during syscallbuf init are word-aligned.
