### PR TITLE
Ensure that registers are up-to-date after time-slice signals upgraded t...

### DIFF
--- a/src/recorder/handle_signal.c
+++ b/src/recorder/handle_signal.c
@@ -254,6 +254,14 @@ static int handle_desched_event(struct task* t, const siginfo_t* si,
 		 || HPC_TIME_SLICE_SIGNAL == sig
 		 || is_arm_desched_event_syscall(t, regs));
 
+	/* This code can be entered through various different paths.
+	 * Ensure they all end up with the most up-to-date register
+	 * contents on exit.
+	 *
+	 * TODO: centralize the PTRACE_CONT/et al. code and make it
+	 * responsible for keeping registers up to date. */
+	memcpy(&t->regs, regs, sizeof(t->regs));
+
 	if (is_disarm_desched_event_syscall(t, regs)) {
 		debug("  (at disarm-desched, so finished buffered syscall; resuming)");
 		return USR_NOOP;

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -4,11 +4,11 @@
 
 #include "rrutil.h"
 
-
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static int sockfds[2];
 
 static const int msg_magic = 0x1337beef;
+const ssize_t num_sockbuf_bytes = 1 << 20;
 /* TODO: rr doesn't know how to create scratch space for struct msghdr
  * yet, so it's forced to make the {send, recv}(m?)msg() functions
  * non-context-switchable.  This test would obviously deadlock in that
@@ -18,7 +18,7 @@ static pthread_barrier_t cheater_barrier;
 
 void* reader_thread(void* dontcare) {
 	char token = '!';
-	int readsock = sockfds[1];
+	int sock = sockfds[1];
 	struct timeval ts;
 	char c = '\0';
 
@@ -31,14 +31,14 @@ void* reader_thread(void* dontcare) {
 
 	atomic_puts("r: reading socket ...");
 	gettimeofday(&ts, NULL);
-	test_assert(1 == read(readsock, &c, sizeof(c)));
+	test_assert(1 == read(sock, &c, sizeof(c)));
 	atomic_printf("r:   ... read '%c'\n", c);
 	test_assert(c == token);
 	++token;
 
 	atomic_puts("r: recv'ing socket ...");
 	gettimeofday(&ts, NULL);
-	test_assert(1 == recv(readsock, &c, sizeof(c), 0));
+	test_assert(1 == recv(sock, &c, sizeof(c), 0));
 	atomic_printf("r:   ... recv'd '%c'\n", c);
 	test_assert(c == token);
 	++token;
@@ -55,7 +55,7 @@ void* reader_thread(void* dontcare) {
 		atomic_puts("r: recmsg'ing socket ...");
 
 		pthread_barrier_wait(&cheater_barrier);
-		test_assert(0 < recvmsg(readsock, &mmsg.msg_hdr, 0));
+		test_assert(0 < recvmsg(sock, &mmsg.msg_hdr, 0));
 		atomic_printf("r:   ... recvmsg'd 0x%x\n", magic);
 		test_assert(msg_magic == magic);
 
@@ -63,7 +63,7 @@ void* reader_thread(void* dontcare) {
 		atomic_puts("r: recmmsg'ing socket ...");
 
 		pthread_barrier_wait(&cheater_barrier);
-		test_assert(1 == recvmmsg(readsock, &mmsg, 1, 0, NULL));
+		test_assert(1 == recvmmsg(sock, &mmsg, 1, 0, NULL));
 		atomic_printf("r:   ... recvmmsg'd 0x%x (%u bytes)\n",
 			      magic, mmsg.msg_len);
 		test_assert(msg_magic == magic);
@@ -72,12 +72,12 @@ void* reader_thread(void* dontcare) {
 		struct pollfd pfd;
 
 		atomic_puts("r: polling socket ...");
-		pfd.fd = readsock;
+		pfd.fd = sock;
 		pfd.events = POLLIN;
 		gettimeofday(&ts, NULL);
 		poll(&pfd, 1, -1);
 		atomic_puts("r:   ... done, doing nonblocking read ...");
-		test_assert(1 == read(readsock, &c, sizeof(c)));
+		test_assert(1 == read(sock, &c, sizeof(c)));
 		atomic_printf("r:   ... read '%c'\n", c);
 		test_assert(c == token);
 		++token;
@@ -86,12 +86,12 @@ void* reader_thread(void* dontcare) {
 		struct pollfd pfd;
 
 		atomic_puts("r: polling socket ...");
-		pfd.fd = readsock;
+		pfd.fd = sock;
 		pfd.events = POLLIN;
 		gettimeofday(&ts, NULL);
 		ppoll(&pfd, 1, NULL, NULL);
 		atomic_puts("r:   ... done, doing nonblocking read ...");
-		test_assert(1 == read(readsock, &c, sizeof(c)));
+		test_assert(1 == read(sock, &c, sizeof(c)));
 		atomic_printf("r:   ... read '%c'\n", c);
 		test_assert(c == token);
 		++token;
@@ -103,19 +103,39 @@ void* reader_thread(void* dontcare) {
 		atomic_puts("r: epolling socket ...");
 		test_assert(0 <= (epfd = epoll_create(1/*num events*/)));
 		ev.events = EPOLLIN;
