### PR TITLE
Clean up buffers and fds on thread exit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ target_link_libraries(rr
   libdisasm.a
 )
 
+target_link_libraries(rrpreload
+  -ldl
+)
+
 install(TARGETS rr rrpreload
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
@@ -124,6 +128,7 @@ set(BASIC_TESTS
   tcgets
   term_nonmain
   tgkill
+  thread_cleanup
   threads
   tiocinq
   user_ignore_sig

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -3015,8 +3015,8 @@ void rec_process_syscall(struct task *t)
 	 */
 	SYS_REC0(writev)
 
-	case SYS_rrcall_init_syscall_buffer:
-		init_syscall_buffer(t, NULL, SHARE_DESCHED_EVENT_FD);
+	case SYS_rrcall_init_buffers:
+		init_buffers(t, NULL, SHARE_DESCHED_EVENT_FD);
 		break;
 
 	default:

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/queue.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -289,11 +290,11 @@ void rec_sched_deregister_thread(struct task** t_ptr)
 	num_active_threads--;
 	assert(num_active_threads >= 0);
 
-	/* delete all counter data */
-	cleanup_hpc(t);
+	destroy_hpc(t);
 
 	sys_close(t->child_mem_fd);
 	close(t->desched_fd);
+	munmap(t->syscallbuf_hdr, t->num_syscallbuf_bytes);
 
 	detach_and_reap(t);
 

--- a/src/recorder/recorder.c
+++ b/src/recorder/recorder.c
@@ -430,7 +430,7 @@ static void syscall_state_changed(struct task* t, int by_waitpid)
 			    "Event stack and current event must be in sync.");
 		assert_exec(t, (-ENOSYS != retval
 				|| (0 > syscallno
-				    || SYS_rrcall_init_syscall_buffer == t->event
+				    || SYS_rrcall_init_buffers == t->event
 				    || SYS_clone == syscallno
 				    || SYS_exit_group == syscallno
 				    || SYS_exit == syscallno)),

--- a/src/replayer/rep_sched.c
+++ b/src/replayer/rep_sched.c
@@ -122,12 +122,12 @@ void rep_sched_enumerate_tasks(pid_t** tids, size_t* len)
 	assert(i == num_threads);
 }
 
-void rep_sched_deregister_thread(struct task **t_ptr)
+void rep_sched_deregister_thread(struct task** t_ptr)
 {
-	struct task * t = *t_ptr;
+	struct task* t = *t_ptr;
+
 	destroy_hpc(t);
 
-	//sys_fclose(t->inst_dump);
 	sys_close(t->child_mem_fd);
 
 	remove_task(t);
@@ -136,7 +136,7 @@ void rep_sched_deregister_thread(struct task **t_ptr)
 
 	detach_and_reap(t);
 
-	sys_free((void**) t_ptr);
+	sys_free((void**)t_ptr);
 }
 
 int rep_sched_get_num_threads()

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1412,21 +1412,12 @@ SYSCALL_DEF(IRREGULAR, write, -1)
 SYSCALL_DEF(EMU, writev, 0)
 
 /**
- *  void* rrcall_init_syscall_buffer(void* untraced_syscall_ip,
- *                                   struct sockaddr_un* addr,
- *                                   struct msghdr* msg, int* fdptr,
- *                                   struct socketcall_args* args_vec);
+ *  void* rrcall_init_buffers(struct rrcall_init_buffers_params* args);
  *
  * Do what's necessary to map the shared syscall buffer region in the
- * caller's address space and return the mapped region.
- * |untraced_syscall_ip| lets rr know where our untraced syscalls will
- * originate from.  |addr| is the address of the control socket the
- * child expects to connect to.  |msg| is a pre-prepared IPC that can
- * be used to share fds; |fdptr| is a pointer to the control-message
- * data buffer where the fd number being shared will be stored.
- * |args_vec| provides the tracer with preallocated space to make
- * socketcall syscalls.
+ * caller's address space and return the mapped region.  |args| is an
+ * inout parameter that's documented in syscall_buffer.h.
  *
  * This is a "magic" syscall implemented by rr.
  */
-SYSCALL_DEF(IRREGULAR, rrcall_init_syscall_buffer, -1)
+SYSCALL_DEF(IRREGULAR, rrcall_init_buffers, -1)

--- a/src/share/hpc.c
+++ b/src/share/hpc.c
@@ -233,7 +233,7 @@ void stop_hpc(struct task* t)
 	stop_counter(t, &counters->rbc);
 }
 
