### PR TITLE
Work around hang caused by runaway tracees, which we await precise kills...

### DIFF
--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -54,6 +54,7 @@
 #include <stdio.h>
 #include <syscall.h>
 #include <sys/epoll.h>
+#include <sysexits.h>
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -404,7 +405,7 @@ static void logmsg(const char* msg, ...)
 		logmsg("[FATAL] (%s:%d: errno: %s: tid: %d) " msg "\n",	\
 		       __FILE__, __LINE__, strerror(errno),		\
 		       traced_gettid(), ##__VA_ARGS__);			\
-		traced_raise(SIGABRT);					\
+		traced_syscall1(SYS_exit_group, EX_OSERR);		\
 	} while (0)
 
 #ifdef DEBUGTAG

--- a/src/replayer/replayer.cc
+++ b/src/replayer/replayer.cc
@@ -1803,6 +1803,7 @@ static void replay_one_trace_frame(struct dbg_context* dbg, Task* t)
 
 	if (DREQ_DETACH == req.type) {
 		log_info("(debugger detached from us, rr exiting)");
+		dbg_destroy_context(&dbg);
 		exit(0);
 	}
 


### PR DESCRIPTION
....

Resolves #782, sort of.
