### PR TITLE
We have to decrement the target rcb when we reset the counter.

### DIFF
--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -137,7 +137,7 @@ struct dbg_context* dbg_await_client_connection(const char* address, short port)
 	if (ret) {
 		fatal("Couldn't bind to server address");
 	}
-	fprintf(stderr, "(rr debug server listening on %s:%d)",
+	fprintf(stderr, "(rr debug server listening on %s:%d)\n",
 		!strcmp(address, "127.0.0.1") ? "" : address,
 		ntohs(dbg->addr.sin_port));
 	/* block until debugging client connects to us */

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -106,7 +106,7 @@ struct rep_trace_step {
 		int signo;
 
 		struct {
-			uint64_t rcb;
+			int64_t rcb;
 			/* XXX can be just $ip in "production". */
 			const struct user_regs_struct* regs;
 			int signo;


### PR DESCRIPTION
Resolves #437.

This may be the cause of some of the other overshoot bugs, fingers crossed.  Not terribly likely though.
