### PR TITLE
Add rr's own locally cached view of processes' address spaces.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,12 +111,16 @@ set(BASIC_TESTS
   io
   link
   madvise
+  map_fixed
+  mmap_discontinuous
   mmap_private
   mmap_ro
   mmap_shared
   mmap_shared_subpage
   mmap_tmpfs
   mmap_write
+  mprotect
+  mprotect_stack
   mremap
   perf_event
   prctl

--- a/src/main.cc
+++ b/src/main.cc
@@ -309,6 +309,7 @@ static void print_usage(void)
 "                             always allow emergency debugging, even\n"
 "                             when it doesn't seem like a good idea, for\n"
 "                             example if stderr isn't a tty.\n"
+"  -k, --check-cached-mmaps   verify that cached task mmaps match /proc/maps\n"
 "  -m, --mark-stdio           mark stdio writes with [rr.<EVENT-NO>],\n"
 "                             where EVENT-NO is the global trace time at\n"
 "                             which the write occures.\n"
@@ -443,6 +444,7 @@ static int parse_common_args(int argc, char** argv, struct flags* flags)
 {
 	struct option opts[] = {
 		{ "checksum", required_argument, NULL, 'c' },
+		{ "check-cached-mmaps", no_argument, NULL, 'k' },
 		{ "cpu-unbound", no_argument, NULL, 'u' },
 		{ "dump-at", required_argument, NULL, 't' },
 		{ "dump-on", required_argument, NULL, 'd' },
@@ -454,7 +456,7 @@ static int parse_common_args(int argc, char** argv, struct flags* flags)
 	};
 	while (1) {
 		int i = 0;
-		switch (getopt_long(argc, argv, "+c:d:fmt:uvw:", opts, &i)) {
+		switch (getopt_long(argc, argv, "+c:d:fkmt:uvw:", opts, &i)) {
 		case -1:
 			return optind;
 		case 'c':
@@ -475,19 +477,22 @@ static int parse_common_args(int argc, char** argv, struct flags* flags)
 			flags->dump_on = atoi(optarg);
 			break;
 		case 'f':
-			flags->force_enable_debugger = 1;
+			flags->force_enable_debugger = true;
+			break;
+		case 'k':
+			flags->check_cached_mmaps = true;
 			break;
 		case 'm':
-			flags->mark_stdio = 1;
+			flags->mark_stdio = true;
 			break;
 		case 't':
 			flags->dump_at = atoi(optarg);
 			break;
 		case 'u':
-			flags->cpu_unbound = 1;
+			flags->cpu_unbound = true;
 			break;
 		case 'v':
-			flags->verbose = 1;
+			flags->verbose = true;
 			break;
 		case 'w':
 			flags->wait_secs = atoi(optarg);

--- a/src/replayer/replayer.cc
+++ b/src/replayer/replayer.cc
@@ -1639,6 +1639,11 @@ static void replay_one_trace_frame(struct dbg_context* dbg,
 		assert(dbg_is_resume_request(&req));
 	}
 
+	if (STATE_SYSCALL_EXIT == t->trace.state
+	    && rr_flags()->check_cached_mmaps) {
+		t->vm()->verify(t);
+	}
+
 	if (dbg && stop_sig) {
 		dbg_notify_stop(dbg, get_threadid(t), stop_sig);
 	}

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -14,7 +14,6 @@
 #define __unused __attribute__((unused))
 
 #define CHECK_ALIGNMENT(addr) 	assert(((long int)(addr) & 0x3) == 0)
-#define PAGE_ALIGN(length)		((length + PAGE_SIZE - 1) & PAGE_MASK)
 
 #define PTR_SIZE		(sizeof(void*))
 #define INT_SIZE		(sizeof(int))
@@ -76,6 +75,8 @@ struct flags {
 	/* Mark the trace global time along with tracee writes to
 	 * stdio. */
 	bool mark_stdio;
+	// Check that cached mmaps match /proc/maps after each event.
+	bool check_cached_mmaps;
 };
 
 struct msghdr;

--- a/src/test/map_fixed.c
+++ b/src/test/map_fixed.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	size_t page_size = sysconf(_SC_PAGESIZE);
+	byte* map1 = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+			  MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	byte* map1_end = map1 + page_size;
+	byte* map2;
+
+	test_assert(map1 != (void*)-1);
+
+	map2 = mmap(map1_end, page_size, PROT_READ | PROT_WRITE,
+		    MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	test_assert(map2 != (void*)-1);
+	test_assert(map2 == map1_end);
+
+	atomic_puts(" done");
+
+	return 0;
+}

--- a/src/test/map_fixed.run
+++ b/src/test/map_fixed.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh map_fixed "$@"
+compare_test 'done'

--- a/src/test/mmap_discontinuous.c
+++ b/src/test/mmap_discontinuous.c
@@ -1,0 +1,49 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static int create_segment(size_t num_bytes) {
+	char filename[] = "/dev/shm/rr-test-XXXXXX";
+	int fd = mkstemp(filename);
+	unlink(filename);
+	test_assert(fd >= 0);
+	ftruncate(fd, num_bytes);
+	return fd;
+}
+
+int main(int argc, char *argv[]) {
+	size_t page_size = sysconf(_SC_PAGESIZE);
+	int fd = create_segment(3 * page_size);
+
+	byte* wpage1 = mmap(NULL, page_size, PROT_WRITE, MAP_SHARED, fd,
+			    0);
+	byte* wpage2 = mmap(NULL, page_size, PROT_WRITE, MAP_SHARED, fd,
+			    2 * page_size);
+
+	test_assert(wpage1 != (void*)-1 && wpage2 != (void*)-1);
+	test_assert(wpage1 != wpage2);
+	test_assert(wpage2 - wpage1 == page_size
+		    || wpage1 - wpage2 == page_size);
+
+	wpage1 = mmap(NULL, page_size, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
+		      -1, 0);
+	wpage2 = mmap(NULL, page_size, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
+		      -1, 2 * page_size);
+
+	test_assert(wpage1 != (void*)-1 && wpage2 != (void*)-1);
+	test_assert(wpage1 != wpage2);
+	test_assert(wpage2 - wpage1 == page_size
+		    || wpage1 - wpage2 == page_size);
+
+#if 0
+	{
+		char cmd[4096];
+		snprintf(cmd, sizeof(cmd) - 1, "cat /proc/%d/maps", getpid());
+		system(cmd);
+	}
+#endif
+
+	atomic_puts(" done");
+
+	return 0;
+}

--- a/src/test/mmap_discontinuous.run
+++ b/src/test/mmap_discontinuous.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh mmap_shared "$@"
+compare_test 'done'

--- a/src/test/mprotect.c
+++ b/src/test/mprotect.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	size_t page_size = sysconf(_SC_PAGESIZE);
+	byte* map1 = mmap(NULL, 2 * page_size, PROT_READ | PROT_WRITE,
+			 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	byte* map1_end = map1 + 2 * page_size;
+	byte* map2;
+	byte* map2_end;
+
+	test_assert(map1 != (void*)-1);
+
+	atomic_printf("map1 = [%p, %p)\n", map1, map1_end);
+
+	mprotect(map1 + page_size, page_size, PROT_NONE);
+
+	map2 = mmap(map1_end, 2 * page_size, PROT_READ | PROT_WRITE,
+		    MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	map2_end = map2 + page_size;
+	test_assert(map2 != (void*)-1);
+	test_assert(map2 == map1_end);
+
+	atomic_printf("map2 = [%p, %p)\n", map2, map2_end);
+
+	mprotect(map2, page_size, PROT_NONE);
+
+	atomic_puts(" done");
+
+	return 0;
+}

--- a/src/test/mprotect.run
+++ b/src/test/mprotect.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh mprotect "$@"
+compare_test 'done'

--- a/src/test/mprotect_stack.c
+++ b/src/test/mprotect_stack.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	size_t page_size = sysconf(_SC_PAGESIZE);
+	byte* map1 = mmap(NULL, 2 * page_size, PROT_READ | PROT_WRITE,
+			 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	byte* map1_end = map1 + 2 * page_size;
+	byte* map2;
+	byte* map2_end;
+
+	test_assert(map1 != (void*)-1);
+
+	atomic_printf("map1 = [%p, %p)\n", map1, map1_end);
+
+	mprotect(map1 + page_size, page_size, PROT_NONE);
+
+	map2 = mmap(map1_end, 2 * page_size, PROT_READ | PROT_WRITE,
+		    MAP_STACK | MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	map2_end = map2 + page_size;
+	test_assert(map2 != (void*)-1);
+	test_assert(map2 == map1_end);
+
+	atomic_printf("map2 = [%p, %p)\n", map2, map2_end);
+
+	mprotect(map2, page_size, PROT_NONE);
+
+	atomic_puts(" done");
+
+	return 0;
+}

--- a/src/test/mprotect_stack.run
+++ b/src/test/mprotect_stack.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh mprotect_stack "$@"
+compare_test 'done'

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -75,7 +75,7 @@ function usage {
 # do that, the tests take impractically long to run.
 #
 # TODO: find a way to run faster with CPU binding
-GLOBAL_OPTIONS=-u
+GLOBAL_OPTIONS="-u --check-cached-mmaps"
 
 TESTNAME=$1
 LIB_ARG=$2


### PR DESCRIPTION
This commit adds a cached address space structure and updates it per
syscalls that affect memory mappings: mmap/mremap/unmap/et al.  The
patch is straightforward except for the |is_adjacent_mapping()| helper
which decides if two mappings should be merged.  The subtlety in that
helper is that the heuristics were chosen so that the cached map and
the kernel's (/proc/[tid]/maps) maintain a bijection, for simplicity.

Also added is a new "-k/--check-cached-maps" flag, which has rr assert
that its locally cached map matches /proc/[tid]/maps after each
syscall.  This flag is now enabled for all unit tests and should
default on for future DEBUG builds.

r?/f? @rocallahan, however in depth you want to look.
