### PR TITLE
Auto-launch gdb during replay, but only open socket for "replay -s".

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -278,6 +278,8 @@ static void print_usage(void)
 "                             in the trace.  See -m above.\n"
 "  -p, --dbgport=PORT         bind the debugger server to PORT\n"
 "  -q, --no-redirect-output   don't replay writes to stdout/stderr\n"
+"  -s, --socket-only          only open the debugger socket; don't\n"
+"                             automatically launch the debugger too.\n"
 "\n"
 "Syntax for `dump`\n"
 " rr dump [OPTIONS] <trace_dir> <event-spec>...\n"
@@ -338,12 +340,13 @@ static int parse_replay_args(int cmdi, int argc, char** argv,
 		{ "dbgport", required_argument, NULL, 'p' },
 		{ "goto", required_argument, NULL, 'g' },
 		{ "no-redirect-output", no_argument, NULL, 'q' },
+		{ "socket-only", no_argument, NULL, 's' },
 		{ 0 }
 	};
 	optind = cmdi + 1;
 	while (1) {
 		int i = 0;
-		switch (getopt_long(argc, argv, "+ag:p:q", opts, &i)) {
+		switch (getopt_long(argc, argv, "+ag:p:qs", opts, &i)) {
 		case -1:
 			return optind;
 		case 'a':
@@ -358,6 +361,9 @@ static int parse_replay_args(int cmdi, int argc, char** argv,
 			break;
 		case 'q':
 			flags->redirect = false;
+			break;
+		case 's':
+			flags->dont_launch_debugger = true;
 			break;
 		default:
 			return -1;

--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -8,6 +8,8 @@
 
 #include "../share/types.h"
 
+#define DBG_SOCKET_READY_SIG SIGURG
+
 struct dbg_context;
 
 /**
@@ -139,13 +141,29 @@ bool dbg_is_resume_request(const struct dbg_request* req);
  * port based on |start_port| will be searched for.  Otherwise, if
  * |port| is already bound, this function will fail.
  *
+ * If we're opening this connection on behalf of a known client, past
+ * its pid as |client| and its |client_params_fd|.  |exe_image| is the
+ * process that will be debugged by client, or null ptr if there isn't
+ * a client.
+ *
+ * |exe_image| is of the process that will be debugged, or nullptr if we don't know
+ *
  * This function is infallible: either it will return a valid
  * debugging context, or it won't return.
  */
 enum { DONT_PROBE = 0, PROBE_PORT };
 struct dbg_context* dbg_await_client_connection(const char* addr,
-						unsigned short port,
-						int probe);
+						unsigned short desired_port,
+						int probe,
+						const char* exe_image = nullptr,
+						pid_t client = -1,
+						int client_params_fd = -1);
+
+/**
+ * Launch a debugger using the params that were written to
+ * |params_pipe_fd|.
+ */
+void dbg_launch_debugger(int params_pipe_fd);
 
 /**
  * Call this when the target of |req| is needed to fulfill the

--- a/src/share/types.h
+++ b/src/share/types.h
@@ -80,6 +80,8 @@ struct flags {
 	// Dump trace frames in a more easily machine-parseable
 	// format.
 	bool raw_dump;
+	// Only open a debug socket, don't launch the debugger too.
+	bool dont_launch_debugger;
 };
 
 struct msghdr;

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -181,7 +181,7 @@ function replay { replayflags=$1
 #
 # Load the "expect" script to drive replay of the recording of |exe|.
 function debug { exe=$1; expectscript=$2; replayargs=$3
-    python $TESTDIR/$expectscript.py $exe-$nonce rr -u replay --dbgport=$$ $replayargs trace_0/
+    python $TESTDIR/$expectscript.py $exe-$nonce rr $GLOBAL_OPTIONS replay $replayargs trace_0/
     if [[ $? == 0 ]]; then
         passed=y
 	echo "Test '$TESTNAME' PASSED"


### PR DESCRIPTION
This changes the rr process tree.  We reserve the top-level rr process
as a future debugger client.  It forks a child which drives replay
until debugger-connection time.  Then the child notifies the parent,
which exec()s gdb on top of itself (preparing the magic commands to
connect to the remote target).

The previous behavior can be re-enabled by passing "-s".  This is
useful when you're frequently restarting execution with nontrivial
breakpoints, and you want them preserved across restarts by detaching
and re-attaching to a new run.

Resolves #740.