-		ev.data.fd = readsock;
+		ev.data.fd = sock;
 		gettimeofday(&ts, NULL);
 		test_assert(0 == epoll_ctl(epfd, EPOLL_CTL_ADD, ev.data.fd,
 					   &ev));
 		test_assert(1 == epoll_wait(epfd, &ev, 1, -1));
 		atomic_puts("r:   ... done, doing nonblocking read ...");
-		test_assert(readsock == ev.data.fd);
-		test_assert(1 == read(readsock, &c, sizeof(c)));
+		test_assert(sock == ev.data.fd);
+		test_assert(1 == read(sock, &c, sizeof(c)));
 		atomic_printf("r:   ... read '%c'\n", c);
 		test_assert(c == token);
 		++token;
 
 		close(epfd);
+	}
+	{
+		char* buf = (char*)malloc(num_sockbuf_bytes);
+		ssize_t nwritten = 0;
+
+		++token;
+		memset(buf, token, num_sockbuf_bytes);
+
+		atomic_printf("r: writing outbuf of size %d ...\n",
+			      num_sockbuf_bytes);
+		while (nwritten < num_sockbuf_bytes) {
+			ssize_t this_write =
+				write(sock, buf,
+				      num_sockbuf_bytes - nwritten);
+			atomic_printf("r:   wrote %d bytes this time\n",
+				      this_write);
+			nwritten += this_write;
+		}
+
+		free(buf);
 	}
 	/* Make the main thread wait on our join() */
 	atomic_puts("r: sleeping ...");
