### PR TITLE
Files on tmpfs should always be copied to the trace since they are, pres...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(BASIC_TESTS
   mmap_private
   mmap_ro
   mmap_shared
+  mmap_tmpfs
   perf_event
   prctl
   priority

--- a/src/test/mmap_tmpfs.c
+++ b/src/test/mmap_tmpfs.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#define TEST_FILENAME "foo.so"
+#define TOKEN "hello kitty"
+
+int main(int argc, char *argv[]) {
+	int fd = open(TEST_FILENAME, O_CREAT | O_EXCL | O_RDWR, 0700);
+	char* bytes;
+
+	write(fd, TOKEN, sizeof(TOKEN));
+	close(fd);
+
+	fd = open(TEST_FILENAME, O_RDONLY);
+	bytes = (char*)mmap(NULL, 4096, PROT_READ | PROT_EXEC, MAP_PRIVATE,
+			    fd, 0);
+	test_assert(bytes);
+	test_assert(!strcmp(bytes, TOKEN));
+	munmap(bytes, 4096);
+	close(fd);
+
+	unlink(TEST_FILENAME);
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/mmap_tmpfs.run
+++ b/src/test/mmap_tmpfs.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh mmap_tmpfs "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
...umably, temporary.
#538 v2.

Resolves #537.
