### PR TITLE
Restore syscallbuf record data one record at a time.

### DIFF
--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -1563,6 +1563,11 @@ void rec_process_syscall(Task *t)
 					  (byte*)regs.edx);
 			break;
 
+		case F_GETOWN_EX:
+			record_child_data(t, sizeof(struct f_owner_ex),
+					  (byte*)regs.edx);
+			break;
+
 		default:
 			fatal("Unknown fcntl %d", cmd);
 		}

--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -1453,6 +1453,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 			case F_SETLKW64:
 			case F_GETLK:
 			case F_GETLK64:
+			case F_GETOWN_EX:
 				step->syscall.num_emu_args = 1;
 				break;
 			default:

--- a/src/replayer/replayer.h
+++ b/src/replayer/replayer.h
@@ -59,8 +59,11 @@ struct rep_flush_state {
 	/* After the data is restored, the number of record bytes that
 	 * still need to be flushed. */
 	size_t num_rec_bytes_remaining;
-	/* The record we're currently replaying. */
-	const struct syscallbuf_record* rec;
+	/* The syscallbuf record that was saved to trace.  This is
+	 * what we'll use to restore |child_rec| below. */
+	const struct syscallbuf_record* rec_rec;
+	/* Pointer to the tracee's next syscallbuf record to replay. */
+	struct syscallbuf_record* child_rec;
 	/* The next step to take. */
 	RepFlushState state;
 	/* Track the state of retiring desched arm/disarm ioctls, when

--- a/src/test/fcntl_owner_ex.run
+++ b/src/test/fcntl_owner_ex.run
@@ -1,5 +1,2 @@
 source `dirname $0`/util.sh fcntl_owner_ex "$@"
-
-fails "syscalbuffer mis-replays syscalls with inoutparams."
-
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #526.  Resolves #525.

Not very exciting in and of itself, but lays the groundwork for a relatively trivial patch to buffer poll().
