### PR TITLE
Fix replay bug in fcntl(F_GETLK) operations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(BASIC_TESTS
   clock
   exit_group
   fadvise
+  flock
   fork_syscalls
   hello
   ignored_async_usr1

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1264,9 +1264,6 @@ void rec_process_syscall(struct task *t)
 		case F_GETLK64:
 		case F_SETLK64:
 		case F_SETLKW64:
-		case F_GETLK:
-		case F_SETLK:
-		case F_SETLKW:
 			record_child_data(t, sizeof(struct flock64),
 					  (void*)regs.edx);
 			break;

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1019,7 +1019,6 @@ static void assert_at_recorded_rcb(struct task* t)
 	assert_exec(t, !t->hpc->started || read_rbc(t->hpc) == t->trace.rbc,
 		    "rbc mismatch for event in synchronous signal delivery; expected %"PRId64", got %"PRId64,
 		    t->trace.rbc, read_rbc(t->hpc));
-
 }
 
 /**

--- a/src/test/flock.c
+++ b/src/test/flock.c
@@ -1,0 +1,117 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#define _GNU_SOURCE
+
+#include "rrutil.h"
+
+#define FILENAME "foo.txt"
+
+int main(int argc, char *argv[]) {
+	ssize_t pagesize = sysconf(_SC_PAGESIZE);
+	int fd;
+	int i;
+	int err;
+	pid_t parent_pid = getpid();
+	pid_t pid;
+	int status;
+
+	fd = open(FILENAME, O_CREAT | O_EXCL | O_RDWR, 0600);
+	test_assert(fd >= 0);
+
+	unlink(FILENAME);
+
+	atomic_printf("parent pid is %d\n", parent_pid);
+
+	/* Write a page's worth of data. */
+	for (i = 0; i < pagesize / sizeof(i); ++i) {
+		ssize_t nwritten = write(fd, &i, sizeof(i));
+		test_assert(nwritten == sizeof(i));
+	}
+
+	{
+		struct flock lock = { .l_type = F_RDLCK,
+				      .l_whence = SEEK_SET,
+				      .l_start = pagesize,
+				      .l_len = -pagesize / 2 };
+
+		atomic_printf("sizeof(flock) = %d\n", sizeof(lock));
+
+		/* It should currently be unlocked. */
+		err = fcntl(fd, F_GETLK, &lock);
+		test_assert(0 == err);
+
+		atomic_printf("before lock: type: %d, pid: %d\n",
+			      lock.l_type, lock.l_pid);
+		test_assert(F_UNLCK == lock.l_type);
+
+		lock.l_type = F_RDLCK;
+		fcntl(fd, F_SETLK, &lock);
+		test_assert(0 == err);
+
+		/* Make sure our lock "took". */
+		if (0 == (pid = fork())) {
+			lock.l_type = F_WRLCK;
+			err = fcntl(fd, F_GETLK, &lock);
+			test_assert(0 == err);
+
+			atomic_printf("  after lock: type: %d, pid: %d\n",
+				      lock.l_type, lock.l_pid);
+			test_assert(F_RDLCK == lock.l_type
+				    && pagesize / 2 == lock.l_start
+				    && pagesize / 2 == lock.l_len
+				    && parent_pid == lock.l_pid);
+			return 0;
+		} else {
+			waitpid(pid, &status, 0);
+			test_assert(WIFEXITED(status)
+				    && 0 == WEXITSTATUS(status));
+		}
+	}
+
+	{
+		struct flock64 lock = { .l_type = F_WRLCK,
+					.l_whence = SEEK_SET,
+					.l_start = 0, .l_len = pagesize };
+
+		atomic_printf("sizeof(flock64) = %d\n", sizeof(lock));
+
+		/* We should be able to take a write lock on the whole
+		 * file.  The kernel will upgrade the readlock. */
+		err = fcntl(fd, F_GETLK64, &lock);
+		test_assert(0 == err);
+
+		atomic_printf("before lock: type: %d, pid: %d\n",
+			      lock.l_type, lock.l_pid);
+		test_assert(F_UNLCK == lock.l_type);
+
+		lock.l_type = F_WRLCK;
+		fcntl(fd, F_SETLK64, &lock);
+		test_assert(0 == err);
+
+		/* Make sure our lock "took". */
+		if (0 == (pid = fork())) {
+			lock.l_type = F_RDLCK;
+			err = fcntl(fd, F_GETLK64, &lock);
+			test_assert(0 == err);
+
+			atomic_printf("  after lock: type: %d, pid: %d\n",
+				      lock.l_type, lock.l_pid);
+			test_assert(F_WRLCK == lock.l_type
+				    && 0 == lock.l_start
+				    && pagesize == lock.l_len
+				    && parent_pid == lock.l_pid);
+			return 0;
+		} else {
+			waitpid(pid, &status, 0);
+			test_assert(WIFEXITED(status)
+				    && 0 == WEXITSTATUS(status));
+		}
+
+		lock.l_type = F_UNLCK;
+		fcntl(fd, F_SETLK64, &lock);
+		test_assert(0 == err);
+	}
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/flock.run
+++ b/src/test/flock.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh flock "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
This should be the underlying cause of #511.  Unfortunately, because of the design of the kernel ABI, we can't buffer flock operations anymore under the current system :/.  Oh well.
