### PR TITLE
Restart a new debugging session when the debugger sends the "run" comman...

### DIFF
--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -401,9 +401,10 @@ static void logmsg(const char* msg, ...)
 
 #define fatal(msg, ...)							\
 	do {								\
-		logmsg("[FATAL] (%s:%d: errno: %s) " msg "\n",		\
-		       __FILE__, __LINE__, strerror(errno), ##__VA_ARGS__); \
-		assert("Bailing because of fatal error" && 0);		\
+		logmsg("[FATAL] (%s:%d: errno: %s: tid: %d) " msg "\n",	\
+		       __FILE__, __LINE__, strerror(errno),		\
+		       traced_gettid(), ##__VA_ARGS__);			\
+		traced_raise(SIGABRT);					\
 	} while (0)
 
 #ifdef DEBUGTAG

--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -109,6 +109,9 @@ enum DbgRequestType{
 
 	/* gdb host detaching from stub.  No parameters. */
 	DREQ_DETACH,
+
+	/* Uses params.restart. */
+	DREQ_RESTART,
 };
 
 /**
@@ -127,6 +130,11 @@ struct dbg_request {
 		} mem;
 
 		DbgRegister reg;
+
+		struct {
+			int event;
+			short port;
+		} restart;
 	};
 };
 

--- a/src/replayer/rep_process_event.h
+++ b/src/replayer/rep_process_event.h
@@ -38,7 +38,7 @@ private:
 
 /**
  * Collect emulated files that aren't referenced by tracees.  Call
- * this only when a tracee (possibly shared) file table has been
+ * this only when a tracee's (possibly shared) file table has been
  * destroyed.  All other gc triggers are handled internally.
  */
 void gc();

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -1104,6 +1104,12 @@ public:
 	 */
 	static Task* find(pid_t rec_tid);
 
+	/**
+	 * |Task::count()| will be zero and all the OS tasks will be
+	 * gone when this returns, or this won't return.
+	 */
+	static void killall();
+
 	/* State only used during recording. */
 
 	/* The running count of events that have been recorded for

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1369,7 +1369,7 @@ int create_shmem_segment(const char* name, size_t num_bytes)
 	char path[PATH_MAX];
 	snprintf(path, sizeof(path) - 1, "%s/%s", SHMEM_FS, name);
 
-	int fd = open(path, O_CREAT | O_EXCL | O_RDWR, 0600);
+	int fd = open(path, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
 	if (0 > fd) {
 		fatal("Failed to create shmem segment %s", path);
 	}

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -1,7 +1,7 @@
-import pexpect, signal, sys, time
+import pexpect, re, signal, sys, time
 
 __all__ = [ 'expect_gdb', 'send_gdb','expect_rr', 'send_rr',
-            'interrupt_gdb', 'ok' ]
+            'restart_replay', 'interrupt_gdb', 'ok' ]
 
 # Public API
 def expect_gdb(what):
@@ -17,6 +17,17 @@ def interrupt_gdb():
         failed('interrupting gdb', e)
     expect_gdb('stopped.')
 
+def restart_replay():
+    send_gdb('r\n')
+    expect_gdb('Start it from the beginning')
+
+    send_gdb('y\n')
+    expect_gdb(re.compile(r'target extended-remote :(\d+)'))
+    port = gdb_rr.match.group(1)
+
+    send_gdb('target extended-remote :'+ port +'\n')
+    expect_gdb('Remote debugging using :'+ port)
+
 def send_gdb(what):
     send(gdb_rr, what)
 
@@ -27,7 +38,7 @@ def ok():
     clean_up()
 
 # Internal helpers
-TIMEOUT_SEC = 20
+TIMEOUT_SEC = 5
 # gdb and rr are part of the same process tree, so they share
 # stdin/stdout.
 gdb_rr = None

--- a/src/test/target_fork.c
+++ b/src/test/target_fork.c
@@ -2,7 +2,12 @@
 
 #include "rrutil.h"
 
-static void breakpoint(void) {
+static void bad_breakpoint(void) {
+	int break_here = 1;
+	(void)break_here;
+}
+
+static void good_breakpoint(void) {
 	int break_here = 1;
 	(void)break_here;
 }
@@ -11,6 +16,8 @@ int main(int argc, char** argv) {
 	int num_syscalls;
 	int child;
 	int i;
+
+	bad_breakpoint();
 
 	test_assert(argc == 2);
 	num_syscalls = atoi(argv[1]);
@@ -21,7 +28,7 @@ int main(int argc, char** argv) {
 	}
 
 	if (0 == (child = fork())) {
-		breakpoint();
+		good_breakpoint();
 		exit(0);
 	}
 

--- a/src/test/target_fork.run
+++ b/src/test/target_fork.run
@@ -1,8 +1,9 @@
 test=target_fork
 source `dirname $0`/util.sh $test "$@"
 
-record $test 1000
+EVENTS=1000
+record $test $EVENTS
 TARGET_PID=$(grep 'child ' record.out | awk '{print $2}')
 
 echo Targeting recorded pid $TARGET_PID ...
-debug $test generic_break "-f $TARGET_PID"
+debug $test bad_good_break "-f $TARGET_PID -g $EVENTS"

--- a/src/test/target_process.c
+++ b/src/test/target_process.c
@@ -3,19 +3,11 @@
 #include "rrutil.h"
 
 int main(int argc, char** argv) {
-	int num_syscalls;
 	const char* exe_image;
 	int child;
-	int i;
 
-	test_assert(argc == 3);
-	num_syscalls = atoi(argv[1]);
-	exe_image = argv[2];
-
-	atomic_printf("%d: running %d syscalls ...\n", getpid(), num_syscalls);
-	for (i = 0; i < num_syscalls; ++i) {
-		sys_gettid();
-	}
+	test_assert(argc == 2);
+	exe_image = argv[1];
 
 	atomic_printf("%d: forking and exec'ing %s...\n", getpid(), exe_image);
 	if (0 == (child = fork())) {

--- a/src/test/target_process.run
+++ b/src/test/target_process.run
@@ -4,8 +4,8 @@ source `dirname $0`/util.sh $test "$@"
 save_exe breakpoint
 saved_breakpoint="breakpoint-$nonce"
 
-record $test "1000 $saved_breakpoint"
+record $test "$saved_breakpoint"
 TARGET_PID=$(grep 'child ' record.out | awk '{print $2}')
 
 echo Targeting recorded pid $TARGET_PID ...
-debug $test breakpoint "-p $TARGET_PID"
+debug $test restart_breakpoint "-p $TARGET_PID"


### PR DESCRIPTION
...d.

The use case is that you debug as far as you can in your current
session, and want to restart with a new replayer.  We sue the "run"
(restart process from the bugging) command, which is pretty
appropriate.

This part 1 implementation doesn't work like normal "run" though.  The
workflow goes like this

```
# debugging, decide to restart
(gdb) run
# the old replay session shuts down
Remote connection closed
# the new replayer starts up
Attach to the rr debug server with this command:
  target extended-remote :1111
(gdb) target extended-remote :1111
# gdb connects to new session
Remote debugging using :1111
```

Additionally, the user can pass a single int arg to "run" to specify a
new event to replay up to.  By default, it's the event that was
specified on the command line, or the last one passed to "run".

```
(gdb) run EVENT-NUM
```

Part 1 of #763.
