### PR TITLE
Examine mapped files through /proc/fd instead of path name.

### DIFF
--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -109,7 +109,7 @@ struct mmapped_file {
 	 * data? */
 	int copied;
 
-	char filename[1024];
+	char filename[PATH_MAX];
 	struct stat stat;
 
 	/* Bounds of mapped region. */

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -3,6 +3,7 @@
 #ifndef TYPES_H_
 #define TYPES_H_
 
+#include <linux/limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/test/mmap_shared.run
+++ b/src/test/mmap_shared.run
@@ -1,5 +1,5 @@
 source `dirname $0`/util.sh mmap_shared "$@"
 
-fails "rr doesn't handle 'anonymous' shared mappings yet"
+fails "Multiple SHARED mappings of the same underlying resource are replayed as multiple anonymous mappings."
 
 compare_test 'done'


### PR DESCRIPTION
Resolves #448.
