### PR TITLE
Warn the user when a tracee process is cut down by a fatal signal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(BASIC_TESTS
   clock
   clone
   condvar_stress
+  crash
   exit_group
   fadvise
   flock

--- a/src/recorder/recorder.cc
+++ b/src/recorder/recorder.cc
@@ -635,68 +635,6 @@ static void runnable_state_changed(Task* t)
 	maybe_reset_syscallbuf(t);
 }
 
-enum { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
-static int default_action(int sig)
-{
-	if (SIGRTMIN <= sig && sig <= SIGRTMAX) {
-		return TERMINATE;
-	}
-	switch (sig) {
-		/* TODO: SSoT for signal defs/semantics. */
-#define CASE(_sig, _act) case SIG## _sig: return _act
-	CASE(HUP, TERMINATE);
-	CASE(INT, TERMINATE);
-	CASE(QUIT, DUMP_CORE);
-	CASE(ILL, DUMP_CORE);
-	CASE(ABRT, DUMP_CORE);
-	CASE(FPE, DUMP_CORE);
-	CASE(KILL, TERMINATE);
-	CASE(SEGV, DUMP_CORE);
-	CASE(PIPE, TERMINATE);
-	CASE(ALRM, TERMINATE);
-	CASE(TERM, TERMINATE);
-	CASE(USR1, TERMINATE);
-	CASE(USR2, TERMINATE);
-	CASE(CHLD, IGNORE);
-	CASE(CONT, CONTINUE);
-	CASE(STOP, STOP);
-	CASE(TSTP, STOP);
-	CASE(TTIN, STOP);
-	CASE(TTOU, STOP);
-	CASE(BUS, DUMP_CORE);
-	/*CASE(POLL, TERMINATE);*/
-	CASE(PROF, TERMINATE);
-	CASE(SYS, DUMP_CORE);
-	CASE(TRAP, DUMP_CORE);
-	CASE(URG, IGNORE);
-	CASE(VTALRM, TERMINATE);
-	CASE(XCPU, DUMP_CORE);
-	CASE(XFSZ, DUMP_CORE);
-	/*CASE(IOT, DUMP_CORE);*/
-	/*CASE(EMT, TERMINATE);*/
-	CASE(STKFLT, TERMINATE);
-	CASE(IO, TERMINATE);
-	CASE(PWR, TERMINATE);
-	/*CASE(LOST, TERMINATE);*/
-	CASE(WINCH, IGNORE);
-	default:
-		fatal("Unknown signal %d", sig);
-#undef CASE
-	}
-}
-
-/**
- * Return nonzero if |sig| may cause the status of other tasks to
- * change unpredictably beyond rr's observation.
- */
-static int possibly_destabilizing_signal(int sig)
-{
-	/* XXX: this heuristic is based only on the fact that it works
-	 * with SIGABRT and SIGTERM.  Deeper answers are almost
-	 * certainly available in the kernel source. */
-	return DUMP_CORE == default_action(sig);
-}
-
 /**
  * |t| is delivering a signal, and its state changed.  |by_waitpid| is
  * nonzero if the status change was observed by a waitpid() call.

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -1103,6 +1103,7 @@ void pop_pseudosig(Task* t);
  * and |deterministic| is nonzero for deterministically-delivered
  * signals (see handle_signal.c).
  */
+enum { NONDETERMINISTIC_SIG = 0, DETERMINISTIC_SIG = 1 };
 void push_pending_signal(Task* t, int no, int deterministic);
 void pop_signal_delivery(Task* t);
 void pop_signal_handler(Task* t);

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1220,6 +1220,64 @@ bool is_now_contended_pi_futex(Task* t, byte* futex, long* next_val)
 	return now_contended;
 }
 
+enum { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
+static int default_action(int sig)
+{
+	if (SIGRTMIN <= sig && sig <= SIGRTMAX) {
+		return TERMINATE;
+	}
+	switch (sig) {
+		/* TODO: SSoT for signal defs/semantics. */
+#define CASE(_sig, _act) case SIG## _sig: return _act
+	CASE(HUP, TERMINATE);
+	CASE(INT, TERMINATE);
+	CASE(QUIT, DUMP_CORE);
+	CASE(ILL, DUMP_CORE);
+	CASE(ABRT, DUMP_CORE);
+	CASE(FPE, DUMP_CORE);
+	CASE(KILL, TERMINATE);
+	CASE(SEGV, DUMP_CORE);
+	CASE(PIPE, TERMINATE);
+	CASE(ALRM, TERMINATE);
+	CASE(TERM, TERMINATE);
+	CASE(USR1, TERMINATE);
+	CASE(USR2, TERMINATE);
+	CASE(CHLD, IGNORE);
+	CASE(CONT, CONTINUE);
+	CASE(STOP, STOP);
+	CASE(TSTP, STOP);
+	CASE(TTIN, STOP);
+	CASE(TTOU, STOP);
+	CASE(BUS, DUMP_CORE);
+	/*CASE(POLL, TERMINATE);*/
+	CASE(PROF, TERMINATE);
+	CASE(SYS, DUMP_CORE);
+	CASE(TRAP, DUMP_CORE);
+	CASE(URG, IGNORE);
+	CASE(VTALRM, TERMINATE);
+	CASE(XCPU, DUMP_CORE);
+	CASE(XFSZ, DUMP_CORE);
+	/*CASE(IOT, DUMP_CORE);*/
+	/*CASE(EMT, TERMINATE);*/
+	CASE(STKFLT, TERMINATE);
+	CASE(IO, TERMINATE);
+	CASE(PWR, TERMINATE);
+	/*CASE(LOST, TERMINATE);*/
+	CASE(WINCH, IGNORE);
+	default:
+		fatal("Unknown signal %d", sig);
+#undef CASE
+	}
+}
+
+bool possibly_destabilizing_signal(int sig)
+{
+	// XXX: this heuristic is based only on the fact that it works
+	// with SIGABRT and SIGTERM.  Deeper answers are almost
+	// certainly available in the kernel source.
+	return DUMP_CORE == default_action(sig);
+}
+
 static bool has_fs_name(const char* path)
 {
 	struct stat dummy;

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -372,6 +372,12 @@ int is_syscall_restart(Task* t, int syscallno,
 bool is_now_contended_pi_futex(Task* t, byte* futex, long* next_val);
 
 /**
+ * Return true if |sig| may cause the status of other tasks to change
+ * unpredictably beyond rr's observation.
+ */
+bool possibly_destabilizing_signal(int sig);
+
+/**
  * Return nonzero if a mapping of |filename| with metadata |stat|,
  * using |flags| and |prot|, should almost certainly be copied to
  * trace; i.e., the file contents are likely to change in the interval

--- a/src/test/crash.c
+++ b/src/test/crash.c
@@ -1,0 +1,10 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	volatile int* p = NULL;
+	*p = 42;
+	test_assert("Not reached" && 0);
+	return 0;
+}

--- a/src/test/crash.run
+++ b/src/test/crash.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh crash "$@"
+
+record crash
+replay
+check ''


### PR DESCRIPTION
Resolves #654.
