### PR TITLE
Restore SIGSEGV handler after rdtsc traps in which SIGSEGV is blocked.

### DIFF
--- a/src/replayer/dbg_gdb.cc
+++ b/src/replayer/dbg_gdb.cc
@@ -278,14 +278,8 @@ struct dbg_context* dbg_await_client_connection(const char* addr,
 	} else {
 		fprintf(stderr,
 			"Attach to the rr debug server with this command:\n"
-			"  target extended-remote %s:%d\n",
+			"  target remote %s:%d\n",
 			!strcmp(addr, "127.0.0.1") ? "" : addr, port);
-		// XXX if we're a restarted replayer in gdb,
-		// our replay spam has destroyed the gdb
-		// prompt.  It's not obvious to the user that
-		// commands can be entered.  So put one back.
-		printf("(rr is replacing gdb's prompt now, whether or not gdb is running)\n(gdb) ");
-		fflush(stdout);
 	}
 	await_debugger(dbg);
 	return dbg;

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -30,6 +30,10 @@ struct Sighandlers;
 class Task;
 struct TaskGroup;
 
+/** Add the signal |_sig| to |_set|. */
+#define SIGSET_ADD(_set, _sig)			\
+	((_set) | (1 << ((_sig) - 1)))
+
 struct syscallbuf_hdr;
 struct syscallbuf_record;
 
@@ -936,6 +940,9 @@ public:
 	 */
 	void inited_syscallbuf();
 
+	/** Return true iff |sig| is blocked for this. */
+	bool is_sig_blocked(int sig);
+
 	/**
 	 * Return nonzero if |t| may not be immediately runnable,
 	 * i.e., resuming execution and then |waitpid()|'ing may block
@@ -1011,6 +1018,9 @@ public:
 	 * invoked when |sig| is received.
 	 */
 	bool signal_has_user_handler(int sig) const;
+
+	/** Return |sig|'s current sigaction. */
+	const kernel_sigaction& signal_action(int sig) const;
 
 	/** Return the task group this belongs to. */
 	TaskGroup::shr_ptr task_group() { return tg; }

--- a/src/test/rdtsc.c
+++ b/src/test/rdtsc.c
@@ -2,13 +2,6 @@
 
 #include "rrutil.h"
 
-
-static uint64_t rdtsc(void) {
-	uint32_t hi, lo;
-	__asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
-	return (uint64_t)hi << 32 | (uint64_t)lo;
-}
-
 static void breakpoint(void) {
 	int break_here = 1;
 	(void)break_here;

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -118,4 +118,13 @@ inline static void check_data(void* buf, size_t len)
 	test_assert(len == nwritten);
 }
 
+/**
+ * Return the current value of the time-stamp counter.
+ */
+inline static uint64_t rdtsc(void) {
+	uint32_t hi, lo;
+	__asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+	return (uint64_t)hi << 32 | (uint64_t)lo;
+}
+
 #endif /* RRUTIL_H */


### PR DESCRIPTION
See long comment in handle_signal.c

Resolves #692.
