### PR TITLE
Fix broken FUTEX_LOCK_PI semantics.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(BASIC_TESTS
   mprotect
   mprotect_stack
   mremap
+  mutex_pi_stress
   nanosleep
   perf_event
   prctl

--- a/src/recorder/rec_process_event.h
+++ b/src/recorder/rec_process_event.h
@@ -9,8 +9,13 @@
 /**
  * Prepare |t| to enter its current syscall event.  Return nonzero if
  * a context-switch is allowed for |t|, 0 if not.
+ *
+ * Set |*kernel_sync_addr| to non-NULL to force waiting on that memory
+ * cell in the child's address space to become |sync_val|.  This is an
+ * overly general mechanism that's used for FUTEX_LOCK_PI.  If you're
+ * not FUTEX_LOCK_PI, you probably shouldn't be using this.
  */
-int rec_prepare_syscall(Task* t);
+int rec_prepare_syscall(Task* t, byte** kernel_sync_addr, long* sync_val);
 /**
  * Prepare |t| for its current syscall event to be interrupted and
  * possibly restarted.

--- a/src/share/task.cc
+++ b/src/share/task.cc
@@ -1020,6 +1020,18 @@ Task::post_exec()
 	prname = prname_from_exe_image(as->exe_image());
 }
 
+long
+Task::read_word(byte* child_addr)
+{
+	off_t offset = reinterpret_cast<off_t>(child_addr);
+	long v;
+	ssize_t nread = pread(child_mem_fd, &v, sizeof(v), offset);
+	assert_exec(this, sizeof(v) == nread,
+		    "Expected to read %d bytes at %p, but only read %d",
+		    sizeof(v), child_addr, nread);
+	return v;
+}
+
 void
 Task::set_signal_disposition(int sig, const struct kernel_sigaction& sa)
 {
@@ -1054,6 +1066,16 @@ Task::update_prname(byte* child_addr)
 	name[15] = '\0';
 	prname = name;
 	free(name);
+}
+
+void
+Task::write_word(byte* child_addr, long word)
+{
+	off_t offset = reinterpret_cast<off_t>(child_addr);
+	ssize_t nwritten = pwrite(child_mem_fd, &word, sizeof(word), offset);
+	assert_exec(this, sizeof(word) == nwritten,
+		    "Expected to write %d bytes at %p, but only wrote %d",
+		    sizeof(word), child_addr, nwritten);
 }
 
 /*static*/ Task::Map::const_iterator

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -829,6 +829,14 @@ public:
 	void post_exec();
 
 	/**
+	 * Return the word at |child_addr| in this address space.
+	 *
+	 * NB: doesn't use the ptrace API, so safe to use even when
+	 * the tracee isn't at a trace-stop.
+	 */
+	long read_word(byte* child_addr);
+
+	/**
 	 * Set the disposition and resethand semantics of |sig| to
 	 * |sa|, overwriting whatever may already be there.
 	 */
@@ -866,6 +874,14 @@ public:
 	 * task.
 	 */
 	AddressSpace::shr_ptr vm() { return as; }
+
+	/**
+	 * Write |word| to |child_addr| in this address space.
+	 *
+	 * NB: doesn't use the ptrace API, so safe to use even when
+	 * the tracee isn't at a trace-stop.
+	 */
+	void write_word(byte* child_addr, long word);
 
 	/** Return an iterator at the beginning of the task map. */
 	static Task::Map::const_iterator begin();

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -363,6 +363,15 @@ int is_syscall_restart(Task* t, int syscallno,
 		       const struct user_regs_struct* regs);
 
 /**
+ * Return true if a FUTEX_LOCK_PI operation on |futex| done by |t|
+ * will transition the futex into the contended state.  (This results
+ * in the kernel atomically setting the FUTEX_WAITERS bit on the futex
+ * value.)  The new value of the futex after the kernel updates it is
+ * returned in |next_val|.
+ */
+bool is_now_contended_pi_futex(Task* t, byte* futex, long* next_val);
+
+/**
  * Return nonzero if a mapping of |filename| with metadata |stat|,
  * using |flags| and |prot|, should almost certainly be copied to
  * trace; i.e., the file contents are likely to change in the interval

--- a/src/test/mutex_pi_stress.c
+++ b/src/test/mutex_pi_stress.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+#define NUM_THREADS 10
+#define NUM_TRIALS 1000
+
+static pthread_mutex_t lock;
+
+static void* thread(void* idp) {
+	int tid = (intptr_t)idp;
+	int i;
+
+	atomic_printf("thread %d starting ...\n", tid);
+	for (i = 0; i < NUM_TRIALS; ++i) {
+		pthread_mutex_lock(&lock);
+		sched_yield();
+		pthread_mutex_unlock(&lock);
+	}
+	atomic_printf("  ... thread %d done.\n", tid);
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	pthread_mutexattr_t attr;
+	pthread_t threads[NUM_THREADS];
+	int i;
+
+	pthread_mutexattr_init(&attr);
+	test_assert(0 == pthread_mutexattr_setprotocol(&attr,
+						       PTHREAD_PRIO_INHERIT));
+	test_assert(0 == pthread_mutex_init(&lock, &attr));
+
+	for (i = 0; i < NUM_THREADS; ++i) {
+		test_assert(0 == pthread_create(&threads[i], NULL,
+						thread, (void*)(intptr_t)i));
+	}
+	for (i = 0; i < NUM_THREADS; ++i) {
+		test_assert(0 == pthread_join(threads[i], NULL));
+	}
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/mutex_pi_stress.run
+++ b/src/test/mutex_pi_stress.run
@@ -1,0 +1,5 @@
+# Switch threads very eagerly on recorded events.
+RECORD_ARGS="-e1"
+
+source `dirname $0`/util.sh mutex_pi_stress "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #552.  Resolves #576.

@rocallahan if you don't mind, I could use another pair of eyes on the pseudo-proof that this approach is correct in the long comment in rec_process_event.cc.  (The rest of the patch is pretty straightforward.)
