### PR TITLE
Consolidate checksum code in shared helper iterator.

### DIFF
--- a/src/replayer/dbg_gdb.c
+++ b/src/replayer/dbg_gdb.c
@@ -119,7 +119,7 @@ struct dbg_context* dbg_await_client_connection(const char* address,
 		dbg->addr.sin_port = htons(port);
 		ret = bind(listen_fd,
 			   (struct sockaddr*)&dbg->addr, sizeof(dbg->addr));
-		if (ret && (EADDRINUSE == errno || EPERM == errno)) {
+		if (ret && (EADDRINUSE == errno || EACCES == errno)) {
 			continue;
 		}
 		if (ret != 0) {

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -96,7 +96,6 @@ long int str2li(const char* start, size_t max_size);
 void * str2x(const char* start, size_t max_size);
 void read_line(FILE* file, char* buf, int size, char* name);
 void add_scratch(void *ptr, int size);
-int overall_scratch_size();
 void add_protected_map(struct task *t, void *start);
 bool is_protected_map(struct task *t, void *start);
 void add_sig_handler(pid_t tid, unsigned int signum, struct sigaction * sa);


### PR DESCRIPTION
Heading towards #78.

This appears to be catching a real execution divergence somewhere in ld.  Pretty reliably reproducible, there's a bit that's set in the recorded checksum that's not set in the replay one.  We need one more debugging helper to make slogging through these kinds of bugs approach sanity ... the one I started writing about 4 hours ago before getting sidetracked :/.  But now a nap beckons.