-void cleanup_hpc(struct task* t)
+static void cleanup_hpc(struct task* t)
 {
 	struct hpc_context* counters = t->hpc;
 
@@ -272,6 +272,7 @@ void reset_hpc(struct task *t, uint64_t val)
 void destroy_hpc(struct task *t)
 {
 	struct hpc_context* counters = t->hpc;
+	cleanup_hpc(t);
 	sys_free((void**) &counters);
 }
 

--- a/src/share/hpc.h
+++ b/src/share/hpc.h
@@ -47,7 +47,6 @@ void init_hpc(struct task *t);
 void destroy_hpc(struct task *t);
 void start_hpc(struct task *t, uint64_t val);
 void stop_hpc(struct task *t);
-void cleanup_hpc(struct task* t);
 void reset_hpc(struct task *t, uint64_t val);
 void stop_rbc(struct task *t);
 int pending_rbc_down(struct hpc_context *counters);

--- a/src/share/syscall_buffer.h
+++ b/src/share/syscall_buffer.h
@@ -51,17 +51,20 @@
 /* TODO: static_assert(LAST_SYSCALL < FIRST_RRCALL) */
 #define FIRST_RRCALL 400
 
-#define __NR_rrcall_init_syscall_buffer 442
-#define SYS_rrcall_init_syscall_buffer __NR_rrcall_init_syscall_buffer
+#define __NR_rrcall_init_buffers 442
+#define SYS_rrcall_init_buffers __NR_rrcall_init_buffers
 
 /**
- * Packs up the inout parameters passed to
- * |rrcall_init_syscall_buffer()|.  We use this struct because there
- * are too many params to pass through registers on at least x86.
- * (It's also a little cleaner.)
+ * Packs up the inout parameters passed to |rrcall_init_buffers()|.
+ * We use this struct because there are too many params to pass
+ * through registers on at least x86.  (It's also a little cleaner.)
  */
-struct rrcall_init_syscall_buffer_params {
+struct rrcall_init_buffers_params {
 	/* "In" params. */
+	/* The syscallbuf lib's idea of whether buffering is enabled.
+	 * We let the syscallbuf code decide in order to more simply
+	 * replay the same decision that was recorded. */
+	int syscallbuf_enabled;
 	/* Lets rr know where our untraced syscalls will originate
 	 * from. */
 	void* untraced_syscall_ip;
@@ -78,6 +81,12 @@ struct rrcall_init_syscall_buffer_params {
 	struct socketcall_args* args_vec;
 
 	/* "Out" params. */
+	/* Returned pointer to and size of the scratch segment.  For
+	 * the purposes of this code, it doesn't matter what the
+	 * scratch region is, all we need to know about it is that it
+	 * must be unmapped at thread exit time. */
+	void* scratch_ptr;
+	size_t num_scratch_bytes;
 	/* Returned pointer to and size of the shared syscallbuf
 	 * segment. */
 	void* syscallbuf_ptr;

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -386,6 +386,7 @@ struct task {
 	void* syscallbuf_lib_end;
 	/* Points at rr's mapping of the (shared) syscall buffer. */
 	struct syscallbuf_hdr* syscallbuf_hdr;
+	size_t num_syscallbuf_bytes;
 	/* Points at the tracee's mapping of the buffer. */
 	void* syscallbuf_child;
 

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -363,18 +363,15 @@ void finish_remote_syscalls(struct task* t,
 	remote_syscall1(_c, _s, _no, 0)
 
 /**
- * Initialize the syscall buffer in |t|, i.e., implement
+ * Initialize tracee buffers in |t|, i.e., implement
  * RRCALL_init_syscall_buffer.  |t| must be at the point of *exit
  * from* the rrcall.  Its registers will be updated with the return
  * value from the rrcall, which is also returned from this call.
  * |map_hint| suggests where to map the region.
  *
  * Pass SHARE_DESCHED_EVENT_FD to additionally share that fd.
- *
- * XXX: this is a weird place to stick this helper
  */
 enum { SHARE_DESCHED_EVENT_FD = 1, DONT_SHARE_DESCHED_EVENT_FD = 0 };
-void* init_syscall_buffer(struct task* t, void* map_hint,
-			  int share_desched_fd);
+void* init_buffers(struct task* t, void* map_hint, int share_desched_fd);
 
 #endif /* UTIL_H_ */

--- a/src/test/thread_cleanup.c
+++ b/src/test/thread_cleanup.c
@@ -1,0 +1,24 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static void* thread(void* unused) {
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	int i;
+
+	/* Chosen so that |3MB * nthreads| exhausts a 32-bit address
+	 * space. */
+	for (i = 0; i < 1500; ++i) {
+		pthread_t t;
+		pthread_create(&t, NULL, thread, NULL);
+		pthread_join(t, NULL);
+	}
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/thread_cleanup.run
+++ b/src/test/thread_cleanup.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh thread_cleanup "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
This patch makes the rr preload library non-optional: we use it hook
pthread_create() and to register a thread cleanup function.  Each
thread keeps a record of buffers that have been mapped on its behalf,
and the desched fd if buffering is enabled, and at thread destruction
time, the cleanup function unmaps and closes those resources.

(rr will technically function without the preload library, but will
leak resources like sieve, as before this patch.)

This patch incidentally fixes a small memory leak in the recorder and
a more serious fd leak in the replayer, which the test for this bug
exposed.

We could really use some C++ up in here.

Resolves #500.
