### PR TITLE
Reuse the debug server state across replay restarts.

### DIFF
--- a/src/replayer/dbg_gdb.h
+++ b/src/replayer/dbg_gdb.h
@@ -184,6 +184,12 @@ struct dbg_context* dbg_await_client_connection(const char* addr,
 void dbg_launch_debugger(int params_pipe_fd);
 
 /**
+ * Notify the debug server that replay is about to be restarted, and
+ * it should prepare any state necessary to restore post-exec.
+ */
+void dbg_prepare_restore_after_exec_restart(struct dbg_context* dbg);
+
+/**
  * Call this when the target of |req| is needed to fulfill the
  * request, but the target is dead.  This situation is a symptom of a
  * gdb or rr bug.

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1364,12 +1364,12 @@ bool should_copy_mmap_region(const char* filename, const struct stat* stat,
 	return true;
 }
 
-int create_shmem_segment(const char* name, size_t num_bytes)
+int create_shmem_segment(const char* name, size_t num_bytes, int cloexec)
 {
 	char path[PATH_MAX];
 	snprintf(path, sizeof(path) - 1, "%s/%s", SHMEM_FS, name);
 
-	int fd = open(path, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
+	int fd = open(path, O_CREAT | O_EXCL | O_RDWR | cloexec, 0600);
 	if (0 > fd) {
 		fatal("Failed to create shmem segment %s", path);
 	}

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -385,9 +385,12 @@ bool should_copy_mmap_region(const char* filename, const struct stat* stat,
 
 /**
  * Return an fd referring to a new shmem segment with descriptive
- * |name| of size |num_bytes|.
+ * |name| of size |num_bytes|.  Pass O_NO_CLOEXEC to clo_exec to
+ * prevent setting the O_CLOEXEC flag.
  */
-int create_shmem_segment(const char* name, size_t num_bytes);
+enum { O_NO_CLOEXEC = 0 };
+int create_shmem_segment(const char* name, size_t num_bytes,
+			 int cloexec = O_CLOEXEC);
 
 /**
  * Ensure that the shmem segment referred to by |fd| has exactly the

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -20,13 +20,7 @@ def interrupt_gdb():
 def restart_replay():
     send_gdb('r\n')
     expect_gdb('Start it from the beginning')
-
     send_gdb('y\n')
-    expect_gdb(re.compile(r'target extended-remote :(\d+)'))
-    port = gdb_rr.match.group(1)
-
-    send_gdb('target extended-remote :'+ port +'\n')
-    expect_gdb('Remote debugging using :'+ port)
 
 def send_gdb(what):
     send(gdb_rr, what)
@@ -38,7 +32,7 @@ def ok():
     clean_up()
 
 # Internal helpers
-TIMEOUT_SEC = 5
+TIMEOUT_SEC = 20
 # gdb and rr are part of the same process tree, so they share
 # stdin/stdout.
 gdb_rr = None
@@ -81,7 +75,7 @@ def send(prog, what):
 def set_up():
     global gdb_rr
     try:
-        gdb_rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('rr.log', 'w'))
+        gdb_rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('gdb_rr.log', 'w'))
         expect_gdb(r'\(gdb\)')
     except Exception, e:
         failed('initializing rr and gdb', e)


### PR DESCRIPTION
With this change, rr restarts replay "transparently" to gdb clients
when the client issues the "run" command; i.e. the user doesn't have
to do anything to reconnect to the restarted replay session.  That
means the debugging workflow is now

```
# rr replay -p pid trace
(gdb) b C
Breakpoint 1
(gdb) c
Breakpoint 1, C ()
# no more debugging to be done.  need to restart session.
(gdb) r
The program being debugged has been started already.
Start it from the beginning? (y or n) y
# rr "transparently" restarts the session
Breakpoint 1, C ()
(gdb)
# ^^ tracee continued up to first breakpoint/watchpoint by gdb,
# restarted debugging session ready.
```

Resolves #763.  This is part 3; turned out to be far easier, cleaner, and more reliable than part 2.

@rocallahan I dare say you'll like this :).  Please give it a try and let me know what you think.  This is way better than I'd hoped the gdb interaction would be for 1.0, so I'm willing to call 1.0 "UI complete" if you're satisfied.
