### PR TITLE
Use F_SET_OWNER_EX to ensure time-slice signals are only delivered to th...

### DIFF
--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1631,6 +1631,8 @@ void emergency_debug(struct task* t)
 {
 	struct dbg_context* dbg;
 
+	flush_trace_files();
+
 	if (probably_not_interactive()) {
 		errno = 0;
 		fatal("(session doesn't look interactive, aborting emergency debugging)");


### PR DESCRIPTION
...e owner task.

Resolves #543.
