### PR TITLE
Clear thread-local 'buffer' pointer after we unmap the memory it points ...

### DIFF
--- a/src/share/syscall_buffer.c
+++ b/src/share/syscall_buffer.c
@@ -451,6 +451,7 @@ static void clean_up_task(void* data)
 		traced_munmap(cleanup->syscallbuf_ptr,
 			      cleanup->num_syscallbuf_bytes);
 		traced_close(cleanup->desched_counter_fd);
+		buffer = NULL;
 	}
 }
 


### PR DESCRIPTION
...to.
