### PR TITLE
Ensure syscallbuf init leaves the stack in a consistent state, and ignor...

### DIFF
--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -603,6 +603,7 @@ static void init_scratch_memory(struct task *t)
 	file.end = t->scratch_ptr + scratch_size;
 	sprintf(file.filename,"scratch for thread %d",t->tid);
 	record_mmapped_file_stats(&file);
+	add_scratch(file.start, file.end - file.start);
 
 	orig_regs.eax = eax;
 	write_child_registers(t->tid,&orig_regs);


### PR DESCRIPTION
...e scratch regions when dumping process memory.

Resolves #499.  Goes without saying that this wasn't the cause of #416.
