### PR TITLE
Handle un-readable tracee mmaps when checksumming, and fix silly logic bug.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -401,12 +401,16 @@ static int parse_common_args(int argc, char** argv, struct flags* flags)
 			return optind;
 		case 'c':
 			if (!strcmp("on-syscalls", optarg)) {
+				log_info("checksumming on syscall exit");
 				flags->checksum = CHECKSUM_SYSCALL;
 			} else if (!strcmp("on-all-events", optarg)) {
+				log_info("checksumming on all events");
 				flags->checksum = CHECKSUM_ALL;
 			} else {
 				flags->checksum = str2li(optarg,
 							 LI_COLUMN_SIZE);
+				log_info("checksumming on at event %d",
+					 flags->checksum);
 			}
 			break;
 		case 'd':

--- a/src/share/ipc.c
+++ b/src/share/ipc.c
@@ -54,7 +54,8 @@ static long read_child_word(pid_t tid, void *addr, int ptrace_op)
 	if (errno != 0) {
 		log_err("Read of word %p from child returned %ld; dumping map",
 			addr, tmp);
-
+		/* TODO: fix this function to take a |task*| param,
+		 * and use |print_process_mmap()|here.*/
 		char path[64];
 		FILE* file;
 		bzero(path, 64);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -133,6 +133,11 @@ void checksum_process_memory(struct task* t);
 void validate_process_memory(struct task* t);
 
 /**
+ * Cat the /proc/[t->tid]/maps file to stdout, line by line.
+ */
+void print_process_mmap(struct task* t);
+
+/**
  * Search for the segment containing |search_addr|, and if found copy
  * out the segment info to |info| and return nonzero.  Return zero if
  * not found.


### PR DESCRIPTION
Still heading towards #78.

This commit is just clearing the queue of "other fixes"; even the simplest gecko tests are too slow to run with checksumming.  But I have an idea ...
