### PR TITLE
Stop messing with libc headers in tests.

### DIFF
--- a/src/test/abort_nonmain.c
+++ b/src/test/abort_nonmain.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
-#include <sys/types.h>
 
 static void* kill_thread(void* dontcare) {
 	atomic_puts("killing ...");

--- a/src/test/accept.c
+++ b/src/test/accept.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
 
 static void client(const struct sockaddr_un* addr) {
 	int clientfd;

--- a/src/test/alarm.c
+++ b/src/test/alarm.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <signal.h>
-#include <string.h>
 
 int caught_sig = 0;
 

--- a/src/test/args.c
+++ b/src/test/args.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <string.h>
 
 int main(int argc, char *argv[]) {
 	test_assert(6 == argc);

--- a/src/test/async_segv.c
+++ b/src/test/async_segv.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
 
 static void handle_segv(int sig) {
 	test_assert(SIGSEGV == sig);

--- a/src/test/async_signal_syscalls.c
+++ b/src/test/async_signal_syscalls.c
@@ -2,11 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
-#include <time.h>
 
 static sig_atomic_t caught_usr1;
 

--- a/src/test/async_usr1.c
+++ b/src/test/async_usr1.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
 
 static sig_atomic_t caught_usr1;
 

--- a/src/test/bad_ip.c
+++ b/src/test/bad_ip.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <string.h>
 
 static void sighandler(int sig, siginfo_t* si, void* utp) {
 	test_assert(SIGSEGV == sig && si->si_addr == (void*)0x42);

--- a/src/test/bad_syscall.c
+++ b/src/test/bad_syscall.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <syscall.h>
 
 int main(int argc, char *argv[]) {
 	int ret = syscall(-10);

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <sys/time.h>
 
 #define ALEN(_a) (sizeof(_a) / sizeof(_a[0]))
 

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -4,11 +4,6 @@
 
 #include "rrutil.h"
 
-#include <poll.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static int sockfds[2];

--- a/src/test/clock.c
+++ b/src/test/clock.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
-#include <time.h>
 
 static void breakpoint() {
 	int break_here = 1;

--- a/src/test/fadvise.c
+++ b/src/test/fadvise.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <syscall.h>
 
 int main(int argc, char *argv[]) {
 	/* There's not a (simple) way to meaningfully test fadvise,

--- a/src/test/fork_syscalls.c
+++ b/src/test/fork_syscalls.c
@@ -2,12 +2,6 @@
 
 #include "rrutil.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <time.h>
 
 static void syscalls(int num) {
 	struct timespec ts;

--- a/src/test/ignored_async_usr1.c
+++ b/src/test/ignored_async_usr1.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
 
 int main(int argc, char *argv[]) {
 	int dummy, i;

--- a/src/test/int3.c
+++ b/src/test/int3.c
@@ -7,7 +7,6 @@ static void breakpoint() {
 
 #include "rrutil.h"
 
-#include <signal.h>
 
 static void handle_sigtrap(int sig) {
 	atomic_puts("caught SIGTRAP!");

--- a/src/test/intr_futex_wait_restart.c
+++ b/src/test/intr_futex_wait_restart.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';

--- a/src/test/intr_poll.c
+++ b/src/test/intr_poll.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <stdlib.h>
 
 static int pipefds[2];
 static int poll_pipe(int timeout_ms) {

--- a/src/test/intr_ptrace_decline.c
+++ b/src/test/intr_ptrace_decline.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';

--- a/src/test/intr_read_no_restart.c
+++ b/src/test/intr_read_no_restart.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';

--- a/src/test/intr_read_restart.c
+++ b/src/test/intr_read_restart.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';

--- a/src/test/intr_sleep.c
+++ b/src/test/intr_sleep.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <time.h>
 
 static int interrupted_sleep() {
 	struct timespec ts = { .tv_sec = 2 };

--- a/src/test/intr_sleep_no_restart.c
+++ b/src/test/intr_sleep_no_restart.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static pthread_t reader;
 static pthread_barrier_t barrier;

--- a/src/test/link.c
+++ b/src/test/link.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <string.h>
 
 #define TOKEN "ABC"
 #define TOKEN_SIZE sizeof(TOKEN)

--- a/src/test/mmap_private.c
+++ b/src/test/mmap_private.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/types.h>
 
 static void breakpoint() {
 	int break_here = 1;

--- a/src/test/mmap_ro.c
+++ b/src/test/mmap_ro.c
@@ -2,11 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 #define DUMMY_FILE "dummy.txt"
 

--- a/src/test/mmap_shared.c
+++ b/src/test/mmap_shared.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <stdlib.h>
-#include <sys/mman.h>
 
 static int create_segment(size_t num_bytes) {
 	char filename[] = "/dev/shm/rr-test-XXXXXX";

--- a/src/test/perf_event.c
+++ b/src/test/perf_event.c
@@ -2,12 +2,6 @@
 
 #include "rrutil.h"
 
-#include <linux/perf_event.h>
-#include <sched.h>
-#include <stdint.h>
-#include <string.h>
-#include <sys/syscall.h>
-
 static int counter_fd;
 
 static int sys_perf_event_open(struct perf_event_attr *attr,

--- a/src/test/prctl.c
+++ b/src/test/prctl.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <string.h>
-#include <sys/prctl.h>
 
 int main(int argc, char *argv[]) {
 	char setname[16] = "prctl-test";

--- a/src/test/priority.c
+++ b/src/test/priority.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <sys/time.h>
-#include <sys/resource.h>
 
 int main() {
 	int prio1, prio2;

--- a/src/test/prw.c
+++ b/src/test/prw.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 int main(int argc, char *argv[]) {
 	int fd = open("prw.txt", O_CREAT | O_RDWR, 0600);

--- a/src/test/rdtsc.c
+++ b/src/test/rdtsc.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <inttypes.h>
-#include <stdint.h>
 
 static uint64_t rdtsc(void) {
 	uint32_t hi, lo;

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -4,9 +4,34 @@
 #define RRUTIL_H
 
 #include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <linux/perf_event.h>
+#include <poll.h>
 #include <pthread.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syscall.h>
+#include <sys/epoll.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/vfs.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <time.h>
 #include <unistd.h>
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))

--- a/src/test/segfault.c
+++ b/src/test/segfault.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
 
 static void sighandler(int sig) {
 	atomic_printf("caught signal %d, exiting\n", sig);

--- a/src/test/sigchld_interrupt_signal.c
+++ b/src/test/sigchld_interrupt_signal.c
@@ -2,11 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 int main(int argc, char *argv[]) {
 	pid_t c;

--- a/src/test/sigill.c
+++ b/src/test/sigill.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
 
 static void sighandler(int sig) {
 	atomic_printf("caught signal %d, exiting\n", sig);

--- a/src/test/sigprocmask.c
+++ b/src/test/sigprocmask.c
@@ -2,10 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
-#include <sys/syscall.h>
-
 static int signals_unblocked;
 
 static void handle_usr1(int sig) {

--- a/src/test/sigrt.c
+++ b/src/test/sigrt.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
 
 static int num_signals_caught;
 

--- a/src/test/sigtrap.c
+++ b/src/test/sigtrap.c
@@ -2,7 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
 
 static void handle_sigtrap(int sig) {
 	atomic_puts("caught SIGTRAP!");

--- a/src/test/splice.c
+++ b/src/test/splice.c
@@ -4,9 +4,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <string.h>
 
 #define TOKEN "ABC"
 #define TOKEN_SIZE sizeof(TOKEN)

--- a/src/test/statfs.c
+++ b/src/test/statfs.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <fcntl.h>
-#include <inttypes.h>
-#include <sys/vfs.h>
 
 #define DUMMY_FILENAME "foo.txt"
 

--- a/src/test/switch_read.c
+++ b/src/test/switch_read.c
@@ -2,15 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <poll.h>
-#include <signal.h>
-#include <string.h>
-#include <syscall.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 
 static const char start_token = '!';
 static const char sentinel_token = ' ';

--- a/src/test/tcgets.c
+++ b/src/test/tcgets.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <sys/ioctl.h>
-#include <termios.h>
 
 int main(int argc, char *argv[]) {
 	struct termios tc = { 0 };

--- a/src/test/term_nonmain.c
+++ b/src/test/term_nonmain.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <sys/types.h>
 
 static void waittermsig(int sig, const char* waiter)
 {

--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -2,9 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
 
 static int num_signals_caught;
 

--- a/src/test/threads.c
+++ b/src/test/threads.c
@@ -2,11 +2,6 @@
 
 #include "rrutil.h"
 
-#include <errno.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
 
 long int counter = 0;
 

--- a/src/test/user_ignore_sig.c
+++ b/src/test/user_ignore_sig.c
@@ -2,8 +2,6 @@
 
 #include "rrutil.h"
 
-#include <signal.h>
-#include <stdlib.h>
 
 static void handle_usr1(int sig) {
 	test_assert("Shouldn't have caught SIGUSR1" && 0);


### PR DESCRIPTION
Script-driven rewrite heading towards #447.

Annoyed me one time too many.  Waste of time dealing with these.
