### PR TITLE
mremap() is a regular executed syscall.

### DIFF
--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -688,7 +688,7 @@ SYSCALL_DEF(EXEC, mprotect, 0)
  * potentially moving it at the same time (controlled by the flags
  * argument and the available virtual address space).
  */
-SYSCALL_DEF(IRREGULAR, mremap, -1)
+SYSCALL_DEF(EXEC, mremap, 0)
 
 /**
  *  int munmap(void *addr, size_t length)

--- a/src/test/mremap.run
+++ b/src/test/mremap.run
@@ -1,5 +1,2 @@
 source `dirname $0`/util.sh mremap "$@"
-
-fails "Multiple SHARED mappings of the same underlying resource are replayed as multiple anonymous mappings."
-
 compare_test 'done'


### PR DESCRIPTION
Fixes the test failure that #629 was filed for.
