### PR TITLE
Remove obsoleted buffer-enabled-ness code.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -578,20 +578,17 @@ int main(int argc, char* argv[])
 		log_info("Scheduler using max_events=%d, max_rbc=%d",
 			 flags->max_events, flags->max_rbc);
 
-		/* We always preload the syscallbuf library.  Whether
-		 * or not syscalls are actually buffered is controlled
-		 * by this env var. */
 		if (flags->use_syscall_buffer) {
-			setenv(SYSCALLBUF_ENABLED_ENV_VAR, "1", 1);
+			/* We rely on the distribution package or the
+			 * user to set up the LD_LIBRARY_PATH properly
+			 * so that we can LD_PRELOAD the bare library
+			 * name.  Trying to do otherwise is possible,
+			 * but annoying. */
+			flags->syscall_buffer_lib_path =
+				SYSCALLBUF_LIB_FILENAME;
 		} else {
 			log_info("Syscall buffer disabled by flag");
-			unsetenv(SYSCALLBUF_ENABLED_ENV_VAR);
 		}
-		/* We rely on the distribution package or the user to
-		 * set up the LD_LIBRARY_PATH properly so that we can
-		 * LD_PRELOAD the bare library name.  Trying to do
-		 * otherwise is possible, but annoying. */
-		flags->syscall_buffer_lib_path = SYSCALLBUF_LIB_FILENAME;
 	}
 
 	start(argc - argi , argv + argi, environ);

--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -26,9 +26,6 @@ extern "C" {
 /* This size counts the header along with record data. */
 #define SYSCALLBUF_BUFFER_SIZE (1 << 20)
 
-/* Set this env var to enable syscall buffering. */
-#define SYSCALLBUF_ENABLED_ENV_VAR "_RR_USE_SYSCALLBUF"
-
 /* TODO: convert the following macros into task.h helpers. */
 
 /**
@@ -90,10 +87,6 @@ typedef unsigned char byte;
  */
 struct rrcall_init_buffers_params {
 	/* "In" params. */
-	/* The syscallbuf lib's idea of whether buffering is enabled.
-	 * We let the syscallbuf code decide in order to more simply
-	 * replay the same decision that was recorded. */
-	int syscallbuf_enabled;
 	/* Where our traced syscalls will originate. */
 	byte* traced_syscall_ip;
 	/* Where our untraced syscalls will originate. */

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1764,13 +1764,8 @@ void* init_buffers(Task* t, void* map_hint, int share_desched_fd)
 	args = (struct rrcall_init_buffers_params*)
 	       read_child_data(t, sizeof(*args), child_args);
 
-	if (args->syscallbuf_enabled) {
-		child_map_addr =
-			init_syscall_buffer(t, &state, args,
-					    map_hint, share_desched_fd);
-	} else {
-		args->syscallbuf_ptr = nullptr;
-	}
+	child_map_addr = init_syscall_buffer(t, &state, args,
+					     map_hint, share_desched_fd);
 
 	/* Return the mapped buffers to the child. */
 	write_child_data(t, sizeof(*args), child_args, (byte*)args);


### PR DESCRIPTION
Part 2 of #730.  Resolves #730.

Semi-backout of ea11bdd, but I decided to keep the name "rrpreload".  It gives a better idea up front of how the library is used, and has more flexibility for other uses that we may eventually put it to.
