### PR TITLE
Add a helper that can make a (traced) 6-arg syscall.

### DIFF
--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -39,11 +39,19 @@ extern "C" {
 	 && (uintptr_t)(_eip) <= (uintptr_t)(_t)->syscallbuf_lib_end)
 
 /**
- * True when |_eip| is at a buffered syscall, i.e. one initiated by a
- * libc wrapper in the library.  Callers may assume
- * |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
+ * True when |_eip| is at a traced syscall made by the syscallbuf
+ * code.  Callers may assume |SYSCALLBUF_IS_IP_IN_LIB()| is implied by
+ * this.
  */
-#define SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(_eip, _t)			\
+#define SYSCALLBUF_IS_IP_TRACED_SYSCALL(_eip, _t)			\
+	((uintptr_t)(_eip) == (uintptr_t)(_t)->traced_syscall_ip)	\
+
+/**
+ * True when |_eip| is at a buffered (and therefore untraced) syscall,
+ * i.e. one initiated by a libc wrapper in the library.  Callers may
+ * assume |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
+ */
+#define SYSCALLBUF_IS_IP_UNTRACED_SYSCALL(_eip, _t)			\
 	((uintptr_t)(_eip) == (uintptr_t)(_t)->untraced_syscall_ip)	\
 
 /* "Magic" (rr-implemented) syscall that we use to initialize the
@@ -71,8 +79,9 @@ struct rrcall_init_buffers_params {
 	 * We let the syscallbuf code decide in order to more simply
 	 * replay the same decision that was recorded. */
 	int syscallbuf_enabled;
-	/* Lets rr know where our untraced syscalls will originate
-	 * from. */
+	/* Where our traced syscalls will originate. */
+	byte* traced_syscall_ip;
+	/* Where our untraced syscalls will originate. */
 	byte* untraced_syscall_ip;
 	/* Address of the control socket the child expects to connect
 	 * to. */

--- a/src/recorder/handle_signal.cc
+++ b/src/recorder/handle_signal.cc
@@ -516,7 +516,11 @@ static int go_to_a_happy_place(Task* t,
 			debug("  tracee outside syscallbuf lib");
 			goto happy_place;
 		}
-		if (SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(regs->eip, t)
+		if (SYSCALLBUF_IS_IP_TRACED_SYSCALL(regs->eip, t)) {
+			debug("  tracee at traced syscallbuf syscall");
+			goto happy_place;
+		}
+		if (SYSCALLBUF_IS_IP_UNTRACED_SYSCALL(regs->eip, t)
 		    && t->desched_rec()) {
 			debug("  tracee interrupted by desched of %s",
 			      syscallname(t->desched_rec()->syscallno));
@@ -558,10 +562,11 @@ static int go_to_a_happy_place(Task* t,
 				return -1;
 			}
 
-			fatal("TODO: support multiple pending signals; received %s (code: %d) at $ip:%p while trying to deliver %s (code: %d)",
-			      signalname(tmp_si.si_signo), tmp_si.si_code,
-			      (void*)regs->eip,
-			      signalname(si->si_signo), si->si_code);
+			assert_exec(t, 0,
+				    "TODO: support multiple pending signals; received %s (code: %d) at $ip:%p while trying to deliver %s (code: %d)",
+				    signalname(tmp_si.si_signo),
+				    tmp_si.si_code, (void*)regs->eip,
+				    signalname(si->si_signo), si->si_code);
 		}
 		if (!is_syscall) {
 			continue;

--- a/src/recorder/rec_sched.cc
+++ b/src/recorder/rec_sched.cc
@@ -195,7 +195,8 @@ Task* rec_sched_get_active_thread(Task* t, int* by_waitpid)
 				debug("    ... but it's dead");
 			}
 		}
-		assert(next->unstable || next->may_be_blocked());
+		assert_exec(next, next->unstable || next->may_be_blocked(),
+			    "Scheduled task should have been blocked or unstable");
 		next->status = status;
 		*by_waitpid = 1;
 	}

--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -534,7 +534,7 @@ static void init_scratch_memory(Task* t)
 static void maybe_noop_restore_syscallbuf_scratch(Task* t)
 {
 	read_child_registers(t, &t->regs);
-	if (SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(t->regs.eip, t)) {
+	if (SYSCALLBUF_IS_IP_UNTRACED_SYSCALL(t->regs.eip, t)) {
 		debug("  noop-restoring scratch for write-only desched'd %s",
 		      syscallname(t->regs.orig_eax));
 		set_child_data(t);

--- a/src/replayer/replayer.cc
+++ b/src/replayer/replayer.cc
@@ -1309,7 +1309,7 @@ static void assert_at_buffered_syscall(Task* t,
 {
 	void* ip = (void*)regs->eip;
 
-	assert_exec(t, SYSCALLBUF_IS_IP_BUFFERED_SYSCALL(ip, t),
+	assert_exec(t, SYSCALLBUF_IS_IP_UNTRACED_SYSCALL(ip, t),
 		    "Bad ip %p: should have been buffered-syscall ip", ip);
 	assert_exec(t, regs->orig_eax == syscallno,
 		    "At %s; should have been at %s(%d)",

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -1091,6 +1091,9 @@ public:
 	pid_t rec_tid;
 	int child_mem_fd;
 
+	/* The instruction pointer from which traced syscalls made by
+	 * the syscallbuf will originate. */
+	byte* traced_syscall_ip;
 	/* The instruction pointer from which untraced syscalls will
 	 * originate, used to determine whether a syscall is being
 	 * made by the syscallbuf wrappers or not. */

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1661,6 +1661,7 @@ static void* init_syscall_buffer(Task* t, struct current_state_buffer* state,
 	void* tmp;
 	int zero = 0;
 
+	t->traced_syscall_ip = args->traced_syscall_ip;
 	t->untraced_syscall_ip = args->untraced_syscall_ip;
 	format_syscallbuf_shmem_path(tid, shmem_name);
 	/* NB: the sockaddr prepared by the child uses the recorded


### PR DESCRIPTION
Mostly straightforward except
- We previously relied on traced syscalls being made from libc
  (i.e. outside the syscallbuf lib) when stepping to deliver signals.
  Now they won't be, so we have to explicitly recognize traced
  syscalls.  (This is arguably better for clarity.)
- It's imperative for debugging that users can see backtraces from
  traced (and untraced) syscalls.  So CFI directives had to be added
  to the new _raw_traced_syscall() helper, shamelessly cadged from
  hand-written glibc assembly.

Resolves #687.
