### PR TITLE
Don't checksum the mappings of libs we don't think will change.

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -532,12 +532,12 @@ static int go_to_a_happy_place(struct task* t,
 
 		if (!is_syscall && !is_trace_trap(&tmp_si)) {
 			if (HPC_TIME_SLICE_SIGNAL == tmp_si.si_signo) {
-				log_info("Ignoring SIG_TIMESLICE");
+				debug("  ignoring SIG_TIMESLICE");
 				continue;
 			}
 			if (HPC_TIME_SLICE_SIGNAL == si->si_signo) {
 				memcpy(si, &tmp_si, sizeof(*si));
-				log_info("Upgraded delivery of SIG_TIMESLICE to %s",
+				debug("  upgraded delivery of SIG_TIMESLICE to %s",
 					 signalname(si->si_signo));
 				handle_siginfo_regs(t, si, regs);
 				return -1;

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -2606,7 +2606,8 @@ void rec_process_syscall(struct task *t)
 
 		file.copied = should_copy_mmap_region(file.filename,
 						      &file.stat,
-						      prot, flags);
+						      prot, flags,
+						      WARN_DEFAULT);
 		if (file.copied) {
 			record_child_data(t, size, addr);
 		}

--- a/src/replayer/rep_process_event.c
+++ b/src/replayer/rep_process_event.c
@@ -569,7 +569,8 @@ static void* finish_direct_mmap(struct task* t,
 		log_warn("Metadata of %s changed: replay divergence likely, but continuing anyway ...",
 			 file->filename);
 	}
-	if (should_copy_mmap_region(file->filename, &metadata, prot, flags)) {
+	if (should_copy_mmap_region(file->filename, &metadata, prot, flags,
+				    WARN_DEFAULT)) {
 		log_warn("%s wasn't copied during recording, but now it should be?",
 			 file->filename);
 	}

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -50,10 +50,11 @@ struct mapped_segment_info {
 	/* Name of the segment, which isn't necessarily an fs entry
 	 * anywhere. */
 	char name[PATH_MAX];	/* technically PATH_MAX + "deleted",
-				 * but let's not go * there. */
+				 * but let's not go there. */
 	void* start_addr;
 	void* end_addr;
-	char flags[32];
+	int prot;
+	int flags;
 	int64_t file_offset;
 	int64_t inode;
 	/* You should probably not be using these. */
@@ -265,8 +266,10 @@ int is_syscall_restart(struct task* t, int syscallno,
  * get away/ with not copying the region.  That doesn't mean it's
  * necessarily safe to skip copying!
  */
+enum { DONT_WARN_SHARED_WRITEABLE = 0, WARN_DEFAULT };
 int should_copy_mmap_region(const char* filename, struct stat* stat,
-			    int prot, int flags);
+			    int prot, int flags,
+			    int warn_shared_writeable);
 
 /* XXX should this go in ipc.h? */
 


### PR DESCRIPTION
For #78.  This gets us about 10x faster.  Unfortunately we still need another 10x to be usable.  Adding this to `should_checksum()` pretty much does the trick

```
if (global_time % 10) {
  return 0;
}
```
