### PR TITLE
Implement Xfer:read:auxv so that gdb can walk out of the vdso.

### DIFF
--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -71,6 +71,7 @@ struct dbg_request {
 		DREQ_GET_THREAD_LIST,
 
 		/* These use params.target. */
+		DREQ_GET_AUXV,
 		DREQ_GET_IS_THREAD_ALIVE,
 		DREQ_SET_CONTINUE_THREAD,
 		DREQ_SET_QUERY_THREAD,
@@ -109,6 +110,15 @@ struct dbg_request {
 
 		dbg_register reg;
 	};
+};
+
+/**
+ * An item in a process's auxiliary vector, for example { AT_SYSINFO,
+ * 0xb7fff414 }.
+ */
+struct dbg_auxv_pair {
+	long key;
+	long value;
 };
 
 /**
@@ -174,6 +184,13 @@ void dbg_notify_stop(struct dbg_context* dbg, dbg_threadid_t which, int sig);
  */
 void dbg_reply_get_current_thread(struct dbg_context* dbg,
 				  dbg_threadid_t thread);
+
+/**
+ * Reply with the target thread's |auxv| containing |len| pairs, or
+ * |len| <= 0 if there was an error reading the auxiliary vector.
+ */
+void dbg_reply_get_auxv(struct dbg_context* dbg,
+			const struct dbg_auxv_pair* auxv, ssize_t len);
 
 /**
  * |alive| is nonzero if the requested thread is alive, zero if dead.

--- a/src/test/backtrace_syscall.py
+++ b/src/test/backtrace_syscall.py
@@ -1,0 +1,12 @@
+from rrutil import *
+
+send_gdb('b __kernel_vsyscall\n')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c\n')
+expect_gdb('Breakpoint 1')
+
+send_gdb('bt\n')
+expect_gdb(r'#0 [^_]*__kernel_vsyscall \(\)')
+
+ok()

--- a/src/test/backtrace_syscall.run
+++ b/src/test/backtrace_syscall.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh backtrace_syscall "$@"
+record simple
+debug simple backtrace_syscall

--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -12,7 +12,7 @@ expect_gdb('Breakpoint 1, hit_barrier')
 send_gdb('info threads\n')
 for i in xrange(NUM_THREADS + 1, 1, -1):
     # The threads are at the vdso, hence the '??' top frame.
-    expect_gdb(str(i) + r'\s+Thread[^?]+\?\? \(\)')
+    expect_gdb(str(i) + r'\s+Thread[^_]+__kernel_vsyscall \(\)')
 
 expect_gdb(r'1\s+Thread[^h]+hit_barrier \(\)')
 


### PR DESCRIPTION
Resolves #564.
