### PR TITLE
Support the truncate64 syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(BASIC_TESTS
   thread_stress
   threads
   tiocinq
+  truncate
   uname
   user_ignore_sig
 )

--- a/src/recorder/rec_process_event.c
+++ b/src/recorder/rec_process_event.c
@@ -1447,6 +1447,7 @@ void rec_process_syscall(struct task *t)
 	SYS_REC0(ftruncate64)
 	SYS_REC0(ftruncate)
 	SYS_REC0(truncate)
+	SYS_REC0(truncate64)
 
 	/**
 	 * int fsync(int fd)

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -345,6 +345,7 @@ SYSCALL_DEF(EMU, fdatasync, 0)
 SYSCALL_DEF(EMU, ftruncate64, 0)
 SYSCALL_DEF(EMU, ftruncate, 0)
 SYSCALL_DEF(EMU, truncate, 0)
+SYSCALL_DEF(EMU, truncate64, 0)
 
 /**
  *  int futex(int *uaddr, int op, int val, const struct timespec *timeout, int *uaddr2, int val3);

--- a/src/test/truncate.c
+++ b/src/test/truncate.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#define _FILE_OFFSET_BITS 64
+
+#include "rrutil.h"
+
+#define TEST_FILE "foo.txt"
+
+ssize_t get_file_size(const char* filename) {
+	struct stat st;
+	test_assert(0 == stat(filename, &st));
+	return st.st_size;
+}
+
+int main(int argc, char *argv[]) {
+	int fd;
+	ssize_t size;
+
+	fd = open(TEST_FILE, O_CREAT | O_EXCL | O_RDWR, 0600);
+	test_assert(0 <= fd);
+
+	size = get_file_size(TEST_FILE);
+	atomic_printf("initial file size: %d\n", size);
+	test_assert(0 == size);
+
+	truncate(TEST_FILE, 4096);
+	size = get_file_size(TEST_FILE);
+	atomic_printf("after truncate(4096): %d\n", size);
+	test_assert(4096 == size);
+
+	ftruncate(fd, 8192);
+	size = get_file_size(TEST_FILE);
+	atomic_printf("after truncate(8192): %d\n", size);
+	test_assert(8192 == size);
+
+	unlink(TEST_FILE);
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/truncate.run
+++ b/src/test/truncate.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh truncate "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #578.
