### PR TITLE
Drop pending signals at desched if they're ignored, and handle interrupt...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(BASIC_TESTS
   barrier
   big_buffers
   block
+  block_intr_sigchld
   breakpoint
   chew_cpu
   clock

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -512,6 +512,7 @@ enum PseudosigType {
 	EUSR_SYSCALLBUF_RESET,
 	EUSR_UNSTABLE_EXIT,
 	EUSR_INTERRUPTED_SYSCALL_NOT_RESTARTED,
+	EUSR_EXIT_SIGHANDLER,
 };
 
 enum EventType {
@@ -942,6 +943,12 @@ public:
 
 	/** Return true iff |sig| is blocked for this. */
 	bool is_sig_blocked(int sig);
+
+	/**
+	 * Return true iff |sig| is SIG_IGN, or it's SIG_DFL and the
+	 * default disposition is "ignore".
+	 */
+	bool is_sig_ignored(int sig);
 
 	/**
 	 * Return nonzero if |t| may not be immediately runnable,

--- a/src/share/trace.cc
+++ b/src/share/trace.cc
@@ -216,6 +216,8 @@ static int encode_event(const struct event* ev, int* state)
 			TRANSLATE(USR_SYSCALLBUF_ABORT_COMMIT);
 			TRANSLATE(USR_SYSCALLBUF_RESET);
 			TRANSLATE(USR_UNSTABLE_EXIT);
+			TRANSLATE(USR_INTERRUPTED_SYSCALL_NOT_RESTARTED);
+			TRANSLATE(USR_EXIT_SIGHANDLER);
 		default:
 			fatal("Unknown pseudosig %d", ev->pseudosig.no);
 #undef TRANSLATE

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -50,6 +50,10 @@ enum {
 	 * interrupted syscall wasn't restarted, so the interruption
 	 * record can be popped off the tracee's event stack. */
 	USR_INTERRUPTED_SYSCALL_NOT_RESTARTED,
+	/* Tracee exited its sighandler.  We leave this breadcrumb so
+	 * that the popping of not-restarted syscall interruptions and
+	 * sigreturns is replayed in the same order. */
+	USR_EXIT_SIGHANDLER,
 	/* TODO: this is actually a pseudo-pseudosignal: it will never
 	 * appear in a trace, but is only used to communicate between
 	 * different parts of the recorder code that should be

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1194,8 +1194,7 @@ bool is_now_contended_pi_futex(Task* t, byte* futex, uint32_t* next_val)
 	return now_contended;
 }
 
-enum { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
-static int default_action(int sig)
+int default_action(int sig)
 {
 	if (SIGRTMIN <= sig && sig <= SIGRTMAX) {
 		return TERMINATE;

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -365,6 +365,10 @@ int is_disarm_desched_event_syscall(Task* t,
  */
 bool is_now_contended_pi_futex(Task* t, byte* futex, uint32_t* next_val);
 
+/** Return the default action of |sig|. */
+enum { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
+int default_action(int sig);
+
 /**
  * Return true if |sig| may cause the status of other tasks to change
  * unpredictably beyond rr's observation.


### PR DESCRIPTION
...ed SYS_restart_syscall.

Dropping ignored signals while processing desched's keeps us from
having to add signal queuing.  The test for that caused interrupted
SYS_restart_syscall's, so basic logic was added for that.  No claim is
made that the logic comprehensive or correct.

Resolves #795.
