### PR TITLE
Add tests of (currently) broken mmap semantics.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ set(BASIC_TESTS
   mmap_ro
   mmap_shared
   mmap_tmpfs
+  mmap_write
+  mremap
   perf_event
   prctl
   priority

--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -594,6 +594,8 @@ static void* finish_copied_mmap(Task* t,
 				int prot, int flags,
 				const struct mmapped_file* file)
 {
+	debug("  finishing copied mmap of %s", file->filename);
+
 	void* mapped_addr = finish_anonymous_mmap(t, state, trace, prot,
 						  /* The restored region
 						   * won't be backed by

--- a/src/test/mmap_write.c
+++ b/src/test/mmap_write.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#define DUMMY_FILE "dummy.txt"
+
+static const int magic = 0x5a5a5a5a;
+
+static void overwrite_file(const char* path, ssize_t num_bytes)
+{
+	int fd = open(path, O_TRUNC | O_RDWR, 0600);
+	int i;
+
+	test_assert(fd >= 0);
+	for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+		write(fd, &magic, sizeof(magic));
+	}
+	close(fd);
+}
+
+int main(int argc, char *argv[]) {
+	size_t num_bytes = sysconf(_SC_PAGESIZE);
+	int fd = open(DUMMY_FILE, O_CREAT | O_EXCL | O_RDWR, 0600);
+	int* rpage;
+	int i;
+
+	test_assert(fd >= 0);
+
+	overwrite_file(DUMMY_FILE, num_bytes);
+
+	rpage = mmap(NULL, num_bytes, PROT_READ, MAP_SHARED, fd, 0);
+	atomic_printf("rpage:%p\n", rpage);
+	test_assert(rpage != (void*)-1);
+
+	for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+		test_assert(rpage[i] == magic);
+	}
+
+	lseek(fd, 0, SEEK_SET);
+
+	for (i = 0; i < num_bytes / sizeof(i); ++i) {
+		int written;
+
+		write(fd, &i, sizeof(i));
+		written = rpage[i];
+		atomic_printf("(wrote %d, read %d)", i, written);
+		test_assert(written == i);
+	}
+
+	atomic_puts(" done");
+	return 0;
+}

--- a/src/test/mmap_write.run
+++ b/src/test/mmap_write.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh mmap_write "$@"
+
+fails "write()s to SHARED mapped files aren't propagated to mapping during replay."
+
+compare_test 'done'

--- a/src/test/mremap.c
+++ b/src/test/mremap.c
@@ -1,0 +1,73 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#define DUMMY_FILE "dummy.txt"
+
+static void check_mapping(int* rpage, int* wpage, ssize_t nr_ints)
+{
+	int i;
+	for (i = 0; i < nr_ints; ++i) {
+		test_assert(wpage[i] == rpage[i]);
+
+		wpage[i] = i;
+
+		test_assert(rpage[i] == i && wpage[i] == rpage[i]);
+	}
+	atomic_printf("  %p and %p point at the same resource\n",
+		      rpage, wpage);
+}
+
+static void overwrite_file(const char* path, ssize_t num_bytes)
+{
+	const int magic = 0x5a5a5a5a;
+	int fd = open(path, O_TRUNC | O_RDWR, 0600);
+	int i;
+	for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+		write(fd, &magic, sizeof(magic));
+	}
+	close(fd);
+}
+
+int main(int argc, char *argv[]) {
+	size_t num_bytes = sysconf(_SC_PAGESIZE);
+	int fd = open(DUMMY_FILE, O_CREAT | O_EXCL | O_RDWR, 0600);
+	int* wpage;
+	int* rpage;
+	int* old_wpage;
+
+	test_assert(fd >= 0);
+
+	overwrite_file(DUMMY_FILE, 2 * num_bytes);
+
+	wpage = mmap(NULL, num_bytes, PROT_READ | PROT_WRITE,
+		     MAP_SHARED, fd, 0);
+	rpage = mmap(NULL, num_bytes, PROT_READ,
+		     MAP_SHARED, fd, 0);
+	atomic_printf("wpage:%p rpage:%p\n", wpage, rpage);
+	test_assert(wpage != (void*)-1 && rpage != (void*)-1
+		    && rpage != wpage);
+
+	/* NB: this is a bad test in that it assumes
+	 * ADDR_COMPAT_LAYOUT address-space allocation semantics.  If
+	 * this test is run "normally", it will most likely fail this
+	 * assertion.  To fix this we'd need to dyanmically determine
+	 * which page is mapped just before the other and then remap
+	 * that page. */
+	test_assert((byte*)rpage - (byte*)wpage == num_bytes);
+
+	check_mapping(rpage, wpage, num_bytes / sizeof(*wpage));
+
+	overwrite_file(DUMMY_FILE, 2 * num_bytes);
+
+	old_wpage = wpage;
+	wpage = mremap(old_wpage, num_bytes, 2 * num_bytes, MREMAP_MAYMOVE);
+	atomic_printf("remapped wpage:%p\n", wpage);
+	test_assert(wpage != (void*)-1 && wpage != old_wpage);
+
+	check_mapping(rpage, wpage, num_bytes / sizeof(*wpage));
+
+	atomic_puts(" done");
+
+	return 0;
+}

--- a/src/test/mremap.run
+++ b/src/test/mremap.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh mremap "$@"
+
+fails "Multiple SHARED mappings of the same underlying resource are replayed as multiple anonymous mappings."
+
+compare_test 'done'

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -3,6 +3,8 @@
 #ifndef RRUTIL_H
 #define RRUTIL_H
 
+#define _GNU_SOURCE
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -36,6 +38,8 @@
 #include <unistd.h>
 
 #include <rr/rr.h>
+
+typedef unsigned char byte;
 
 #define test_assert(cond)  assert("FAILED if not: " && (cond))
 


### PR DESCRIPTION
Tests discussed in #629.
