### PR TITLE
Ensure that syscallbuf critical sections aren't accidentally interrupted.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -520,6 +520,7 @@ static int go_to_a_happy_place(struct task* t,
 		 * (critical section), so there's no chance here of
 		 * "skipping over" a syscall we should have
 		 * recorded. */
+		debug("  stepi out of syscallbuf ...");
 		sys_ptrace_singlestep(tid);
 		sys_waitpid(tid, &status);
 

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -222,8 +222,7 @@ static void handle_ptrace_event(struct task** tp)
 		break;
 
 	default:
-		log_err("Unknown ptrace event: %x -- bailing out", event);
-		sys_exit();
+		fatal("Unknown ptrace event %d", event);
 		break;
 	}
 }


### PR DESCRIPTION
Resolves #434.  \o/
