### PR TITLE
Revise the trace log format: dump raw structs instead of ASCII-ifying.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -149,8 +149,7 @@ static void start(int argc, char* argv[], char** envp)
 		copy_executable(argv[0]);
 		copy_argv(argc, argv);
 		copy_envp(envp);
-		/* create directory for trace files */
-		rec_setup_trace_dir(0);
+		rec_setup_trace_dir();
 
 		pid = sys_fork();
 

--- a/src/recorder/rec_sched.c
+++ b/src/recorder/rec_sched.c
@@ -208,7 +208,7 @@ void rec_sched_register_thread(pid_t parent, pid_t child, int flags)
 
 	assert(child > 0 && child < MAX_TID);
 
-	t->status = 0;
+	t->thread_time = 1;
 	t->rec_tid = t->tid = child;
 	t->child_mem_fd = sys_open_child_mem(child);
 	push_placeholder_event(t);

--- a/src/replayer/rep_sched.c
+++ b/src/replayer/rep_sched.c
@@ -54,7 +54,6 @@ struct task* rep_sched_register_thread(pid_t my_tid, pid_t rec_tid)
 	t->child_mem_fd = sys_open_child_mem(my_tid);
 	push_placeholder_event(t);
 
-	//read_open_inst_dump(t);
 	num_threads++;
 
 	/* initializer replay counters */

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -238,6 +238,10 @@ struct event {
 struct task {
 	/* State only used during recording. */
 
+	/* The running count of events that have been recorded for
+	 * this task.  Starts at "1" to match with "global_time". */
+	int thread_time;
+
 	/* The task group this belongs to. */
 	/*refcounted*/struct task_group* task_group;
 


### PR DESCRIPTION
What motivated this change was the need to extend the current
trace_frame to store extra data.  There were several rather delicate
touch points for that kind of change.  The code that reads and writes
the new format doesn't care what fields are in the structs (only
debugging logging cares, but logging new fields is opt-in).
Compactness wasn't the motivation for this, but the trace files should
be around 2x smaller or so.

The next commit will introduce an 'rr dump' command to log what used
to be directly readable in the trace_i/trace_j files, except with
creature comforts like reading aids and filtering.  This is required
for debugging.

I've been looking for an excuse to do this for a long time ... the trace.c code wasn't my favorite in the tree ;).
