### PR TITLE
Disable buffered syscalls for tracess when they block SIGSYS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ set(BASIC_TESTS
   term_nonmain
   tgkill
   thread_stress
+  threaded_syscall_spam
   threads
   tiocinq
   truncate

--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -75,8 +75,10 @@ extern "C" {
 
 #define __NR_rrcall_init_buffers 442
 #define __NR_rrcall_monkeypatch_vdso 443
+#define __NR_rrcall_clear_tcb_guard 444
 #define SYS_rrcall_init_buffers __NR_rrcall_init_buffers
 #define SYS_rrcall_monkeypatch_vdso __NR_rrcall_monkeypatch_vdso
+#define SYS_rrcall_clear_tcb_guard __NR_rrcall_clear_tcb_guard
 
 typedef unsigned char byte;
 

--- a/src/recorder/recorder.cc
+++ b/src/recorder/recorder.cc
@@ -510,6 +510,7 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 				|| (0 > syscallno
 				    || SYS_rrcall_init_buffers == t->event
 				    || SYS_rrcall_monkeypatch_vdso == t->event
+				    || SYS_rrcall_clear_tcb_guard == t->event
 				    || SYS_clone == syscallno
 				    || SYS_exit_group == syscallno
 				    || SYS_exit == syscallno)),

--- a/src/replayer/syscall_defs.h
+++ b/src/replayer/syscall_defs.h
@@ -1155,8 +1155,8 @@ SYSCALL_DEF(EMU, sigaltstack, 1)
  * delivery is currently blocked for the caller (see also signal(7)
  * for more details).
  */
-SYSCALL_DEF(EMU, sigprocmask, 1)
-SYSCALL_DEF(EMU, rt_sigprocmask, 1)
+SYSCALL_DEF(IRREGULAR, sigprocmask, -1)
+SYSCALL_DEF(IRREGULAR, rt_sigprocmask, -1)
 
 /**
  *  int sigreturn(unsigned long __unused)
@@ -1432,5 +1432,14 @@ SYSCALL_DEF(IRREGULAR, rrcall_init_buffers, -1)
  * This is a "magic" syscall implemented by rr.
  */
 SYSCALL_DEF(IRREGULAR, rrcall_monkeypatch_vdso, -1)
+
+/**
+ *  void rrcall_clear_tcb_guard(void);
+ *
+ * Clear the tcb-guard register, $fs.
+ *
+ * This is a "magic" syscall implemented by rr.
+ */
+SYSCALL_DEF(IRREGULAR, rrcall_clear_tcb_guard, -1)
 
 #define MAX_NR_SYSCALLS 512

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1778,6 +1778,7 @@ void* init_buffers(Task* t, void* map_hint, int share_desched_fd)
 	 * away in the return value slot so that we can easily check
 	 * that we map the segment at the same addr during replay. */
 	state.regs.eax = (uintptr_t)child_map_addr;
+	t->inited_syscallbuf(&state.regs);
 	finish_remote_syscalls(t, &state);
 
 	return child_map_addr;

--- a/src/test/threaded_syscall_spam.c
+++ b/src/test/threaded_syscall_spam.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static int num_its;
+
+static void syscall_spam(void) {
+	int i;
+	struct timespec ts;
+	struct timeval tv;
+	for (i = 0; i < 1 << num_its; ++i) {
+		/* The odds of the signal being caught in the library
+		 * implementing these syscalls is very high.  But even
+		 * if it's not caught there, this test will pass. */
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		gettimeofday(&tv, NULL);
+	}
+}
+
+static void unblock_signals(void) {
+	sigset_t set;
+	atomic_printf("%d: unblocking all signals...\n", sys_gettid());
+	sigfillset(&set);
+	pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+	atomic_printf("  %d: unblocked all sigs\n", sys_gettid());
+}
+
+static void* thread(void* unused) {
+	unblock_signals();
+	syscall_spam();
+	return NULL;
+}
+
+int main(int argc, char** argv) {
+	sigset_t set;
+	pthread_t t;
+
+	test_assert(argc == 2);
+	num_its = atoi(argv[1]);
+	test_assert(num_its > 0);
+
+	atomic_printf("Running 2^%d iterations in two threads\n", num_its);
+
+	sigfillset(&set);
+	test_assert(0 == pthread_sigmask(SIG_BLOCK, &set, NULL));
+	atomic_puts("parent: blocked all sigs");
+
+	pthread_create(&t, NULL, thread, NULL);
+
+	unblock_signals();
+	syscall_spam();
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/threaded_syscall_spam.run
+++ b/src/test/threaded_syscall_spam.run
@@ -1,0 +1,17 @@
+testname=threaded_syscall_spam
+source `dirname $0`/util.sh $testname "$@"
+
+# Without the syscallbuf, trying to record the large number of
+# syscalls in this test is impractical.
+skip_if_no_syscall_buf
+
+# 2^17 iterations is arbitrarily chosen to take ~3s on a fast machine
+record $testname 17
+
+# Because of issue #184, replay takes longer than practical.  So for
+# now we'll skip it and hope other tests exercise the relevant code
+# well enough.
+#replay
+#check 'EXIT-SUCCESS'
+echo Test "'$testname'" PASSED
+passed=y


### PR DESCRIPTION
To do so, the rr tracer has to track the blocked-signal set and detect
when SIGSYS-blockedness changes.  Buffered syscalls are disabled by
flipping off the TCB guard register, which makes it simpler to handle
task creation and syscallbuf initialization in the presence of a
blocked SIGSYS.

Resolves #731.
