### PR TITLE
Make Task::read/write() work properly for all addresses.

### DIFF
--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -3,7 +3,25 @@
 #ifndef __IPC_H__
 #define __IPC_H__
 
-/* XXX this should be a global -D define */
+// NB: this definition is required for pread()/pwrite() to work
+// properly when reading memory addresses that happen to be negative
+// 2's complement numbers.
+// 
+// XXX we can't globally define this currently, because some files
+// need to see 32-bit definitions (rec_process_event.cc f.e.).  But
+// having this here is very bad because files that include this get
+// 32-bit or 64-bit definitions depending on how early they include
+// this.  The options for fixing this are
+//
+//  1. Convert all code to explicit stat64() usage and remove this
+//
+//  2. Globally define this and create rr-local definitions of the
+//  required 32-bit symbols.
+//
+//  3. x64 support to make this problem go away (except for 32-bit
+//  tracees ...)
+//
+// Option (2) is probably best, but option 1 may be less work.
 #define _FILE_OFFSET_BITS 64
 
 #include <sys/user.h>
@@ -16,6 +34,13 @@ void read_child_registers(Task* t, struct user_regs_struct* regs);
 long read_child_code(pid_t pid, byte* addr);
 long read_child_data_word(Task* t, byte* addr);
 void* read_child_data(Task *t, size_t size, byte* addr);
+/**
+ * Directly read |size| bytes from |addr| into |buf|, which must be
+ * backed by at least |size| bytes.
+ *
+ * Don't use this directly.  Use Task::read_bytes() instead.
+ */
+void read_child_data_direct(Task *t, const byte* addr, size_t size, byte* buf);
 void read_child_usr(Task *t, void *dest, void *src, size_t size);
 void* read_child_data_checked(Task *t, size_t size, byte* addr, ssize_t *read_bytes);
 ssize_t checked_pread(Task* t, byte* buf, size_t size, off_t offset);

--- a/src/share/sys.cc
+++ b/src/share/sys.cc
@@ -323,54 +323,16 @@ void sys_fcntl(int fd, int cmd, long arg1)
 	}
 }
 
-void* sys_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset)
-{
-	void* tmp = mmap(addr, length, prot, flags, fd, offset);
-	if (tmp == MAP_FAILED) {
-		log_err("cannot memory-map file");
-		sys_exit();
-	}
-	return tmp;
-}
-
-void sys_munmap(void* addr, size_t length)
-{
-	if (munmap(addr, length) == -1) {
-		log_err("cannot un-map file");
-		sys_exit();
-	}
-}
-
-void* sys_memset(void * block, int c, size_t size)
-{
-	void* tmp;
-	if ((tmp = memset(block,c,size)) == NULL) {
-		log_err("malloc failed, size is: %d\n",size);
-		sys_exit();
-	}
-	return tmp;
-}
-
-void sys_setpgid(pid_t pid, pid_t pgid)
-{
-	if (setpgid(pid, pgid) == -1) {
-		log_err("error setting group id of child process");
-	}
-}
-
 int sys_mkdir(const char *path, mode_t mode)
 {
     struct stat st;
     int status = 0;
 
-    if (stat(path, &st) != 0)
-    {
+    if (stat(path, &st) != 0) {
         // Directory does not exist. EEXIST for race condition
         if (mkdir(path, mode) != 0 && errno != EEXIST)
             status = -1;
-    }
-    else if (!S_ISDIR(st.st_mode))
-    {
+    } else if (!S_ISDIR(st.st_mode)) {
         errno = ENOTDIR;
         status = -1;
     }

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -51,9 +51,4 @@ bool sys_waitpid(pid_t pid, int *status);
 pid_t sys_waitpid_nonblock(pid_t pid, int *status);
 void sys_fcntl(int fd, int cmd, long arg1);
 
-void* sys_mmap(void* addr, size_t length, int prot, int flags, int filedes, off_t offset);
-void sys_munmap(void* addr, size_t length);
-void* sys_memset(void * block, int c, size_t size);
-void sys_setpgid(pid_t pid, pid_t pgid);
-
 #endif /* SYS_H_ */

--- a/src/share/task.cc
+++ b/src/share/task.cc
@@ -1184,6 +1184,18 @@ Task::find(pid_t rec_tid)
 	return tasks.end() != it ? it->second : NULL;
 }
 
+void
+Task::read_bytes_helper(const byte* addr, ssize_t buf_size, byte* buf)
+{
+	return read_child_data_direct(this, (byte*)addr, buf_size, buf);
+}
+
+void
+Task::write_bytes_helper(const byte* addr, ssize_t buf_size, const byte* buf)
+{
+	write_child_data(this, buf_size, (byte*)addr, buf);
+}
+
 /**
  * Push a new event onto |t|'s event stack of type |type|.
  */

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -943,13 +943,8 @@ public:
 	 * return.
 	 */
 	template<size_t N>
-	void read_bytes(const byte* child_addr, byte (&buf)[N])
-	{
-		off_t offset = reinterpret_cast<off_t>(child_addr);
-		ssize_t nread = pread(child_mem_fd, buf, N, offset);
-		assert_exec(this, N == nread,
-			    "Expected to read %d bytes at %p, but only read %d",
-			    N, child_addr, nread);
+	void read_bytes(const byte* child_addr, byte (&buf)[N])	{
+		return read_bytes_helper(child_addr, N, buf);
 	}
 
 	/**
@@ -1006,11 +1001,7 @@ public:
 	 */
 	template<size_t N>
 	void write_bytes(const byte* child_addr, const byte (&buf)[N]) {
-		off_t offset = reinterpret_cast<off_t>(child_addr);
-		ssize_t nwritten = pwrite(child_mem_fd, buf, N, offset);
-		assert_exec(this, N == nwritten,
-			    "Expected to write %d bytes at %p, but only wrote %d",
-			    N, child_addr, nwritten);
+		return write_bytes_helper(child_addr, N, buf);
 	}
 
 	/**
@@ -1210,6 +1201,14 @@ public:
 
 private:
 	Task(pid_t tid, pid_t rec_tid, int priority);
+
+	/**
+	 * Read/write the number of bytes that the template wrapper
+	 * inferred.
+	 */
+	void read_bytes_helper(const byte* addr, ssize_t buf_size, byte* buf);
+	void write_bytes_helper(const byte* addr,
+				ssize_t buf_size, const byte* buf);
 
 	/* The address space of this task. */
 	std::shared_ptr<AddressSpace> as;


### PR DESCRIPTION
The changes in rec_process_event.cc probably look like gratuitous
refactoring, but actually they serve as tests of Task::read/write()
correctness.  Without this patch those reads fail.

Resolves #720.

Took much longer than it should because I got sidetracked trying to make the code stat-correct, but that turned into a rathole.  So, TODO.
