### PR TITLE
Use exec*p() to launch tracees for convenience and fix *getxattr() suppo...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(CUSTOM_TESTS
   cont_signal
   dead_thread_target
   deliver_async_signal_during_syscalls
+  execp
   get_thread_list
   read_bad_mem
   sanity

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1517,6 +1517,33 @@ void rec_process_syscall(struct task *t)
 		 sizeof(struct timezone), (void*)regs.ecx)
 
 	/**
+	 *  ssize_t getxattr(const char *path, const char *name,
+	 *                   void *value, size_t size);
+	 *  ssize_t lgetxattr(const char *path, const char *name,
+	 *                    void *value, size_t size);
+	 *  ssize_t fgetxattr(int fd, const char *name,
+	 *                    void *value, size_t size);
+	 *
+	 * getxattr() retrieves the value of the extended attribute
+	 * identified by name and associated with the given path in
+	 * the file system. The length of the attribute value is
+	 * returned.
+	 */
+	case SYS_getxattr:
+	case SYS_lgetxattr:
+	case SYS_fgetxattr: {
+		ssize_t len = regs.eax;
+		void* value = (void*)regs.edx;
+
+		if (len > 0) {
+			record_child_data(t, len, value);
+		} else {
+			record_noop_data(t);
+		}
+		break;
+	}
+
+	/**
 	 * int inotify_rm_watch(int fd, uint32_t wd)
 	 *
 	 * inotify_rm_watch()  removes the watch associated with the watch descriptor wd from the
@@ -1775,36 +1802,6 @@ void rec_process_syscall(struct task *t)
 		 sizeof(uid_t), (void*)regs.ebx,
 		 sizeof(uid_t), (void*)regs.ecx,
 		 sizeof(uid_t), (void*)regs.edx)
-
-	/*
-	 * ssize_t lgetxattr(const char *path, const char *name, void *value, size_t size);
-	 *
- 	 * getxattr() retrieves the value of the extended attribute identified by name
- 	 * and associated with the given path in the file system.  The length of the
- 	 * attribute value is returned.
- 	 *
- 	 * lgetxattr() is identical to getxattr(), except in the case of a symbolic link,
- 	 * where the link itself is interrogated, not the file that it refers to.
- 	 *
- 	 * fgetxattr() is identical to getxattr(), only the open file referred to by fd
- 	 * (as returned by open(2)) is interrogated in place of path.
- 	 *
- 	 *
- 	 * On success, a positive number is returned indicating the size of the extended
- 	 * attribute value.  On failure, -1 is returned and errno is set appropriately.
- 	 *
- 	 * If the named attribute does not exist, or the process has no access to this
- 	 * attribute, errno is set to ENOATTR.
- 	 *
- 	 * If the size of the value buffer is too small to hold the result, errno is set
- 	 * to ERANGE.
- 	 *
- 	 * If extended attributes are not supported by the file system, or are disabled,
- 	 * errno is set to ENOTSUP.
- 	 *
-	 */
-	SYS_REC1(lgetxattr, regs.esi, (void*)regs.edx)
-
 
 	/*
 	 * int _llseek(unsigned int fd, unsigned long offset_high, unsigned long offset_low,

--- a/src/replayer/replayer.c
+++ b/src/replayer/replayer.c
@@ -1075,6 +1075,9 @@ static void emulate_signal_delivery(struct task* oldtask)
 
 static void assert_at_recorded_rcb(struct task* t, int event)
 {
+	if (!validate) {
+		return;
+	}
 	assert_exec(t, !t->hpc->started || read_rbc(t->hpc) == t->trace.rbc,
 		    "rbc mismatch for '%s'; expected %"PRId64", got %"PRId64,
 		    strevent(event), t->trace.rbc, read_rbc(t->hpc));
@@ -1571,7 +1574,7 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 	 * to reach the rcb we recorded at signal delivery.  So don't
 	 * reset the counter for buffer flushes.  (It doesn't matter
 	 * for non-async-signal types, which are deterministic.) */
-	switch (t->trace.stop_reason) {
+	switch (event) {
 	case USR_SYSCALLBUF_ABORT_COMMIT:
 	case USR_SYSCALLBUF_FLUSH:
 	case USR_SYSCALLBUF_RESET:

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -512,6 +512,22 @@ SYSCALL_DEF(EMU, gettimeofday, 2)
 SYSCALL_DEF(EMU, getuid32, 0)
 
 /**
+ *  ssize_t getxattr(const char *path, const char *name,
+ *                   void *value, size_t size);
+ *  ssize_t lgetxattr(const char *path, const char *name,
+ *                    void *value, size_t size);
+ *  ssize_t fgetxattr(int fd, const char *name,
+ *                    void *value, size_t size);
+ *
+ * getxattr() retrieves the value of the extended attribute identified
+ * by name and associated with the given path in the file system. The
+ * length of the attribute value is returned.
+ */
+SYSCALL_DEF(EMU, getxattr, 1)
+SYSCALL_DEF(EMU, lgetxattr, 1)
+SYSCALL_DEF(EMU, fgetxattr, 1)
+
+/**
  *  int inotify_add_watch(int fd, const char *pathname, uint32_t mask)
  *
  * inotify_add_watch() adds a new watch, or modifies an existing
@@ -570,22 +586,6 @@ SYSCALL_DEF(IRREGULAR, ipc, -1)
  * process group or process.
  */
 SYSCALL_DEF(EMU, kill, 0)
-
-/**
- *  ssize_t lgetxattr(const char *path, const char *name, void *value, size_t size);
- *
- * getxattr() retrieves the value of the extended attribute identified
- * by name and associated with the given path in the file system.  The
- * length of the attribute value is returned.
- *
- * lgetxattr() is identical to getxattr(), except in the case of a
- * symbolic link, where the link itself is interrogated, not the file
- * that it refers to.
- *
- * fgetxattr() is identical to getxattr(), only the open file referred
- * to by fd (as returned by open(2)) is interrogated in place of path.
- */
-SYSCALL_DEF(EMU, lgetxattr, 1)
 
 /**
  *  int link(const char *oldpath, const char *newpath);

--- a/src/share/sys.c
+++ b/src/share/sys.c
@@ -170,7 +170,7 @@ void sys_start_trace(char* executable, char** argv, char** envp)
 	/* signal the parent that the child is ready */
 	kill(getpid(), SIGSTOP);
 
-	execve(executable, argv, envp);
+	execvpe(executable, argv, envp);
 	fatal("Failed to exec %s", executable);
 }
 

--- a/src/test/execp.run
+++ b/src/test/execp.run
@@ -1,0 +1,7 @@
+# Ensure that the test records some USR_SCHED interrupt events.
+
+source `dirname $0`/util.sh execp "$@"
+
+just_record ls -la
+replay
+check '..'

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -145,9 +145,13 @@ function skip_if_syscall_buf {
     fi
 }
 
+function just_record { exe=$1; exeargs=$2;
+    rr -u record $LIB_ARG $RECORD_ARGS $exe $exeargs 1> record.out
+}
+
 function record { exe=$1; exeargs=$2;
     cp ${OBJDIR}/bin/$exe $exe-$nonce
-    rr -u record $LIB_ARG $RECORD_ARGS $exe-$nonce $exeargs 1> record.out
+    just_record ./$exe-$nonce "$exeargs"
 }
 
 #  record_async_signal <signal> <delay-secs> <test>


### PR DESCRIPTION
...rt.

Resolves #37.  Resolves #541.

Incidentally has rr handle failed exec()s, which happen with execp().  (libc blindly exec's until one sticks.)

Taking a break from 544 to band-aid this papercut.
