### PR TITLE
Don't buffer madvise(), because it needs to be executed during replay fo...

### DIFF
--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -1328,18 +1328,6 @@ int __lxstat(int vers, const char* path, struct stat* buf)
 	return ret;
 }
 
-int madvise(void* addr, size_t length, int advice)
-{
-	void* ptr = prep_syscall(NO_SIGNAL_SAFETY);
-	long ret;
-
-	if (!start_commit_buffered_syscall(SYS_madvise, ptr, WONT_BLOCK)) {
-		return syscall(SYS_madvise, addr, length, advice);
-	}
-	ret = untraced_syscall3(SYS_madvise, addr, length, advice);
-	return commit_syscall(SYS_madvise, ptr, ret);
-}
-
 int open(const char* pathname, int flags, ...)
 {
 	/* NB: not arming the desched event is technically correct,

--- a/src/test/madvise.run
+++ b/src/test/madvise.run
@@ -1,2 +1,2 @@
-source `dirname $0`/util.sh mmap_private "$@"
+source `dirname $0`/util.sh madvise "$@"
 compare_test 'done'


### PR DESCRIPTION
...r DONTNEED.

Resolves #544.  \o/

Thanks @rocallahan!
