### PR TITLE
Cleanup buffers from the rr tracer on SYS_exit.

### DIFF
--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -111,16 +111,9 @@ struct rrcall_init_buffers_params {
 	struct socketcall_args* args_vec;
 
 	/* "Out" params. */
-	/* Returned pointer to and size of the scratch segment.  For
-	 * the purposes of this code, it doesn't matter what the
-	 * scratch region is, all we need to know about it is that it
-	 * must be unmapped at thread exit time. */
-	byte* scratch_ptr;
-	size_t num_scratch_bytes;
 	/* Returned pointer to and size of the shared syscallbuf
 	 * segment. */
 	byte* syscallbuf_ptr;
-	size_t num_syscallbuf_bytes;
 };
 
 /**

--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -417,6 +417,11 @@ int rec_prepare_syscall(Task* t, byte** kernel_sync_addr, uint32_t* sync_val)
 		return 0;
 	}
 
+	case SYS_exit:
+		destroy_buffers(t, (DESTROY_ALREADY_AT_EXIT_SYSCALL |
+				    DESTROY_NEED_EXIT_SYSCALL_RESTART));
+		return 0;
+
 	/* int futex(int *uaddr, int op, int val, const struct timespec *timeout, int *uaddr2, int val3); */
 	case SYS_futex:
 		switch (regs.ecx & FUTEX_CMD_MASK) {

--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -1456,6 +1456,8 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		return process_clone(t, trace, state, step);
 
 	case SYS_exit:
+		destroy_buffers(t, DESTROY_DEFAULT);
+		// fall through
 	case SYS_exit_group:
 		step->syscall.emu = 0;
 		assert(state == STATE_SYSCALL_ENTRY);

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -509,6 +509,21 @@ enum { SHARE_DESCHED_EVENT_FD = 1, DONT_SHARE_DESCHED_EVENT_FD = 0 };
 void* init_buffers(Task* t, void* map_hint, int share_desched_fd);
 
 /**
+ * At thread exit time, undo the work that init_buffers() did.
+ *
+ * Pass |DESTROY_ALREADY_AT_EXIT_SYSCALL| if the tracee has already
+ * entered SYS_exit.  Pass |DESTROY_NEED_EXIT_SYSCALL_RESTART| if the
+ * tracee should be returned at a state in which it has entered (or
+ * re-entered) SYS_exit.
+ */
+enum { 
+	DESTROY_DEFAULT = 0,
+	DESTROY_ALREADY_AT_EXIT_SYSCALL = 1 << 0,
+	DESTROY_NEED_EXIT_SYSCALL_RESTART = 1 << 1,
+};
+void destroy_buffers(Task* t, int flags);
+
+/**
  * Locate |t|'s |__kernel_vsyscall()| helper and then monkey-patch it
  * to jump to the preload lib's hook function.
  */


### PR DESCRIPTION
Resolves #721.

We still have to set up an atfork handler, but this is oh so much cleaner and gets rid of most remaining libc deps.
