### PR TITLE
Create an emulated fs to enable properly mapping shared segments during ...

### DIFF
--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -22,4 +22,13 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step);
  */
 void rep_maybe_replay_stdio_write(Task* t);
 
+namespace EmuFs {
+/**
+ * Collect emulated files that aren't referenced by tracees.  Call
+ * this only when a tracee (possibly shared) file table has been
+ * destroyed.  All other gc triggers are handled internally.
+ */
+void gc();
+}
+
 #endif /* REP_PROCESS_EVENT_H_ */

--- a/src/replayer/replayer.cc
+++ b/src/replayer/replayer.cc
@@ -1514,7 +1514,7 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 	case USR_UNSTABLE_EXIT:
 		t->unstable = 1;
 		/* fall through */
-	case USR_EXIT:
+	case USR_EXIT: {
 		/* If the task was killed by a terminating signal,
 		 * then it may have ended abruptly in a syscall or at
 		 * some other random execution point.  That's bad for
@@ -1531,9 +1531,15 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 		 * Other terminating signals have not been observed to
 		 * hang, so that's what's used here.. */
 		syscall(SYS_tkill, t->tid, SIGABRT);
+		// TODO dissociate address space from file table
+		bool file_table_dying = (1 == t->vm()->task_set().size());
 		delete t;
 		/* Early-return because |t| is gone now. */
+		if (file_table_dying) {
+			EmuFs::gc();
+		}
 		return;
+	}
 	case USR_ARM_DESCHED:
 	case USR_DISARM_DESCHED:
 		step.action = TSTEP_DESCHED;

--- a/src/test/mmap_shared.c
+++ b/src/test/mmap_shared.c
@@ -22,6 +22,8 @@ int main(int argc, char *argv[]) {
 	test_assert(wpage != (void*)-1 && rpage != (void*)-1
 		    && rpage != wpage);
 
+	close(128);
+
 	for (i = 0; i < num_bytes / sizeof(int); ++i) {
 		wpage[i] = i;
 		test_assert(rpage[i] == i);

--- a/src/test/mmap_shared.run
+++ b/src/test/mmap_shared.run
@@ -1,5 +1,2 @@
 source `dirname $0`/util.sh mmap_shared "$@"
-
-fails "Multiple SHARED mappings of the same underlying resource are replayed as multiple anonymous mappings."
-
 compare_test 'done'


### PR DESCRIPTION
...replay.

Resolves #629.  There's some other bug preventing the `mremap` test from passing, but that doesn't relate to #629.
