### PR TITLE
Ignore SIG_TIMESLICE when running to disarm-desched ioctl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(BASIC_TESTS
   statfs
   step_thread
   switch_read
+  syscallbuf_timeslice
   tcgets
   term_nonmain
   tgkill
@@ -153,6 +154,7 @@ set(CUSTOM_TESTS
   sanity
   signal_stop
   step1
+  syscallbuf_timeslice_250
 )
 
 foreach(test ${BASIC_TESTS})

--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -520,7 +520,8 @@ static int go_to_a_happy_place(struct task* t,
 		 * (critical section), so there's no chance here of
 		 * "skipping over" a syscall we should have
 		 * recorded. */
-		debug("  stepi out of syscallbuf ...");
+		debug("  stepi out of syscallbuf from %p ...",
+		      (void*)regs->eip);
 		sys_ptrace_singlestep(tid);
 		sys_waitpid(tid, &status);
 

--- a/src/test/syscallbuf_timeslice.c
+++ b/src/test/syscallbuf_timeslice.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char** argv) {
+	int fd;
+	char buf[1 << 12];
+	int i;
+
+	fd = open("/dev/zero", O_RDONLY);
+	for (i = 0; i < 1 << 8; ++i) {
+		read(fd, buf, sizeof(buf));
+	}
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/syscallbuf_timeslice.run
+++ b/src/test/syscallbuf_timeslice.run
@@ -1,0 +1,3 @@
+testname=syscallbuf_timeslice
+source `dirname $0`/util.sh $testname "$@"
+compare_test 'EXIT-SUCCESS'

--- a/src/test/syscallbuf_timeslice_250.run
+++ b/src/test/syscallbuf_timeslice_250.run
@@ -1,0 +1,8 @@
+testname=syscallbuf_timeslice
+timeslice=250
+RECORD_ARGS="-c$timeslice"
+
+source `dirname $0`/util.sh ${testname}_${timeslice} "$@"
+record $testname
+replay
+check 'EXIT-SUCCESS'


### PR DESCRIPTION
Resolves #492.  Makes #416 easier to reproduce.
