### PR TITLE
Patch the vdso __kernel_vsyscall() to jump into librrpreload.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -8,6 +8,7 @@
 #include <sys/prctl.h>
 
 #include <limits>
+#include <string>
 
 #include "preload/syscall_buffer.h"
 #include "recorder/recorder.h"
@@ -17,6 +18,8 @@
 #include "share/dbg.h"
 #include "share/hpc.h"
 #include "share/sys.h"
+#include "share/task.h"
+#include "share/trace.h"
 #include "share/util.h"
 
 using namespace std;
@@ -384,6 +387,7 @@ static int parse_replay_args(int cmdi, int argc, char** argv,
 			     struct flags* flags)
 {
 	struct option opts[] = {
+		{ "autopilot", no_argument, NULL, 'a' },
 		{ "dbgport", required_argument, NULL, 'p' },
 		{ "goto", required_argument, NULL, 'g' },
 		{ "no-redirect-output", no_argument, NULL, 'q' },

--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -29,6 +29,8 @@ extern "C" {
 /* Set this env var to enable syscall buffering. */
 #define SYSCALLBUF_ENABLED_ENV_VAR "_RR_USE_SYSCALLBUF"
 
+/* TODO: convert the following macros into task.h helpers. */
+
 /**
  * True if |_eip| is an $ip within the syscallbuf library.  This *does
  * not* imply that $ip is at a buffered syscall; use the macro below
@@ -37,6 +39,17 @@ extern "C" {
 #define SYSCALLBUF_IS_IP_IN_LIB(_eip, _t)				\
 	((uintptr_t)(_t)->syscallbuf_lib_start <= (uintptr_t)(_eip)	\
 	 && (uintptr_t)(_eip) <= (uintptr_t)(_t)->syscallbuf_lib_end)
+
+/**
+ * True when |_eip| is just before a syscall trap instruction for a
+ * traced syscall made by the syscallbuf code.  Callers may assume
+ * |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
+ *
+ * |int $0x80| is |5d 80|, so the magic-looking |2| below is
+ * |sizeof(int $0x80)|.
+ */
+#define SYSCALLBUF_IS_IP_ENTERING_TRACED_SYSCALL(_eip, _t)		\
+	((uintptr_t)(_eip) + 2 == (uintptr_t)(_t)->traced_syscall_ip)	\
 
 /**
  * True when |_eip| is at a traced syscall made by the syscallbuf
@@ -64,7 +77,9 @@ extern "C" {
 #define FIRST_RRCALL 400
 
 #define __NR_rrcall_init_buffers 442
+#define __NR_rrcall_monkeypatch_vdso 443
 #define SYS_rrcall_init_buffers __NR_rrcall_init_buffers
+#define SYS_rrcall_monkeypatch_vdso __NR_rrcall_monkeypatch_vdso
 
 typedef unsigned char byte;
 

--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -3128,6 +3128,10 @@ void rec_process_syscall(Task *t)
 		init_buffers(t, NULL, SHARE_DESCHED_EVENT_FD);
 		break;
 
+	case SYS_rrcall_monkeypatch_vdso:
+		monkeypatch_vdso(t);
+		break;
+
 	default:
 		print_register_file_tid(t);
 		fatal("Unknown syscall %s(%d)", syscallname(syscall), syscall);

--- a/src/recorder/recorder.cc
+++ b/src/recorder/recorder.cc
@@ -456,6 +456,7 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 		assert_exec(t, (-ENOSYS != retval
 				|| (0 > syscallno
 				    || SYS_rrcall_init_buffers == t->event
+				    || SYS_rrcall_monkeypatch_vdso == t->event
 				    || SYS_clone == syscallno
 				    || SYS_exit_group == syscallno
 				    || SYS_exit == syscallno)),

--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -1573,6 +1573,20 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 	case SYS_rrcall_init_buffers:
 		return process_init_buffers(t, state, step);
 
+	case SYS_rrcall_monkeypatch_vdso:
+		step->syscall.num_emu_args = 0;
+		step->syscall.emu = 1;
+		step->syscall.emu_ret = 1;
+		if (STATE_SYSCALL_ENTRY == state) {
+			step->action = TSTEP_ENTER_SYSCALL;
+			return;
+		}
+		/* Proceed to syscall exit so we can run our own syscalls. */
+		exit_syscall_emu(t, SYS_rrcall_monkeypatch_vdso, 0);
+		monkeypatch_vdso(t);
+		step->action = TSTEP_RETIRE;
+		return;
+
 	default:
 		break;
 	}

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1423,4 +1423,14 @@ SYSCALL_DEF(EMU, writev, 0)
  */
 SYSCALL_DEF(IRREGULAR, rrcall_init_buffers, -1)
 
+/**
+ *  void rrcall_monkeypatch_vdso(void* vdso_hook_trampoline);
+ *
+ * Monkeypatch |__kernel_vsyscall()| to jump into
+ * |vdso_hook_trampoline|.
+ *
+ * This is a "magic" syscall implemented by rr.
+ */
+SYSCALL_DEF(IRREGULAR, rrcall_monkeypatch_vdso, -1)
+
 #define MAX_NR_SYSCALLS 512

--- a/src/share/dbg.h
+++ b/src/share/dbg.h
@@ -10,7 +10,6 @@
 
 #include "../replayer/replayer.h" /* for emergency_debug() */
 
-#include "task.h"
 #include "util.h"
 
 /**

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -515,4 +515,10 @@ void format_syscallbuf_shmem_path(pid_t tid, char (&path)[N])
 enum { SHARE_DESCHED_EVENT_FD = 1, DONT_SHARE_DESCHED_EVENT_FD = 0 };
 void* init_buffers(Task* t, void* map_hint, int share_desched_fd);
 
+/**
+ * Locate |t|'s |__kernel_vsyscall()| helper and then monkey-patch it
+ * to jump to the preload lib's hook function.
+ */
+void monkeypatch_vdso(Task* t);
+
 #endif /* UTIL_H_ */

--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -11,8 +11,9 @@ expect_gdb('Breakpoint 1, hit_barrier')
 
 send_gdb('info threads\n')
 for i in xrange(NUM_THREADS + 1, 1, -1):
-    # The threads are at the vdso, hence the '??' top frame.
-    expect_gdb(r'%d\s+Thread[^(]+\(BP-THREAD-%d\)[^_]+__kernel_vsyscall \(\)'%
+    # The threads are at the kernel syscall entry, or the rr
+    # monkeypatched one.
+    expect_gdb(r'%d\s+Thread[^(]+\(BP-THREAD-%d\)[^_]+(?:__kernel_vsyscall|_raw_traced_syscall) \(\)'%
                (i, i))
 
 expect_gdb(r'1\s+Thread[^h]+hit_barrier \(\)')


### PR DESCRIPTION
This allows rr to buffer libc syscalls that originate at non-POSIX (or
implementation-specific, backwards-compatibility) symbols.  Most
important among these is SYS_futex calls, which are the vast majority
of unbuffered FF syscalls.

Implementations of buffered syscalls in the new scheme will be added
one-by-one as their correctness is established.

@rocallahan you may want to look this one over too.
