### PR TITLE
gdb may request selection of a dead thread, so check the target first.

### DIFF
--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -70,8 +70,10 @@ struct dbg_request {
 		DREQ_GET_STOP_REASON,
 		DREQ_GET_THREAD_LIST,
 
-		/* Is |target| alive? */
+		/* These use params.target. */
 		DREQ_GET_IS_THREAD_ALIVE,
+		DREQ_SET_CONTINUE_THREAD,
+		DREQ_SET_QUERY_THREAD,
 
 		/* These use params.mem. */
 		DREQ_GET_MEM,
@@ -168,6 +170,11 @@ void dbg_reply_get_current_thread(struct dbg_context* dbg,
  * |alive| is nonzero if the requested thread is alive, zero if dead.
  */
 void dbg_reply_get_is_thread_alive(struct dbg_context* dbg, int alive);
+
+/**
+ * |ok| is nonzero if req->target can be selected, zero otherwise.
+ */
+void dbg_reply_select_thread(struct dbg_context* dbg, int ok);
 
 /**
  * The first |len| bytes of the request were read into |mem|.  |len|

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -317,6 +317,10 @@ static struct dbg_request process_debugger_requests(struct dbg_context* dbg,
 		case DREQ_GET_IS_THREAD_ALIVE:
 			dbg_reply_get_is_thread_alive(dbg, !!target);
 			continue;
+		case DREQ_SET_CONTINUE_THREAD:
+		case DREQ_SET_QUERY_THREAD:
+			dbg_reply_select_thread(dbg, !!target);
+			continue;
 		case DREQ_GET_MEM: {
 			size_t len;
 			byte* mem = read_mem(target, req.mem.addr, req.mem.len,


### PR DESCRIPTION
Resolves #438.
