### PR TITLE
Add a basic test of {send,recv}msg.

### DIFF
--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -114,8 +114,6 @@ cd $workdir
 # buy me a lottery ticket.
 nonce=${workdir#/tmp/rr-test-$TESTNAME-}
 
-echo Using lib arg "'$LIB_ARG'"
-
 ##--------------------------------------------------
 ## Now we come to the helpers available to test runners.  This is the
 ## testing "API".


### PR DESCRIPTION
#428 will need some refactoring, don't want to break the basic support that's already there.
