### PR TITLE
Print a more informative error message when an x64 image is seen.

### DIFF
--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -843,6 +843,8 @@ static void process_execve(Task* t,
 		return;
 	}
 
+	t->post_exec();
+
 	long* stack_ptr = (long*)regs.esp;
 
 	/* start_stack points to argc - iterate over argv pointers */
@@ -901,8 +903,6 @@ static void process_execve(Task* t,
 	record_child_data(t, 16, rand_addr);
 
 	init_scratch_memory(t);
-
-	t->post_exec();
 }
 
 static void process_ipc(Task* t,


### PR DESCRIPTION
Resolves #34.
