### PR TITLE
Support the "C" vCont request, and translate signal numbers into gdb-ese.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ set(CUSTOM_TESTS
   break_sync_signal
   break_thread
   break_time_slice
+  cont_signal
   deliver_async_signal_during_syscalls
   get_thread_list
   read_bad_mem

--- a/src/test/alarm.c
+++ b/src/test/alarm.c
@@ -6,10 +6,10 @@
 #include <signal.h>
 #include <string.h>
 
-int stop = 0;
+int caught_sig = 0;
 
 void catcher(int signum , siginfo_t *siginfo_ptr, void *ucontext_ptr) {
-	stop = 1;
+	caught_sig = signum;
 }
 
 int main(int argc, char **argv) {
@@ -23,11 +23,12 @@ int main(int argc, char **argv) {
 
     alarm(1);  /* timer will pop in 1 second */
 
-    for (counter = 0; counter >= 0 && !stop; counter++)
+    for (counter = 0; counter >= 0 && !caught_sig; counter++)
 	    if (counter % 100000 == 0)
 		    write(STDOUT_FILENO, ".", 1);
 
-    atomic_printf("\nSignal caught, Counter is %d\n", counter);
+    atomic_printf("\nSignal %d caught, Counter is %d\n", caught_sig, counter);
+    test_assert(SIGALRM == caught_sig);
 
     return 0;
 }

--- a/src/test/alarm.run
+++ b/src/test/alarm.run
@@ -1,8 +1,7 @@
 source `dirname $0`/util.sh alarm "$@"
 
-# This test is disabled when the syscallbuf is enabled for the same
-# reason that deliver_async_signal_during_syscalls.run is disabled;
-# see the long comment there for an explanation.
+# TODO: this test is disabled because SIG_TIMESLICE and SIG_DESCHED
+# interfere with each other.
 skip_if_syscall_buf
 
 compare_test 'Signal caught'

--- a/src/test/cont_signal.py
+++ b/src/test/cont_signal.py
@@ -1,0 +1,9 @@
+from rrutil import *
+
+send_gdb('c\n')
+expect_gdb('Program received signal SIGUSR1')
+
+send_gdb('c\n')
+expect_gdb('exited normally')
+
+ok()

--- a/src/test/cont_signal.run
+++ b/src/test/cont_signal.run
@@ -1,0 +1,7 @@
+testname=cont_signal
+recorded_exe=async_usr1
+
+source `dirname $0`/util.sh $testname "$@"
+# SIGUSR1, wait 2.0s
+record_async_signal 10 2.0 $recorded_exe
+debug $recorded_exe $testname

--- a/src/test/sigrt.c
+++ b/src/test/sigrt.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	atomic_printf("caught %d signals; expected %d\n", num_signals_caught,
-	       SIGRTMAX - SIGRTMIN);
+	       1 + SIGRTMAX - SIGRTMIN);
 	test_assert(1 + SIGRTMAX - SIGRTMIN == num_signals_caught);
 
 	atomic_puts("EXIT-SUCCESS");


### PR DESCRIPTION
Resolves #423.
