### PR TITLE
Compile rr with g++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(rr_VERSION_MINOR 2pre)
 set(rr_VERSION_PATCH 0)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -O0 -g3 -Wall -Werror -m32 -Wstrict-prototypes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O0 -g3 -Wall -Werror -m32")
 
 # Disable PIC.
 string(REGEX REPLACE "-fPIC" ""
@@ -25,27 +26,27 @@ string(REGEX REPLACE "-fPIC" ""
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
 add_library(rrpreload
-  src/share/syscall_buffer.c
+  src/preload/preload.c
 )
 
 add_executable(rr
-  src/main.c
-  src/recorder/handle_ioctl.c
-  src/recorder/handle_signal.c
-  src/recorder/rec_process_event.c
-  src/recorder/rec_sched.c
-  src/recorder/recorder.c
-  src/replayer/dbg_gdb.c
-  src/replayer/rep_process_event.c
-  src/replayer/rep_sched.c
-  src/replayer/replayer.c
-  src/share/hpc.c
-  src/share/ipc.c
-  src/share/shmem.c
-  src/share/sys.c
-  src/share/task.c
-  src/share/trace.c
-  src/share/util.c
+  src/main.cc
+  src/recorder/handle_ioctl.cc
+  src/recorder/handle_signal.cc
+  src/recorder/rec_process_event.cc
+  src/recorder/rec_sched.cc
+  src/recorder/recorder.cc
+  src/replayer/dbg_gdb.cc
+  src/replayer/rep_process_event.cc
+  src/replayer/rep_sched.cc
+  src/replayer/replayer.cc
+  src/share/hpc.cc
+  src/share/ipc.cc
+  src/share/shmem.cc
+  src/share/sys.cc
+  src/share/task.cc
+  src/share/trace.cc
+  src/share/util.cc
 )
 
 # TODO remove this when we can manage pfm and disasm dependencies

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -96,8 +96,6 @@ struct task_cleanup_data {
 	int desched_counter_fd;
 };
 
-typedef unsigned char byte;
-
 /* Nonzero when syscall buffering is enabled. */
 static int buffer_enabled;
 

--- a/src/preload/seccomp-bpf.h
+++ b/src/preload/seccomp-bpf.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 /*
  * seccomp example for x86 (32-bit and 64-bit) with BPF macros

--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -3,6 +3,10 @@
 #ifndef SYSCALL_BUFFER_H_
 #define SYSCALL_BUFFER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef _GNU_SOURCE
 # define _GNU_SOURCE 1
 #endif
@@ -54,6 +58,8 @@
 #define __NR_rrcall_init_buffers 442
 #define SYS_rrcall_init_buffers __NR_rrcall_init_buffers
 
+typedef unsigned char byte;
+
 /**
  * Packs up the inout parameters passed to |rrcall_init_buffers()|.
  * We use this struct because there are too many params to pass
@@ -67,7 +73,7 @@ struct rrcall_init_buffers_params {
 	int syscallbuf_enabled;
 	/* Lets rr know where our untraced syscalls will originate
 	 * from. */
-	void* untraced_syscall_ip;
+	byte* untraced_syscall_ip;
 	/* Address of the control socket the child expects to connect
 	 * to. */
 	struct sockaddr_un* sockaddr;
@@ -85,11 +91,11 @@ struct rrcall_init_buffers_params {
 	 * the purposes of this code, it doesn't matter what the
 	 * scratch region is, all we need to know about it is that it
 	 * must be unmapped at thread exit time. */
-	void* scratch_ptr;
+	byte* scratch_ptr;
 	size_t num_scratch_bytes;
 	/* Returned pointer to and size of the shared syscallbuf
 	 * segment. */
-	void* syscallbuf_ptr;
+	byte* syscallbuf_ptr;
 	size_t num_syscallbuf_bytes;
 };
 
@@ -166,8 +172,9 @@ struct socketcall_args {
  * THIS POINTER IS NOT GUARANTEED TO BE VALID!!!  Caveat emptor.
  */
 inline static struct syscallbuf_record* next_record(struct syscallbuf_hdr* hdr)
-{	
-	return (void*)hdr->recs + hdr->num_rec_bytes;
+{
+	uintptr_t next = (uintptr_t)hdr->recs + hdr->num_rec_bytes;
+	return (struct syscallbuf_record*)next;
 }
 
 /**
@@ -210,5 +217,9 @@ inline static int is_blacklisted_filename(const char* filename)
 		|| !strcmp("/dev/nvidiactl", filename)
 		|| !strcmp("/usr/share/alsa/alsa.conf", filename));
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSCALL_BUFFER_H_ */

--- a/src/recorder/handle_ioctl.h
+++ b/src/recorder/handle_ioctl.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef HANDLE_IOCTL_H_
 #define HANDLE_IOCTL_H_

--- a/src/recorder/handle_signal.h
+++ b/src/recorder/handle_signal.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef __HANDLE_SIGNAL_H__
 #define __HANDLE_SIGNAL_H__

--- a/src/recorder/rec_process_event.h
+++ b/src/recorder/rec_process_event.h
@@ -1,11 +1,7 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef PROCESS_SYSCALL_H_
 #define PROCESS_SYSCALL_H_
-
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE
-#endif
 
 #include "../share/types.h"
 #include "../share/util.h"

--- a/src/recorder/rec_sched.h
+++ b/src/recorder/rec_sched.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef REC_SCHED_H_
 #define REC_SCHED_H_
@@ -43,7 +43,7 @@ struct task* rec_sched_lookup_thread(pid_t tid);
  * task group.  Otherwise it becomes its own new thread group.
  */
 enum { DEFAULT_COPY = 0, SHARE_SIGHANDLERS = 0x1, SHARE_TASK_GROUP = 0x2 };
-void rec_sched_register_thread(pid_t parent, pid_t child, int flags);
+struct task* rec_sched_register_thread(pid_t parent, pid_t child, int flags);
 void rec_sched_deregister_thread(struct task** t);
 void rec_sched_exit_all(void);
 

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef RECORDER_H_
 #define RECORDER_H_

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef REP_PROCESS_EVENT_H_
 #define REP_PROCESS_EVENT_H_

--- a/src/replayer/rep_sched.h
+++ b/src/replayer/rep_sched.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef REP_SCHED_H_
 #define REP_SCHED_H_

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 /* XXX unify me with recorder definitions, to make this the SSOT for
  * syscall info */
@@ -1422,3 +1422,5 @@ SYSCALL_DEF(EMU, writev, 0)
  * This is a "magic" syscall implemented by rr.
  */
 SYSCALL_DEF(IRREGULAR, rrcall_init_buffers, -1)
+
+#define MAX_NR_SYSCALLS 512

--- a/src/share/config.h
+++ b/src/share/config.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef CONFIG_H_
 #define CONFIG_H_

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef DEBUG_H
 #define DEBUG_H

--- a/src/share/fixedstack.h
+++ b/src/share/fixedstack.h
@@ -1,11 +1,11 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef FIXEDSTACK_H_
 #define FIXEDSTACK_H_
 
 #include <assert.h>
 
-#define FIXEDSTACK_ALEN(_arr) (sizeof(_arr) / sizeof(_arr[0]))
+#define FIXEDSTACK_ALEN(_arr) ssize_t(sizeof(_arr) / sizeof(_arr[0]))
 
 /**
  * Declare a stack named |_name| of fixed size |_nelts|, with elements
@@ -16,7 +16,7 @@
 #define FIXEDSTACK_DECL(_name, _type, _nelts)	\
 	struct _name {				\
 		_type elts[_nelts];		\
-		int len;			\
+		ssize_t len;			\
 	}
 
 /**

--- a/src/share/hpc.cc
+++ b/src/share/hpc.cc
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include "hpc.h"
 
@@ -51,7 +51,7 @@ void libpfm_event_encoding(struct perf_event_attr* attr, const char* event_str, 
 	if (hw_event && attr->type != PERF_TYPE_RAW) {
 		errx(1, "error: %s is not a raw hardware event\n", event_str);
 	}
-	sys_free((void**) &fstr);
+	free(fstr);
 }
 
 
@@ -134,7 +134,8 @@ cpu_type get_cpu_type(void){
 void init_hpc(struct task* t)
 {
 
-	struct hpc_context* counters = sys_malloc_zero(sizeof(struct hpc_context));
+	struct hpc_context* counters =
+		(struct hpc_context*)calloc(1, sizeof(*counters));
 	t->hpc = counters;
 
 	/* get the event that counts down to the initial value
@@ -279,7 +280,7 @@ void destroy_hpc(struct task *t)
 {
 	struct hpc_context* counters = t->hpc;
 	cleanup_hpc(t);
-	sys_free((void**) &counters);
+	free(counters);
 }
 
 #define READ_COUNTER(fd,tmp,size)		 \

--- a/src/share/hpc.h
+++ b/src/share/hpc.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef HPC_H_
 #define HPC_H_

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef __IPC_H__
 #define __IPC_H__
@@ -12,50 +12,45 @@
 
 struct task;
 
-void read_child_registers(int child_id, struct user_regs_struct* regs);
-long read_child_code(pid_t pid, void* addr);
-long read_child_data_word(pid_t pid, void* addr);
-void* read_child_data(struct task *t, size_t size, void* addr);
+void read_child_registers(struct task* t, struct user_regs_struct* regs);
+long read_child_code(pid_t pid, byte* addr);
+long read_child_data_word(struct task* t, byte* addr);
+void* read_child_data(struct task *t, size_t size, byte* addr);
 void read_child_usr(struct task *t, void *dest, void *src, size_t size);
-void* read_child_data_checked(struct task *t, size_t size, void* addr, ssize_t *read_bytes);
-ssize_t checked_pread(struct task *t, void *buf, size_t size, off_t offset);
-void memcpy_child(struct task *t, void *dest, void *src, int size);
+void* read_child_data_checked(struct task *t, size_t size, byte* addr, ssize_t *read_bytes);
+ssize_t checked_pread(struct task* t, byte* buf, size_t size, off_t offset);
+void memcpy_child(struct task* t, void* dest, void* src, int size);
 
-void write_child_code(pid_t pid, void* addr, long code);
-void write_child_data_word(pid_t pid, void *addr, uintptr_t data);
-void write_child_registers(pid_t tid, struct user_regs_struct* regs);
-void write_child_main_registers(pid_t tid, struct user_regs_struct *regs);
-void write_child_segment_registers(pid_t tid, struct user_regs_struct *regs);
-void write_child_data_n(pid_t tid, size_t size, void* addr,
-			const void* data);
-void write_child_data(struct task *t, size_t size, void *addr,
-		      const void *data);
-size_t set_child_data(struct task *t);
+void write_child_code(struct task* t, void* addr, long code);
+void write_child_registers(struct task* t, struct user_regs_struct* regs);
+void write_child_data_n(struct task* t, ssize_t size, byte* addr,
+			const byte* data);
+void write_child_data(struct task* t, ssize_t size, byte* addr,
+		      const byte* data);
+size_t set_child_data(struct task* t);
 
-
-/* access functions to child registers */
-long int read_child_eax(pid_t child_id);
-long int read_child_ebx(pid_t child_id);
-long int read_child_ecx(pid_t child_id);
-long int read_child_edx(pid_t child_id);
-long int read_child_esi(pid_t child_id);
-long int read_child_edi(pid_t child_id);
-long int read_child_ebp(pid_t child_id);
-long int read_child_esp(pid_t child_id);
-long int read_child_eip(pid_t child_id);
-long int read_child_orig_eax(pid_t child_id);
+// XXX rewrite me
+long int read_child_eax(struct task* t);
+long int read_child_ebx(struct task* t);
+long int read_child_ecx(struct task* t);
+long int read_child_edx(struct task* t);
+long int read_child_esi(struct task* t);
+long int read_child_edi(struct task* t);
+long int read_child_ebp(struct task* t);
+long int read_child_esp(struct task* t);
+long int read_child_eip(struct task* t);
+long int read_child_orig_eax(struct task* t);
 
 
-void write_child_eax(int tid, long int val);
-void write_child_ebx(int tid, long int val);
-void write_child_ecx(int tid, long int val);
-void write_child_edx(int tid, long int val);
-void write_child_edi(int tid, long int val);
-void write_child_ebp(int tid, long int val);
+void write_child_eax(struct task* t, long int val);
+void write_child_ebx(struct task* t, long int val);
+void write_child_ecx(struct task* t, long int val);
+void write_child_edx(struct task* t, long int val);
+void write_child_edi(struct task* t, long int val);
+void write_child_ebp(struct task* t, long int val);
 void set_return_value(struct task* context);
 
 
-char* read_child_str(pid_t pid, void* addr);
-void* read_child_data_tid(pid_t tid, size_t size, void* addr);
+char* read_child_str(struct task* t, byte* addr);
 
 #endif /* __IPC_H__ */

--- a/src/share/shmem.cc
+++ b/src/share/shmem.cc
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #include <stdio.h>
 #include <sys/shm.h>

--- a/src/share/shmem.h
+++ b/src/share/shmem.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef __SHMEM_H__
 #define __SHMEM_H__

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef SYS_H_
 #define SYS_H_
@@ -19,31 +19,29 @@ int sys_open(const char* path, int flags, mode_t mode);
 int sys_mkpath(const char *path, mode_t mode);
 void sys_fclose(FILE* file);
 pid_t sys_fork(void);
-int sys_open_child_mem(pid_t child_tid);
+int sys_open_child_mem(struct task* t);
 void sys_kill(int pid, int msg);
 void sys_exit(void);
-void sys_start_trace(char* executable, char** fake_argv, char** envp);
+void sys_start_trace(const char* executable, char** fake_argv, char** envp);
 
 void goto_next_event(struct task *t);
 
-long sys_ptrace(int request, pid_t pid, void* addr, void* data);
-void sys_ptrace_setup(pid_t pid);
-void sys_ptrace_singlestep(pid_t pid);
-void sys_ptrace_singlestep_sig(pid_t pid, int sig);
-void sys_ptrace_sysemu(pid_t pid);
-void sys_ptrace_sysemu_sig(pid_t pid, int sig);
-void sys_ptrace_sysemu_singlestep(pid_t pid);
-void sys_ptrace_sysemu_singlestep_sig(pid_t pid, int sig);
+void sys_ptrace(struct task* t, int request, void* addr, void* data);
+void sys_ptrace_setup(struct task* t);
+void sys_ptrace_singlestep(struct task* t);
+void sys_ptrace_singlestep_sig(struct task* t, int sig);
+void sys_ptrace_sysemu(struct task* t);
+void sys_ptrace_sysemu_singlestep(struct task* t);
 void sys_ptrace_traceme(void);
 void sys_ptrace_cont(pid_t pid);
 void sys_ptrace_cont_sig(pid_t pid, int sig);
-void sys_ptrace_syscall_sig(pid_t pid, int sig);
+void sys_ptrace_syscall_sig(struct task* pid, int sig);
 /* Return zero on success, -1 on error. */
 int sys_ptrace_peekdata(pid_t pid, long addr, long* value);
-unsigned long sys_ptrace_getmsg(pid_t pid);
-void sys_ptrace_getsiginfo(pid_t pid, siginfo_t* sig);
+unsigned long sys_ptrace_getmsg(struct task* t);
+void sys_ptrace_getsiginfo(struct task* t, siginfo_t* sig);
 void sys_ptrace_detach(pid_t pid);
-void sys_ptrace_syscall(pid_t pid);
+void sys_ptrace_syscall(struct task* t);
 
 pid_t sys_waitpid(pid_t pid, int *status);
 pid_t sys_waitpid_nonblock(pid_t pid, int *status);
@@ -51,10 +49,7 @@ void sys_fcntl(int fd, int cmd, long arg1);
 
 void* sys_mmap(void* addr, size_t length, int prot, int flags, int filedes, off_t offset);
 void sys_munmap(void* addr, size_t length);
-void* sys_malloc(int size);
 void* sys_memset(void * block, int c, size_t size);
-void* sys_malloc_zero(int size);
-void sys_free(void** ptr);
 void sys_setpgid(pid_t pid, pid_t pgid);
 
 #endif /* SYS_H_ */

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef TYPES_H_
 #define TYPES_H_
@@ -20,8 +20,6 @@
 
 #define UUL_COLUMN_SIZE 	20
 #define LI_COLUMN_SIZE 		11
-
-typedef enum { FALSE = 0, TRUE = 1 } bool;
 
 typedef unsigned char byte;
 
@@ -55,28 +53,28 @@ struct flags {
 	int option;
 	bool redirect;
 	bool use_syscall_buffer;
-	char *syscall_buffer_lib_path;
+	const char* syscall_buffer_lib_path;
 	int dump_on;	// event
 	int dump_at;	// global time
 	int checksum;
-	/* Nonzero when we're replaying without a controlling debugger. */
-	int autopilot;
+	/* True when we're replaying without a controlling debugger. */
+	bool autopilot;
 	/* IP port to listen on for debug connections. */
 	int dbgport;
 	/* Number of seconds to wait after startup, before starting
 	 * "real work". */
 	int wait_secs;
-	/* Nonzero when not-absolutely-urgently-critical messages will
-	 * be logged. */
-	int verbose;
-	/* Nonzero when tracee processes in record and replay are
-	 * allowed to run on any logical CPU. */
-	int cpu_unbound;
+	/* True when not-absolutely-urgently-critical messages will be
+	 * logged. */
+	bool verbose;
+	/* True when tracee processes in record and replay are allowed
+	 * to run on any logical CPU. */
+	bool cpu_unbound;
 	/* Always allow emergency debugging. */
-	int force_enable_debugger;
+	bool force_enable_debugger;
 	/* Mark the trace global time along with tracee writes to
 	 * stdio. */
-	int mark_stdio;
+	bool mark_stdio;
 };
 
 struct msghdr;

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1,6 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
-
-#define _GNU_SOURCE
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 //#define DEBUGTAG "Util"
 
@@ -33,16 +31,16 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "../recorder/rec_sched.h"
-#include "../replayer/replayer.h"
-
 #include "dbg.h"
 #include "ipc.h"
 #include "sys.h"
-#include "syscall_buffer.h"
 #include "task.h"
 #include "trace.h"
 #include "types.h"
+
+#include "../preload/syscall_buffer.h"
+#include "../recorder/rec_sched.h"
+#include "../replayer/replayer.h"
 
 #ifndef PTRACE_EVENT_SECCOMP
 #define PTRACE_O_TRACESECCOMP			0x00000080
@@ -68,12 +66,6 @@ static void* scratch_table[MAX_TID] = {NULL} ;
 static size_t scratch_table_size = 0;
 static size_t scratch_overall_size = 0;
 
-static struct sigaction * sig_handler_table[MAX_TID][_NSIG] = { {NULL} };
-
-static size_t num_shared_maps = 0;
-static void* shared_maps_starts[MAX_TID] = {0};
-static void* shared_maps_ends[MAX_TID] = {0};
-
 const struct flags* rr_flags(void)
 {
 	return &flags;
@@ -90,7 +82,7 @@ struct flags* rr_flags_for_init(void)
 	return NULL;		/* not reached */
 }
 
-static void* get_mmaped_region_end(struct task* t, void* start)
+static byte* get_mmaped_region_end(struct task* t, byte* start)
 {
 	struct mapped_segment_info info;
 	int found_info = find_segment_containing(t, start, &info);
@@ -98,26 +90,10 @@ static void* get_mmaped_region_end(struct task* t, void* start)
 	return info.end_addr;
 }
 
-void add_protected_map(struct task *t, void *start){
-	assert(num_shared_maps < NUM_MAX_MAPS);
-	shared_maps_starts[num_shared_maps] = start;
-	shared_maps_ends[num_shared_maps++] = get_mmaped_region_end(t,start);
-}
-
-bool is_protected_map(struct task *t, void *start){
-	int i;
-	for (i = 0 ; i < num_shared_maps; ++i) {
-		if (shared_maps_starts[i] <= start && start <  shared_maps_ends[i]) {
-			return TRUE;
-		}
-	}
-	return FALSE;
-}
-
 static int is_start_of_scratch_region(void* start_addr)
 {
 	int i;
-	for (i = 0 ; i < scratch_table_size; ++i) {
+	for (i = 0 ; i < ssize_t(scratch_table_size); ++i) {
 		if (scratch_table[i] == start_addr) {
 			return 1;
 		}
@@ -323,15 +299,17 @@ sleep_hack:
 		 * has been observed to fail when we sleep 3ms, but
 		 * not when we sleep 4ms.  Yep, this hack is that
 		 * horrible! */
-		struct timespec ts = { .tv_nsec = 4000000LL };
+		struct timespec ts;
+		memset(&ts, 0, sizeof(ts));
+		ts.tv_nsec = 4000000LL;
 		nanosleep_nointr(&ts);
 	}
 }
 
-void print_register_file_tid(pid_t tid)
+void print_register_file_tid(struct task* t)
 {
 	struct user_regs_struct regs;
-	read_child_registers(tid, &regs);
+	read_child_registers(t, &regs);
 	print_register_file(&regs);
 }
 
@@ -397,7 +375,7 @@ struct map_iterator_data {
 	ssize_t size_bytes;
 	/* Pointer to data read from the segment if requested,
 	 * otherwise NULL. */
-	void* mem;
+	byte* mem;
 	/* Length of data read from segment.  May be less than nominal
 	 * segment length if an error occurs. */
 	ssize_t mem_len;
@@ -408,8 +386,10 @@ typedef int (*memory_map_iterator_t)(void* it_data, struct task* t,
 
 typedef int (*read_segment_filter_t)(void* filt_data, struct task* t,
 				     const struct mapped_segment_info* info);
-static const read_segment_filter_t kNeverReadSegment = (void*)0;
-static const read_segment_filter_t kAlwaysReadSegment = (void*)1;
+static const read_segment_filter_t kNeverReadSegment =
+	(read_segment_filter_t)0;
+static const read_segment_filter_t kAlwaysReadSegment =
+	(read_segment_filter_t)1;
 
 static int caller_wants_segment_read(struct task* t,
 				     const struct mapped_segment_info* info,
@@ -471,6 +451,7 @@ static void iterate_memory_map(struct task* t,
 		if (caller_wants_segment_read(t, &data.info,
 					      filt, filt_data)) {
 			data.mem =
+				(byte*)
 				read_child_data_checked(t, data.size_bytes,
 							data.info.start_addr,
 							&data.mem_len);
@@ -479,7 +460,7 @@ static void iterate_memory_map(struct task* t,
 		}
 
 		next_action = it(it_data, t, &data);
-		sys_free(&data.mem);
+		free(data.mem);
 
 		if (STOP_ITERATING == next_action) {
 			break;
@@ -512,7 +493,8 @@ static int addr_in_segment(void* addr, const struct mapped_segment_info* info)
 static int find_segment_iterator(void* it_data, struct task* t,
 				 const struct map_iterator_data* data)
 {
-	struct mapped_segment_info* info = it_data;
+	struct mapped_segment_info* info =
+		(struct mapped_segment_info*)it_data;
 	void* search_addr = info->start_addr;
 	if (addr_in_segment(search_addr, &data->info)) {
 		memcpy(info, &data->info, sizeof(*info));
@@ -521,7 +503,7 @@ static int find_segment_iterator(void* it_data, struct task* t,
 	return CONTINUE_ITERATING;
 }
 
-int find_segment_containing(struct task* t, void* search_addr,
+int find_segment_containing(struct task* t, byte* search_addr,
 			    struct mapped_segment_info* info)
 {
 	memset(info, 0, sizeof(*info));
@@ -533,14 +515,16 @@ int find_segment_containing(struct task* t, void* search_addr,
 
 char* get_inst(struct task* t, int eip_offset, int* opcode_size)
 {
-	pid_t tid = t->tid;
 	char* buf = NULL;
-	unsigned long eip = read_child_eip(tid);
+	unsigned long eip = read_child_eip(t);
 	ssize_t nr_read_bytes;
-	unsigned char* inst = read_child_data_checked(t, 128, (void*)(eip + eip_offset), &nr_read_bytes);
+	byte* inst =
+		(byte*)read_child_data_checked(t, 128,
+					       (byte*)(eip + eip_offset),
+					       &nr_read_bytes);
 
 	if (nr_read_bytes <= 0) {
-		sys_free((void**)&inst);
+		free(inst);
 		return NULL;
 	}
 
@@ -550,121 +534,28 @@ char* get_inst(struct task* t, int eip_offset, int* opcode_size)
 	unsigned int size = x86_disasm(inst, 128, 0, 0, &x86_inst);
 	*opcode_size = size;
 
-	buf = sys_malloc(128);
+	buf = (char*)malloc(128);
 	if (size) {
 		x86_format_insn(&x86_inst, buf, 128, att_syntax);
 	} else {
 		/* libdiasm does not support the entire instruction set -- pretty sad */
 		strcpy(buf, "unknown");
 	}
-	sys_free((void**) &inst);
+	free(inst);
 	x86_oplist_free(&x86_inst);
 	x86_cleanup();
 
 	return buf;
 }
 
-bool is_write_mem_instruction(pid_t tid, int eip_offset, int* opcode_size)
-{
-	unsigned long eip = read_child_eip(tid);
-	unsigned char* inst = read_child_data_tid(tid, 128, (void*)(eip + eip_offset));
-
-	x86_init(opt_none, 0, 0);
-	x86_insn_t x86_inst;
-	unsigned int size = x86_disasm(inst, 128, 0, 0, &x86_inst);
-	*opcode_size = size;
-	bool retval = (x86_inst.operands->op.access == op_write && x86_inst.operands->op.type > op_immediate);
-	x86_oplist_free(&x86_inst);
-	x86_cleanup();
-	sys_free((void**) &inst);
-
-	return retval;
-}
-
-
-void emulate_child_inst(struct task * t, int eip_offset)
-{
-	pid_t tid = t->tid;
-	struct user_regs_struct regs;
-	read_child_registers(tid,&regs);
-	unsigned long eip = read_child_eip(tid);
-	unsigned char* inst = read_child_data_tid(tid, 128, (void*)(eip + eip_offset));
-
-	x86_init(opt_none, 0, 0);
-	x86_insn_t x86_inst;
-	unsigned int size = x86_disasm(inst, 128, 0, 0, &x86_inst);
-
-	char buf[128];
-	if (size) {
-		x86_format_insn(&x86_inst, buf, 128, att_syntax);
-	} else {
-		/* libdiasm does not support the entire instruction set -- pretty sad */
-		strcpy(buf, "unknown");
-	}
-
-	if (strcmp("cmpb\t$0x01, (%eax)",buf) == 0) { // emulate the instruction
-		unsigned char right_op = (unsigned char)read_child_data_word(tid,(void*)regs.eax);
-		union {
-			struct {
-				unsigned int CF:1;
-				unsigned int R1_1:1;
-				unsigned int PF:1;
-				unsigned int R0_1:1;
-				unsigned int AF:1;
-				unsigned int R0_2:1;
-				unsigned int ZF:1;
-				unsigned int SF:1;
-				unsigned int TF:1;
-				unsigned int IF:1;
-				unsigned int DF:1;
-				unsigned int OF:1;
-			} b ;
-			long int l;
-		} flags0, flags;
-		asm (
-		    "cmpb $0x1,%1;" // execute the instruction
-		    "pushf;" // store flags (16 bits)
-		    "pop %0;" // pop to flags variable
-		    : "=r" (flags)
-		    : "r" (right_op)
-		    :
-		);
-		assert(flags.b.R1_1 == 1 && flags.b.R0_1 == 0 && flags.b.R0_2 == 0); // sanity check
-
-		flags0.l = regs.eflags;
-		flags0.b.CF = flags.b.CF;
-		flags0.b.PF = flags.b.PF;
-		flags0.b.AF = flags.b.AF;
-		flags0.b.ZF = flags.b.ZF;
-		flags0.b.SF = flags.b.SF;
-		flags0.b.OF = flags.b.OF;
-		regs.eflags = flags0.l;
-		regs.eip += size; // move past the instruction
-
-		push_pseudosig(t, ESIG_SEGV_MMAP_READ, HAS_EXEC_INFO);
-		record_child_data(t, sizeof(long), (void*)regs.eax);
-		//record_parent_data(t,SIG_SEGV_MMAP_READ,sizeof(long),regs.eax, &right_op);
-		record_event(t);
-		pop_pseudosig(t);
-
-		write_child_registers(tid,&regs);
-	} else {
-		log_err("instruction (%s) emulation not supported yet.",inst);
-		assert(0);
-	}
-
-	x86_oplist_free(&x86_inst);
-	x86_cleanup();
-}
-
-void mprotect_child_region(struct task* t, void* addr, int prot)
+void mprotect_child_region(struct task* t, byte* addr, int prot)
 {
 	struct current_state_buffer state;
 	size_t length;
 	long ret;
 
 	/* Page-align the address. */
-	addr = (void*)((int)addr & PAGE_MASK);
+	addr = (byte*)((uintptr_t)addr & PAGE_MASK);
 	length = get_mmaped_region_end(t, addr) - addr;
 
 	prepare_remote_syscalls(t, &state);
@@ -712,153 +603,6 @@ void print_cwd(pid_t tid, char *str)
 }
 
 
-/**
- * for printing syscall data on *replay* stage (as it uses the trace).
- * TODO: fix it so it will be suitable for both stages
- */
-void print_syscall(struct task *t, struct trace_frame *trace)
-{
-
-	int syscall = trace->recorded_regs.orig_eax;
-	int state = trace->state;
-	struct user_regs_struct r;
-	read_child_registers(t->tid, &r);
-
-	fprintf(stderr,"%u:%d:%d:", trace->global_time, t->rec_tid, t->trace.state);
-	if (state == STATE_SYSCALL_ENTRY) {
-		fprintf(stderr," event: %d",t->trace.stop_reason);
-	}
-
-	if (state == STATE_SYSCALL_EXIT) {
-		switch (syscall) {
-
-		/*  int access(const char *pathname, int mode); */
-		case SYS_access:
-		{
-			char *str = read_child_str(t->tid, (void*)r.ebx);
-			fprintf(stderr,"access(const char *pathname(%s), int mode(%lx))", str, r.ecx);
-			sys_free((void**)str);
-			break;
-		}
-
-
-		/* int clock_gettime(clockid_t clk_id, struct timespec *tp); */
-		case SYS_clock_gettime:
-		{
-			fprintf(stderr,"clock_gettime(clockid_t clk_id(%lx), struct timespec *tp(%lx))", r.ebx, r.ecx);
-			break;
-		}
-
-		/* int close(int fd) */
-		case SYS_close:
-		{
-			fprintf(stderr,"close(int fd(%lx))", r.ebx);
-			break;
-		}
-
-		/* int gettimeofday(struct timeval *tv, struct timezone *tz); */
-		case SYS_gettimeofday:
-		{
-			fprintf(stderr,"gettimeofday(struct timeval *tv(%lx), struct timezone *tz(%lx))", r.ebx, r.ecx);
-			break;
-		}
-
-		/* int fstat(int fd, struct stat *buf) */
-		case SYS_fstat64:
-		{
-			fprintf(stderr,"fstat64(int fd(%lx), struct stat *buf(%lx))", r.ebx, r.ecx);
-			break;
-		}
-
-		/* int futex(int *uaddr, int op, int val, const struct timespec *timeout, int *uaddr2, int val3); */
-		case SYS_futex:
-		{
-			fprintf(stderr,"futex(int *uaddr(%lx), int op(%lx), int val(%lx), const struct timespec *timeout(%lx), int *uaddr2(%lx), int val3(%lx))", r.ebx, r.ecx, r.edx, r.esi, r.edi, r.ebp);
-			break;
-		}
-
-		/* int ipc(unsigned int call, int first, int second, int third, void *ptr, long fifth); */
-		case SYS_ipc:
-		{
-			fprintf(stderr,"ipc(unsigned int call(%lx), int first(%lx), int second(%lx), int third(%lx), void *ptr(%lx), long fifth(%lx)", r.ebx, r.ecx, r.edx, r.esi, r.edi, r.ebp);
-			break;
-		}
-
-		/* int _llseek(unsigned int fd, unsigned long offset_high, unsigned long offset_low,
-		 loff_t *result, unsigned int whence); */
-		case SYS__llseek:
-		{
-			fprintf(stderr,"_llseek(unsigned int fd(%lx), unsigned long offset_high(%lx), unsigned long offset_low(%lx), loff_t *result(%lx), unsigned int whence(%lx)",
-					r.ebx, r.ecx, r.edx, r.esi, r.edi);
-			break;
-		}
-
-		/* void *mmap2(void *addr, size_t length, int prot,int flags, int fd, off_t pgoffset);*/
-		case SYS_mmap2:
-		{
-			fprintf(stderr,"mmap2(void* addr(%lx), size_t len(%lx), int prot(%lx), int flags(%lx), int fd(%lx),off_t pgoffset(%lx)", r.ebx, r.ecx, r.edx, r.esi, r.edi, r.ebp);
-			break;
-		}
-
-		/* int munmap(void *addr, size_t length) */
-		case SYS_munmap:
-		{
-			fprintf(stderr,"munmap(void *addr(%lx), size_t length(%lx))", r.ebx, r.ecx);
-			break;
-		}
-
-		/* int open(const char *pathname, int flags) */
-		case SYS_open:
-		{
-			char *str = read_child_str(t->tid,
-						   (void*)r.ebx);
-			fprintf(stderr,"open(const char *pathname(%s), int flags(%lx))", str, r.ecx);
-			sys_free((void**)&str);
-			break;
-		}
-
-		/* int poll(struct pollfd *fds, nfds_t nfds, int timeout)*/
-		case SYS_poll:
-		{
-			fprintf(stderr,"poll(struct pollfd *fds(%lx), nfds_t nfds(%lx), int timeout(%lx)", r.ebx, r.ecx, r.edx);
-			break;
-		}
-
-		/* ssize_t read(int fd, void *buf, size_t count); */
-		case SYS_read:
-		{
-			fprintf(stderr,"read(int fd(%lx), void *buf(%lx), size_t count(%lx)", r.ebx, r.ecx, r.edx);
-			break;
-		}
-
-		/* int socketcall(int call, unsigned long *args) */
-		case SYS_socketcall:
-		{
-			fprintf(stderr,"socketcall(int call(%ld), unsigned long *args(%lx))", r.ebx, r.ecx);
-			break;
-		}
-
-		/* int stat(const char *path, struct stat *buf); */
-		case SYS_stat64:
-		{
-			char* str = read_child_str(t->tid,
-						   (void*)r.ebx);
-			fprintf(stderr,"stat(const char *path(%s), struct stat *buf(%lx))", str, r.ecx);
-			sys_free((void**)&str);
-			break;
-		}
-
-		default:
-		{
-			fprintf(stderr,"%s(%d)/%d -- global_time %u", syscallname(syscall), syscall, state, trace->global_time);
-			break;
-		}
-
-		}
-	}
-	fprintf(stderr, "\n");
-}
-
 static void maybe_print_reg_mismatch(int mismatch_behavior, const char* regname,
 				     const char* label1, long val1,
 				     const char* label2, long val2)
@@ -873,8 +617,10 @@ static void maybe_print_reg_mismatch(int mismatch_behavior, const char* regname,
 }
 
 int compare_register_files(struct task* t,
-			   char* name1, const struct user_regs_struct* reg1,
-			   char* name2, const struct user_regs_struct* reg2,
+			   const char* name1,
+			   const struct user_regs_struct* reg1,
+			   const char* name2,
+			   const struct user_regs_struct* reg2,
 			   int mismatch_behavior)
 {
 	int bail_error = (mismatch_behavior >= BAIL_ON_MISMATCH);
@@ -956,7 +702,7 @@ void assert_child_regs_are(struct task* t,
 			   const struct user_regs_struct* regs,
 			   int event, int state)
 {
-	read_child_registers(t->tid, &t->regs);
+	read_child_registers(t, &t->regs);
 	compare_register_files(t, "replaying", &t->regs, "recorded", regs,
 			       BAIL_ON_MISMATCH);
 	/* TODO: add perf counter validations (hw int, page faults, insts) */
@@ -970,7 +716,7 @@ uint64_t str2ull(const char* start, size_t max_size)
 	}
 
 	uint64_t val = 0;
-	while (isdigit(start[idx]) && idx <= max_size) {
+	while (isdigit(start[idx]) && idx <= ssize_t(max_size)) {
 		char tmp_char[2];
 		tmp_char[0] = start[idx];
 		tmp_char[1] = '\0';
@@ -997,7 +743,7 @@ long int str2li(const char* start, size_t max_size)
 	}
 
 	long int val = 0;
-	while (isdigit(start[idx]) && idx <= max_size) {
+	while (isdigit(start[idx]) && idx <= ssize_t(max_size)) {
 		char tmp_char[2];
 		tmp_char[0] = start[idx];
 		tmp_char[1] = '\0';
@@ -1011,7 +757,7 @@ long int str2li(const char* start, size_t max_size)
 	return val;
 }
 
-void * str2x(const char* start, size_t max_size)
+byte* str2x(const char* start, size_t max_size)
 {
 	int idx = 0;
 
@@ -1020,7 +766,7 @@ void * str2x(const char* start, size_t max_size)
 	}
 
 	long int val = 0;
-	while (idx <= max_size) {
+	while (idx <= ssize_t(max_size)) {
 		int tmp = 0;
 		if (isdigit(start[idx])) {
 			tmp = start[idx] - '0';
@@ -1034,10 +780,10 @@ void * str2x(const char* start, size_t max_size)
 		idx++;
 	}
 
-	return (void*)val;
+	return (byte*)val;
 }
 
-void read_line(FILE* file, char *buf, int size, char *name)
+void read_line(FILE* file, char* buf, int size, const char* name)
 {
 	if (feof(file) || fgets(buf, size, file) == NULL) {
 		printf("error reading line in file: %s  -- bailing out\n", name);
@@ -1054,12 +800,12 @@ void read_line(FILE* file, char *buf, int size, char *name)
  */
 static void dump_binary_chunk(FILE* out, const char* label,
 			      const uint32_t* buf, size_t buf_len,
-			      const char* start_addr)
+			      const byte* start_addr)
 {
 	int i;
 
 	fprintf(out,"%s\n", label);
-	for (i = 0 ; i < buf_len; i += 1) {
+	for (i = 0 ; i < ssize_t(buf_len); i += 1) {
 		uint32_t word = buf[i];
 		fprintf(out, "0x%08x | [%p]\n", word,
 			start_addr + i * sizeof(*buf));
@@ -1068,7 +814,7 @@ static void dump_binary_chunk(FILE* out, const char* label,
 
 void dump_binary_data(const char* filename, const char* label,
 		      const uint32_t* buf, size_t buf_len,
-		      const char* start_addr)
+		      const byte* start_addr)
 {
 	FILE* out = fopen(filename, "w");
 	if (!out) {
@@ -1108,9 +854,9 @@ int should_dump_memory(struct task* t, int event, int state, int global_time)
 static int dump_process_memory_iterator(void* it_data, struct task* t,
 					const struct map_iterator_data* data)
 {
-	FILE* dump_file = it_data;
-	const unsigned* buf = data->mem;
-	void* start_addr = data->info.start_addr;
+	FILE* dump_file = (FILE*)it_data;
+	const unsigned* buf = (const unsigned*)data->mem;
+	byte* start_addr = data->info.start_addr;
 
 	if (!buf) {
 		/* This segment was filtered by debugging code. */
@@ -1205,15 +951,17 @@ static void notify_checksum_error(struct task* t,
  * checksums.  The iterator data determines which behavior the helper
  * function takes on, and to/from which file it writes/read.
  */
+enum ChecksumMode { STORE_CHECKSUMS, VALIDATE_CHECKSUMS };
 struct checksum_iterator_data {
-	enum { STORE_CHECKSUMS, VALIDATE_CHECKSUMS } mode;
+		ChecksumMode mode;
 	FILE* checksums_file;
 };
 static int checksum_iterator(void* it_data, struct task* t,
 			     const struct map_iterator_data* data)
 {
-	struct checksum_iterator_data* c = it_data;
-	unsigned* buf = data->mem;
+	struct checksum_iterator_data* c =
+		(struct checksum_iterator_data*)it_data;
+	unsigned* buf = (unsigned*)data->mem;
 	ssize_t valid_mem_len = data->mem_len;
 	unsigned checksum = 0;
 	int i;
@@ -1232,19 +980,21 @@ static int checksum_iterator(void* it_data, struct task* t,
 		 *
 		 * So here, we set things up so that we only checksum
 		 * the deterministic region. */
-		void* child_hdr = data->info.start_addr;
-		struct syscallbuf_hdr* hdr = read_child_data(t, sizeof(*hdr),
-							     child_hdr);
+		byte* child_hdr = data->info.start_addr;
+		struct syscallbuf_hdr* hdr =
+			(struct syscallbuf_hdr*)read_child_data(t,
+								sizeof(*hdr),
+								child_hdr);
 		valid_mem_len = sizeof(*hdr) + hdr->num_rec_bytes +
 				sizeof(struct syscallbuf_record);
-		sys_free((void**)&hdr);
+		free(hdr);
 	}
 
 	/* If this segment was filtered, then data->mem_len will be 0
 	 * to indicate nothing was read.  And data->mem will be NULL
 	 * to double-check that.  In that case, the checksum will just
 	 * be 0. */
-	for (i = 0; i < valid_mem_len / sizeof(*buf); ++i) {
+	for (i = 0; i < ssize_t(valid_mem_len / sizeof(*buf)); ++i) {
 		checksum += buf[i];
 	}
 
@@ -1316,9 +1066,10 @@ static int checksum_segment_filter(void* filt_data, struct task* t,
  * address space, or validate an existing computed checksum.  Behavior
  * is selected by |mode|.
  */
-static void iterate_checksums(struct task* t, int mode)
+static void iterate_checksums(struct task* t, ChecksumMode mode)
 {
-	struct checksum_iterator_data c = { 0 };
+	struct checksum_iterator_data c;
+	memset(&c, sizeof(c), 0);
 	char filename[PATH_MAX];
 	const char* fmode = (STORE_CHECKSUMS == mode) ? "w" : "r";
 
@@ -1375,74 +1126,15 @@ void validate_process_memory(struct task* t)
 	iterate_checksums(t, VALIDATE_CHECKSUMS);
 }
 
-/**
- * @start_addr: start address of where code should be injected
- * @code_size : given in bytes - must be a multiple of 4!
- */
-struct current_state_buffer* init_code_injection(pid_t pid, void* start_addr, int code_size)
-{
-	//check if code size is a multiple of 4
-	assert(code_size % 4 == 0);
-
-	struct current_state_buffer* buf = sys_malloc(sizeof(struct current_state_buffer));
-	buf->pid = pid;
-
-	//save the current state of the register file
-	read_child_registers(pid, &(buf->regs));
-
-	//save original instructions; assure word alignment
-	long* tmp = (long*) ((unsigned long) start_addr & ~0x3);
-	long* code_buffer = sys_malloc(code_size + (2 * sizeof(long)));
-
-	int i = 0;
-	while ((void *) tmp + i < (void *) start_addr + code_size) {
-		//TODO: re-implemnt read_code
-		//code_buffer[i] = read_child_code(pid, tmp + i);
-		//	printf("read instruction: %lx\n",code_buffer[i]);
-		i++;
-	}
-
-	buf->code_size = i * 4;
-	buf->code_buffer = code_buffer;
-	buf->start_addr = tmp;
-	return buf;
-}
-
-void restore_original_state(struct current_state_buffer* buf)
-{
-	//restoring the original state involves two steps:
-	//1. restore register file (including eip)
-	write_child_registers(buf->pid, &(buf->regs));
-
-	//2. copy the original code back to the child
-	int i;
-	for (i = 0; i < buf->code_size / 4; i++) {
-		write_child_code(buf->pid, buf->start_addr + i, buf->code_buffer[i]);
-	}
-}
-
 void cleanup_code_injection(struct current_state_buffer* buf)
 {
-	sys_free((void**) &buf->code_buffer);
-	sys_free((void**) &buf);
+	free(buf->code_buffer);
+	free(buf);
 }
 
 void add_scratch(void *ptr, int size) {
 	scratch_table[scratch_table_size++] = ptr;
 	scratch_overall_size += size;
-}
-
-void add_sig_handler(pid_t tid, unsigned int signum, struct sigaction * sa){
-	assert(signum < SIGRTMAX + 1);
-	if (sig_handler_table[tid][signum] != NULL)
-		sys_free((void**)&(sig_handler_table[tid][signum]));
-	sig_handler_table[tid][signum] = sys_malloc(sizeof(struct sigaction));
-	memcpy(sig_handler_table[tid][signum], sa, sizeof(struct sigaction));
-}
-
-struct sigaction * get_sig_handler(pid_t tid, unsigned int signum){
-	assert(signum < SIGRTMAX + 1);
-	return sig_handler_table[tid][signum];
 }
 
 void copy_syscall_arg_regs(struct user_regs_struct* to,
@@ -1458,35 +1150,37 @@ void copy_syscall_arg_regs(struct user_regs_struct* to,
 
 void record_struct_msghdr(struct task* t, struct msghdr* child_msghdr)
 {
-	struct msghdr* msg = read_child_data(t, sizeof(*msg), child_msghdr);
+	struct msghdr* msg =
+		(struct msghdr*)read_child_data(t, sizeof(*msg),
+						(byte*)child_msghdr);
 	struct iovec* iov;
 
 	/* Record the entire struct, because some of the direct fields
 	 * are written as inoutparams. */
-	record_child_data(t, sizeof(*child_msghdr), child_msghdr);
-	record_child_data(t, msg->msg_namelen, msg->msg_name);
+	record_child_data(t, sizeof(*child_msghdr), (byte*)child_msghdr);
+	record_child_data(t, msg->msg_namelen, (byte*)msg->msg_name);
 
 	assert("TODO: record more than 1 iov" && msg->msg_iovlen == 1);
 
-	record_child_data(t, sizeof(struct iovec), msg->msg_iov);
-	iov = read_child_data(t, sizeof(struct iovec), msg->msg_iov);
-	record_child_data(t, iov->iov_len, iov->iov_base);
+	record_child_data(t, sizeof(struct iovec), (byte*)msg->msg_iov);
+	iov = (struct iovec*)read_child_data(t, sizeof(struct iovec), (byte*)msg->msg_iov);
+	record_child_data(t, iov->iov_len, (byte*)iov->iov_base);
 
-	record_child_data(t, msg->msg_controllen, msg->msg_control);
+	record_child_data(t, msg->msg_controllen, (byte*)msg->msg_control);
 
-	sys_free((void**) &iov);
-	sys_free((void**) &msg);
+	free(iov);
+	free(msg);
 }
 
 void record_struct_mmsghdr(struct task* t, struct mmsghdr* child_mmsghdr)
 {
 	/* struct mmsghdr has an inline struct msghdr as its first
 	 * field, so it's OK to make this "cast". */
-	record_struct_msghdr(t, (void*)child_mmsghdr);
+	record_struct_msghdr(t, (struct msghdr*)child_mmsghdr);
 	/* We additionally have to record the outparam number of
 	 * received bytes. */
 	record_child_data(t, sizeof(child_mmsghdr->msg_len),
-			  &child_mmsghdr->msg_len);
+			  (byte*)&child_mmsghdr->msg_len);
 }
 
 void restore_struct_msghdr(struct task* t, struct msghdr* child_msghdr)
@@ -1502,7 +1196,7 @@ void restore_struct_msghdr(struct task* t, struct msghdr* child_msghdr)
 
 void restore_struct_mmsghdr(struct task* t, struct mmsghdr* child_mmsghdr)
 {
-	restore_struct_msghdr(t, (void*)child_mmsghdr);
+	restore_struct_msghdr(t, (struct msghdr*)child_mmsghdr);
 	set_child_data(t);
 }
 
@@ -1682,17 +1376,16 @@ int should_copy_mmap_region(const char* filename, struct stat* stat,
 void prepare_remote_syscalls(struct task* t,
 			     struct current_state_buffer* state)
 {
-	pid_t tid = t->tid;
 	byte syscall_insn[] = { 0xcd, 0x80 };
 
 	/* Save current state of |t|. */
 	memset(state, 0, sizeof(*state));
 	state->pid = t->tid;
-	read_child_registers(tid, &state->regs);
+	read_child_registers(t, &state->regs);
 	state->code_size = sizeof(syscall_insn);
-	state->start_addr = (void*)state->regs.eip;
+	state->start_addr = (byte*)state->regs.eip;
 	state->code_buffer =
-		read_child_data(t, state->code_size, state->start_addr);
+		(byte*)read_child_data(t, state->code_size, state->start_addr);
 
 	/* Inject phony syscall instruction. */
 	write_child_data(t, state->code_size, state->start_addr,
@@ -1702,18 +1395,16 @@ void prepare_remote_syscalls(struct task* t,
 void* push_tmp_str(struct task* t, struct current_state_buffer* state,
 		   const char* str, struct restore_mem* mem)
 {
-	pid_t tid = t->tid;
-
 	mem->len = strlen(str) + 1/*null byte*/;
-	mem->saved_sp = (void*)state->regs.esp;
+	mem->saved_sp = (byte*)state->regs.esp;
 
 	state->regs.esp -= mem->len;
-	write_child_registers(tid, &state->regs);
-	mem->addr = (void*)state->regs.esp;
+	write_child_registers(t, &state->regs);
+	mem->addr = (byte*)state->regs.esp;
 
-	mem->data = read_child_data(t, mem->len, mem->addr);
+	mem->data = (byte*)read_child_data(t, mem->len, mem->addr);
 
-	write_child_data(t, mem->len, mem->addr, str);
+	write_child_data(t, mem->len, mem->addr, (const byte*)str);
 
 	return mem->addr;
 }
@@ -1721,15 +1412,13 @@ void* push_tmp_str(struct task* t, struct current_state_buffer* state,
 void pop_tmp_mem(struct task* t, struct current_state_buffer* state,
 		 struct restore_mem* mem)
 {
-	pid_t tid = t->tid;
-
-	assert(mem->saved_sp == (void*)state->regs.esp + mem->len);
+	assert(mem->saved_sp == (byte*)state->regs.esp + mem->len);
 
 	write_child_data(t, mem->len, mem->addr, mem->data);
-	sys_free((void**)&mem->data);
+	free(mem->data);
 
 	state->regs.esp += mem->len;
-	write_child_registers(tid, &state->regs);
+	write_child_registers(t, &state->regs);
 }
 
 long remote_syscall(struct task* t, struct current_state_buffer* state,
@@ -1750,10 +1439,10 @@ long remote_syscall(struct task* t, struct current_state_buffer* state,
 	callregs.esi = a4;
 	callregs.edi = a5;
 	callregs.ebp = a6;
-	write_child_registers(tid, &callregs);
+	write_child_registers(t, &callregs);
 
 	/* Advance to syscall entry. */
-	sys_ptrace_syscall(tid);
+	sys_ptrace_syscall(t);
 	sys_waitpid(tid, &t->status);
 
 	/* Skip past a seccomp trace, if we happened to see one. */
@@ -1762,18 +1451,18 @@ long remote_syscall(struct task* t, struct current_state_buffer* state,
 	     * this check if an event is added with number 8 (just
 	     * after SECCOMP */
 	    || GET_PTRACE_EVENT(t->status) == PTRACE_EVENT_SECCOMP_OBSOLETE) {
-		sys_ptrace_syscall(tid);
+		sys_ptrace_syscall(t);
 		sys_waitpid(tid, &t->status);
 	}
 	assert(GET_PTRACE_EVENT(t->status) == 0);
 
-	read_child_registers(t->tid, &callregs);
+	read_child_registers(t, &callregs);
 	assert_exec(t, callregs.orig_eax == syscallno,
 		    "Should be entering %s, but instead at %s",
 		    syscallname(syscallno), syscallname(callregs.orig_eax));
 
 	/* Start running the syscall. */
-	sys_ptrace_syscall(tid);
+	sys_ptrace_syscall(t);
 	if (WAIT == wait) {
 		return wait_remote_syscall(t, state, syscallno);
 	}
@@ -1788,7 +1477,7 @@ long wait_remote_syscall(struct task* t, struct current_state_buffer* state,
 	/* Wait for syscall-exit trap. */
 	sys_waitpid(tid, &t->status);
 
-	read_child_registers(t->tid, &regs);
+	read_child_registers(t, &regs);
 	assert_exec(t, regs.orig_eax == syscallno,
 		    "Should be entering %s, but instead at %s",
 		    syscallname(syscallno), syscallname(regs.orig_eax));
@@ -1806,10 +1495,10 @@ void finish_remote_syscalls(struct task* t,
 	/* Restore stomped instruction. */
 	write_child_data(t, state->code_size, state->start_addr,
 			 state->code_buffer);
-	sys_free((void**)&state->code_buffer);
+	free(state->code_buffer);
 
 	/* Restore stomped registers. */
-	write_child_registers(tid, &state->regs);
+	write_child_registers(t, &state->regs);
 }
 
 /**
@@ -1886,11 +1575,12 @@ static int recv_fd(int sock, int* remote_fdno)
 	return fd;
 }
 
-static void write_socketcall_args(struct task* t, void* child_args_vec,
+static void write_socketcall_args(struct task* t,
+				  struct socketcall_args* child_args_vec,
 				  long arg1, long arg2, long arg3)
 {
 	struct socketcall_args args = { { arg1, arg2, arg3 } };
-	write_child_data(t, sizeof(args), child_args_vec, &args);
+	write_child_data(t, sizeof(args), (byte*)child_args_vec, (byte*)&args);
 }
 
 void* init_syscall_buffer(struct task* t, struct current_state_buffer* state,
@@ -1904,7 +1594,7 @@ void* init_syscall_buffer(struct task* t, struct current_state_buffer* state,
 	int listen_sock, sock, child_sock;
 	int shmem_fd, child_shmem_fd;
 	void* map_addr;
-	void* child_map_addr;
+	byte* child_map_addr;
 	void* tmp;
 	int zero = 0;
 
@@ -2000,15 +1690,15 @@ void* init_syscall_buffer(struct task* t, struct current_state_buffer* state,
 	}
 
 	/* Get the newly-allocated fd. */
-	tmp = read_child_data(t, sizeof(child_shmem_fd), args->fdptr);
+	tmp = read_child_data(t, sizeof(child_shmem_fd), (byte*)args->fdptr);
 	child_shmem_fd = *(int*)tmp;
-	sys_free(&tmp);
+	free(tmp);
 
 	/* Zero out the child buffers we use here.  They contain
 	 * "real" fds, which in general will not be the same across
 	 * record/replay. */
 	write_socketcall_args(t, args->args_vec, 0, 0, 0);
-	write_child_data(t, sizeof(zero), args->fdptr, &zero);
+	write_child_data(t, sizeof(zero), (byte*)args->fdptr, (byte*)&zero);
 
 	/* Socket magic is now done. */
 	close(listen_sock);
@@ -2025,13 +1715,13 @@ void* init_syscall_buffer(struct task* t, struct current_state_buffer* state,
 	}
 	t->num_syscallbuf_bytes = args->num_syscallbuf_bytes
 				= SYSCALLBUF_BUFFER_SIZE;
-	child_map_addr = (void*)remote_syscall6(t, state, SYS_mmap2,
+	child_map_addr = (byte*)remote_syscall6(t, state, SYS_mmap2,
 						map_hint,
 						args->num_syscallbuf_bytes,
 						PROT_READ | PROT_WRITE,
 						MAP_SHARED, child_shmem_fd, 0);
 	t->syscallbuf_child = args->syscallbuf_ptr = child_map_addr;
-	t->syscallbuf_hdr = map_addr;
+	t->syscallbuf_hdr = (struct syscallbuf_hdr*)map_addr;
 	/* No entries to begin with. */
 	memset(t->syscallbuf_hdr, 0, sizeof(*t->syscallbuf_hdr));
 
@@ -2044,7 +1734,7 @@ void* init_syscall_buffer(struct task* t, struct current_state_buffer* state,
 void* init_buffers(struct task* t, void* map_hint, int share_desched_fd)
 {
 	struct current_state_buffer state;
-	void* child_args;
+	byte* child_args;
 	struct rrcall_init_buffers_params* args;
 	void* child_map_addr = NULL;
 
@@ -2054,8 +1744,9 @@ void* init_buffers(struct task* t, void* map_hint, int share_desched_fd)
 
 	prepare_remote_syscalls(t, &state);
 	/* Arguments to the rrcall. */
-	child_args = (void*)state.regs.ebx;
-	args = read_child_data(t, sizeof(*args), child_args);
+	child_args = (byte*)state.regs.ebx;
+	args = (struct rrcall_init_buffers_params*)
+	       read_child_data(t, sizeof(*args), child_args);
 
 	args->scratch_ptr = t->scratch_ptr;
 	args->num_scratch_bytes = t->scratch_size;
@@ -2069,8 +1760,8 @@ void* init_buffers(struct task* t, void* map_hint, int share_desched_fd)
 	}
 
 	/* Return the mapped buffers to the child. */
-	write_child_data(t, sizeof(*args), child_args, args);
-	sys_free((void**)&args);
+	write_child_data(t, sizeof(*args), child_args, (byte*)args);
+	free(args);
 
 	/* The tracee doesn't need this addr returned, because it's
 	 * already written to the inout |args| param, but we stash it

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
 #ifndef UTIL_H_
 #define UTIL_H_
@@ -51,8 +51,8 @@ struct mapped_segment_info {
 	 * anywhere. */
 	char name[PATH_MAX];	/* technically PATH_MAX + "deleted",
 				 * but let's not go there. */
-	void* start_addr;
-	void* end_addr;
+	byte* start_addr;
+	byte* end_addr;
 	int prot;
 	int flags;
 	int64_t file_offset;
@@ -73,10 +73,7 @@ const struct flags* rr_flags(void);
 struct flags* rr_flags_for_init(void);
 
 char* get_inst(struct task* t, int eip_offset, int* opcode_size);
-bool is_write_mem_instruction(pid_t pid, int eip_offset, int* opcode_size);
-void emulate_child_inst(struct task * t, int eip_offset);
 void print_inst(struct task* t);
-void print_syscall(struct task *t, struct trace_frame *trace);
 
 /**
  * Return zero if |reg1| matches |reg2|.  Passing EXPECT_MISMATCHES
@@ -88,22 +85,20 @@ void print_syscall(struct task *t, struct trace_frame *trace);
  */
 enum { EXPECT_MISMATCHES = 0, LOG_MISMATCHES, BAIL_ON_MISMATCH };
 int compare_register_files(struct task* t,
-			   char* name1, const struct user_regs_struct* reg1,
-			   char* name2, const struct user_regs_struct* reg2,
+			   const char* name1,
+			   const struct user_regs_struct* reg1,
+			   const char* name2,
+			   const struct user_regs_struct* reg2,
 			   int mismatch_behavior);
 
 void assert_child_regs_are(struct task* t, const struct user_regs_struct* regs, int event, int state);
 uint64_t str2ull(const char* start, size_t max_size);
 long int str2li(const char* start, size_t max_size);
-void * str2x(const char* start, size_t max_size);
-void read_line(FILE* file, char* buf, int size, char* name);
+byte* str2x(const char* start, size_t max_size);
+void read_line(FILE* file, char* buf, int size, const char* name);
 void add_scratch(void *ptr, int size);
-void add_protected_map(struct task *t, void *start);
-bool is_protected_map(struct task *t, void *start);
-void add_sig_handler(pid_t tid, unsigned int signum, struct sigaction * sa);
-struct sigaction * get_sig_handler(pid_t tid, unsigned int signum);
 
-void print_register_file_tid(pid_t tid);
+void print_register_file_tid(struct task* t);
 void print_register_file(struct user_regs_struct* regs);
 
 /**
@@ -115,7 +110,7 @@ void print_register_file(struct user_regs_struct* regs);
  */
 void dump_binary_data(const char* filename, const char* label,
 		      const uint32_t* buf, size_t buf_len,
-		      const char* start_addr);
+		      const byte* start_addr);
 
 /**
  * Format a suitable filename within the trace directory for dumping
@@ -167,7 +162,7 @@ void print_process_mmap(struct task* t);
  * out the segment info to |info| and return nonzero.  Return zero if
  * not found.
  */
-int find_segment_containing(struct task* t, void* search_addr,
+int find_segment_containing(struct task* t, byte* search_addr,
 			    struct mapped_segment_info* info);
 
 /**
@@ -233,11 +228,11 @@ struct current_state_buffer {
 	pid_t pid;
 	struct user_regs_struct regs;
 	int code_size;
-	long* code_buffer;
-	long* start_addr;
+	byte* code_buffer;
+	byte* start_addr;
 };
 
-void mprotect_child_region(struct task * t, void * addr, int prot);
+void mprotect_child_region(struct task* t, byte* addr, int prot);
 
 /**
  * Copy the registers used for syscall arguments (not including
@@ -320,11 +315,11 @@ void prepare_remote_syscalls(struct task* t,
  */
 struct restore_mem {
 	/* Address of tmp mem. */
-	void* addr;
+	byte* addr;
 	/* Pointer to saved data. */
-	void* data;
+	byte* data;
 	/* (We keep this around for error checking.) */
-	void* saved_sp;
+	byte* saved_sp;
 	/* Length of tmp mem. */
 	size_t len;
 };


### PR DESCRIPTION
NB: this commit doesn't attempt rewrite rr in the C++ idiom, it only
prepares the codebase for future evolution to C++.

This commit includes quite a few code changes required for C++ compile
cleanliness.  The changes are mostly mechanical and minor
- using byte\* instead of void\* for pointer arithmetic
- removing sys_malloc and sys_free
- using struct task\* t params consistently instead of pid_t

The latter change allowed removing some redundant code.

In a few places, the edits that would have been required were more
substantial than the effort to wholesale rewrite the code.  So the
code was rewritten.

Resolves #614.
