### PR TITLE
Add support for creat syscall.

### DIFF
--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -773,6 +773,14 @@ void rec_process_syscall(struct task *t)
 	}
 
 	/**
+	 *  int creat(const char *pathname, mode_t mode);
+	 *
+	 * creat() is equivalent to open() with flags equal to
+	 * O_CREAT|O_WRONLY|O_TRUNC.
+	 */
+	SYS_REC0(creat)
+
+	/**
 	 * int dup2(int oldfd, int newfd)
 	 *
 	 * dup2()  makes newfd be the copy of oldfd, closing newfd first if necessary, but note the

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -821,10 +821,10 @@ void rep_process_syscall(struct task* t, struct rep_trace_step* step)
 	assert_exec(t, SYS_restart_syscall != syscall,
 		    "restart_syscall must have interruption record");
 
-	assert("Syscallno not in table, but possibly valid"
-	       && syscall < ALEN(syscall_table));
-	assert("Valid but unhandled syscallno"
-	       && rep_UNDEFINED != def->type);
+	assert_exec(t, syscall < ALEN(syscall_table),
+		    "%d not in syscall table, but possibly valid", syscall);
+	assert_exec(t, rep_UNDEFINED != def->type,
+		    "Valid but unhandled syscallno %d", syscall);
 
 	step->syscall.no = syscall;
 

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -130,6 +130,14 @@ SYSCALL_DEF(IRREGULAR, clone, -1)
 SYSCALL_DEF(EMU, close, 0)
 
 /**
+ *  int creat(const char *pathname, mode_t mode);
+ *
+ * creat() is equivalent to open() with flags equal to
+ * O_CREAT|O_WRONLY|O_TRUNC.
+ */
+SYSCALL_DEF(EMU, creat, 0)
+
+/**
  *  int dup(int oldfd)
  *
  * dup() uses the lowest-numbered unused descriptor for the new


### PR DESCRIPTION
Followup to #427; I must have forgotten to run the unit tests, because the test added there fails when there's no syscallbuf.  The syscallbuf code implements `creat` as a wrapper around `open`, but apparently libc uses the direct `creat` syscall for some reason.
