### PR TITLE
Make global_time and trace_file_lines_counter be the same thing.

### DIFF
--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1163,8 +1163,7 @@ static void assert_at_buffered_syscall(struct task* t,
 	void* ip = (void*)regs->eip;
 
 	assert_exec(t, SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(ip, t),
-		    "(trace line %d) Bad ip %p: should have been buffered-syscall ip",
-		    get_trace_file_lines_counter(), ip);
+		    "Bad ip %p: should have been buffered-syscall ip", ip);
 	assert_exec(t, regs->orig_eax == syscallno,
 		    "At %s; should have been at %s(%d)",
 		    syscallname(regs->orig_eax),
@@ -1357,7 +1356,7 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 	int stop_sig = 0;
 
 	debug("[line %d] %d: replaying %s; state %s",
-	      get_trace_file_lines_counter(), t->rec_tid,
+	      get_global_time(), t->rec_tid,
 	      strevent(event), statename(t->trace.state));
 	if (t->syscallbuf_hdr) {
 		debug("    (syscllbufsz:%u, abrtcmt:%u)",

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -52,11 +52,10 @@ inline static int should_log()
 			fprintf(stderr,					\
 				"[EMERGENCY] (%s:%d:%s: errno: %s) "	\
 				"(task %d at trace line %d)\n"		\
-				" -> Assertion `"#_cond "' failed to hold: "\
+				" -> Assertion `"#_cond "' failed to hold: " \
 				_msg "\n",				\
 				__FILE__, __LINE__, __FUNCTION__,	\
-				clean_errno(),				\
-				t->tid, get_trace_file_lines_counter(),	\
+				clean_errno(), t->tid, get_global_time(), \
 				##__VA_ARGS__);				\
 			log_pending_events(_t);				\
 			emergency_debug(_t);				\
@@ -72,9 +71,7 @@ inline static int should_log()
 			"(trace line %d)\n"				\
 			" -> " M "\n",					\
 			__FILE__, __LINE__, __FUNCTION__,		\
-			clean_errno(),					\
-			get_trace_file_lines_counter(),			\
-			##__VA_ARGS__);					\
+			clean_errno(), get_global_time(), ##__VA_ARGS__); \
 		abort();						\
 	} while (0)
 

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -155,6 +155,19 @@ void record_parent_data(struct task *t, size_t len, void *addr, void *buf);
  */
 void record_event(struct task* t);
 void record_mmapped_file_stats(struct mmapped_file *file);
+/**
+ * Return the current global time.  This is approximately the number
+ * of events that have been recorded or replayed.  It is exactly the
+ * line number within the first trace file (trace_dir/trace_0) of the
+ * event that was just recorded or is being replayed.
+ *
+ * Beware: if there are multiple trace files, this value doesn't
+ * directly identify a unique file:line, by itself.
+ *
+ * TODO: we should either stop creating multiple files, or use an
+ * interface like |const char* get_trace_file_coord()| that would
+ * return a string like "trace_0:457293".
+ */
 unsigned int get_global_time(void);
 unsigned int get_time(pid_t tid);
 void record_argv_envp(int argc, char* argv[], char* envp[]);
@@ -167,7 +180,6 @@ void rec_setup_trace_dir(int version);
 void init_environment(char* trace_path, int* argc, char** argv, char** envp);
 void read_next_trace(struct trace_frame *trace);
 void peek_next_trace(struct trace_frame *trace);
-int get_trace_file_lines_counter();
 void read_next_mmapped_file_stats(struct mmapped_file *file);
 void peek_next_mmapped_file_stats(struct mmapped_file *file);
 void rep_init_trace_files(void);


### PR DESCRIPTION
This was making #78 slightly more annoying to work with.
