### PR TITLE
Add a start_debug_server() to directly open a connection, bypassing inte...

### DIFF
--- a/src/replayer/dbg_gdb.cc
+++ b/src/replayer/dbg_gdb.cc
@@ -70,6 +70,7 @@ bool dbg_is_resume_request(const struct dbg_request* req)
 	switch (req->type) {
 	case DREQ_CONTINUE:
 	case DREQ_STEP:
+	case DREQ_DETACH:
 		return true;
 	default:
 		return false;
@@ -648,9 +649,10 @@ static int process_packet(struct dbg_context* dbg)
 		ret = 1;
 		break;
 	case 'D':
-		log_info("gdb is detaching from us, exiting");
-		write_packet(dbg, "OK");
-		exit(0);
+		log_info("gdb is detaching from us");
+		dbg->req.type = DREQ_DETACH;
+		ret = 1;
+		break;
 	case 'g':
 		dbg->req.type = DREQ_GET_REGS;
 		dbg->req.target = dbg->query_thread;

--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -93,6 +93,9 @@ enum DbgRequestType{
 	DREQ_CONTINUE,
 	DREQ_INTERRUPT,
 	DREQ_STEP,
+
+	/* gdb host detaching from stub.  No parameters. */
+	DREQ_DETACH,
 };
 
 /**

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -20,6 +20,17 @@ void replay(void);
 void emergency_debug(Task* t);
 
 /**
+ * Start a debugging connection for |t| and return when there are no
+ * more requests to process (usually because the debugger detaches).
+ *
+ * Unlike |emergency_debug()|, this helper doesn't attempt to
+ * determine whether blocking rr on a debugger connection might be a
+ * bad idea.  It will always open the debug socket and block awaiting
+ * a connection.
+ */
+void start_debug_server(Task* t);
+
+/**
  * The state of a (dis)arm-desched-event ioctl that's being processed.
  */
 enum RepDeschedType { DESCHED_ARM, DESCHED_DISARM };


### PR DESCRIPTION
...ractive-session checks.

Helping out with #660.
