### PR TITLE
Check rbc matches for all events, not just async signals.

### DIFF
--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -55,7 +55,7 @@ inline static int should_log()
 				" -> Assertion `"#_cond "' failed to hold: " \
 				_msg "\n",				\
 				__FILE__, __LINE__, __FUNCTION__,	\
-				clean_errno(), t->tid, get_global_time(), \
+				clean_errno(), _t->tid, get_global_time(), \
 				##__VA_ARGS__);				\
 			log_pending_events(_t);				\
 			emergency_debug(_t);				\


### PR DESCRIPTION
Debugging patch we hoped might catch something causing #416, but ended up not.  Did catch some places where we were (benignly) replaying events differently than they were recorded, which is confusing.  Very useful to have in.