@@ -128,10 +148,13 @@ int main(int argc, char *argv[]) {
 	char token = '!';
 	struct timeval ts;
 	pthread_t reader;
+	int sock;
 
 	gettimeofday(&ts, NULL);
 
 	socketpair(AF_LOCAL, SOCK_STREAM, 0, sockfds);
+	sock = sockfds[0];
+
 	pthread_barrier_init(&cheater_barrier, NULL, 2);
 
 	pthread_mutex_lock(&lock);
@@ -149,7 +172,7 @@ int main(int argc, char *argv[]) {
 	atomic_puts("M: sleeping again ...");
 	usleep(500000);
 	atomic_printf("M: writing '%c' to socket ...\n", token);
-	write(sockfds[0], &token, sizeof(token));
+	write(sock, &token, sizeof(token));
 	++token;
 	atomic_puts("M:   ... done");
 
@@ -157,7 +180,7 @@ int main(int argc, char *argv[]) {
 	atomic_puts("M: sleeping again ...");
 	usleep(500000);
 	atomic_printf("M: sending '%c' to socket ...\n", token);
-	send(sockfds[0], &token, sizeof(token), 0);
+	send(sock, &token, sizeof(token), 0);
 	++token;
 	atomic_puts("M:   ... done");
 	{
@@ -175,7 +198,7 @@ int main(int argc, char *argv[]) {
 		usleep(500000);
 		atomic_printf("M: sendmsg'ing 0x%x to socket ...\n",
 			      msg_magic);
-		sendmsg(sockfds[0], &mmsg.msg_hdr, 0);
+		sendmsg(sock, &mmsg.msg_hdr, 0);
 		atomic_puts("M:   ... done");
 		pthread_barrier_wait(&cheater_barrier);
 
@@ -184,7 +207,7 @@ int main(int argc, char *argv[]) {
 		usleep(500000);
 		atomic_printf("M: sendmmsg'ing 0x%x to socket ...\n",
 			      msg_magic);
-		sendmmsg(sockfds[0], &mmsg, 1, 0);
+		sendmmsg(sock, &mmsg, 1, 0);
 		atomic_printf("M:   ... sent %u bytes\n", mmsg.msg_len);
 		pthread_barrier_wait(&cheater_barrier);
 	}
@@ -192,7 +215,7 @@ int main(int argc, char *argv[]) {
 	atomic_puts("M: sleeping again ...");
 	usleep(500000);
 	atomic_printf("M: writing '%c' to socket ...\n", token);
-	write(sockfds[0], &token, sizeof(token));
+	write(sock, &token, sizeof(token));
 	++token;
 	atomic_puts("M:   ... done");
 
@@ -200,7 +223,7 @@ int main(int argc, char *argv[]) {
 	atomic_puts("M: sleeping again ...");
 	usleep(500000);
 	atomic_printf("M: writing '%c' to socket ...\n", token);
-	write(sockfds[0], &token, sizeof(token));
+	write(sock, &token, sizeof(token));
 	++token;
 	atomic_puts("M:   ... done");
 
@@ -208,8 +231,49 @@ int main(int argc, char *argv[]) {
 	atomic_puts("M: sleeping again ...");
 	usleep(500000);
 	atomic_printf("M: writing '%c' to socket ...\n", token);
-	write(sockfds[0], &token, sizeof(token));
+	write(sock, &token, sizeof(token));
 	++token;
+	atomic_puts("M:   ... done");
+
+	/* Force a wait on write() */
+	atomic_puts("M: sleeping again ...");
+	usleep(500000);
+	atomic_printf("M: reading socket ...\n");
+	++token;
+	{
+		char* buf = (char*)malloc(num_sockbuf_bytes);
+		ssize_t nread = 0;
+
+		while (nread < num_sockbuf_bytes) {
+			char* this_buf = buf + nread;
+			ssize_t this_read = read(sock, this_buf,
+						 num_sockbuf_bytes - nread);
+			int i;
+
+			atomic_printf("M:   read %d bytes this time,\n",
+				      this_read);
+			test_assert(this_read > 0);
+			/* XXX: we would like to assert that the
+			 * written data was read in more than one
+			 * chunk, which should imply that at least one
+			 * write() from the other thread blocked, but
+			 * it's possible for multiple write()s to
+			 * complete and fill the read buffer here
+			 * before the reader returns. */
+			/*test_assert(this_read < num_sockbuf_bytes);*/
+
+			for (i = nread; i < nread + this_read; ++i) {
+				if (token != buf[i]) {
+					atomic_printf("M:   byte %d should be '%c', but is '%c'\n",
+						      i, token, buf[i]);
+				}
+			}
+			nread += this_read;
+			atomic_printf("M:      %d total so far\n", nread);
+		}
+
+		free(buf);
+	}
 	atomic_puts("M:   ... done");
 
 	pthread_join(reader, NULL);


### PR DESCRIPTION
...o desched, and handle desched'd syscalls that don't use scratch space.

Resolves #572.
