### PR TITLE
Copy non-system read-only files being mmap'd.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(BASIC_TESTS
   io
   link
   mmap_private
+  mmap_ro
   mmap_shared
   perf_event
   prctl

--- a/src/share/util.c
+++ b/src/share/util.c
@@ -1535,10 +1535,18 @@ int should_copy_mmap_region(const char* filename, struct stat* stat,
 		      filename);
 		return 0;
 	}
+	if (!(0222 & stat->st_mode)) {
+		/* We couldn't write the file because it's read only.
+		 * But it's not a root-owned file (therefore not a
+		 * system file), so it's likely that it could be
+		 * temporary.  Copy it. */
+		debug("  (copy for read-only, non-system file)");
+		return 1;
+	}
 	if (!can_write_file) {
 		/* mmap'ing another user's (non-system) files?  Highly
 		 * irregular ... */
-		fatal("Uhandled mmap %s(prot:%x%s); uid:%d mode:%o",
+		fatal("Unhandled mmap %s(prot:%x%s); uid:%d mode:%o",
 		      filename, prot, (flags & MAP_SHARED) ? ";SHARED" : "",
 		      stat->st_uid, stat->st_mode);
 	}

--- a/src/test/mmap_ro.c
+++ b/src/test/mmap_ro.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#define DUMMY_FILE "dummy.txt"
+
+int main(int argc, char *argv[]) {
+	size_t num_bytes = sysconf(_SC_PAGESIZE);
+	int fd = open(DUMMY_FILE, O_CREAT | O_EXCL | O_RDWR, 0600);
+	int one = 1;
+	int* rpage;
+
+	test_assert(fd >= 0);
+
+	test_assert(sizeof(one) == write(fd, &one, sizeof(one)));
+
+	test_assert(0 == fchmod(fd, 0400));
+
+	rpage = mmap(NULL, num_bytes, PROT_READ, MAP_SHARED, fd, 0);
+	test_assert(rpage != (void*)-1);
+
+	unlink(DUMMY_FILE);
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/mmap_ro.run
+++ b/src/test/mmap_ro.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh mmap_ro "$@"
+compare_test 'EXIT-SUCCESS'


### PR DESCRIPTION
Resolves #443.
