### PR TITLE
Conditionally enable non-essential perf counters.

### DIFF
--- a/src/recorder/handle_signal.cc
+++ b/src/recorder/handle_signal.cc
@@ -436,7 +436,9 @@ static void record_signal(Task* t, const siginfo_t* si,
 		 * instruction could be retired, this code wouldn't
 		 * work.  This also cross-checks the sighandler
 		 * information we maintain in |t->sighandlers|. */
+#ifdef HPC_ENABLE_EXTRA_PERF_COUNTERS
 		assert(0 == read_insts(t->hpc));
+#endif
 
 		/* It's somewhat difficult engineering-wise to compute
 		 * the sigframe size at compile time, and it can vary

--- a/src/share/hpc.h
+++ b/src/share/hpc.h
@@ -21,22 +21,27 @@
  * hope that tracees don't either. */
 #define HPC_TIME_SLICE_SIGNAL SIGSTKFLT
 
+// Define this macro to enable perf counters that may be interesting
+// for experimentation, but aren't necessary for core functionality.
+//#define HPC_ENABLE_EXTRA_PERF_COUNTERS
+
 class Task;
 
-typedef struct _hpc_event
-{
+typedef struct {
 	struct perf_event_attr attr;
 	int fd;
 } hpc_event_t;
 
 struct hpc_context {
-	pid_t tid;
-	int started;
+	bool started;
+	int group_leader;
 
-	hpc_event_t inst;
 	hpc_event_t rbc;
+#ifdef HPC_ENABLE_EXTRA_PERF_COUNTERS
+	hpc_event_t inst;
 	hpc_event_t page_faults;
 	hpc_event_t hw_int;
+#endif
 };
 
 void init_libpfm(void);
@@ -48,13 +53,14 @@ void destroy_hpc(Task *t);
 void start_hpc(Task *t, int64_t val);
 void stop_hpc(Task *t);
 void reset_hpc(Task *t, int64_t val);
-void stop_rbc(Task *t);
-int pending_rbc_down(struct hpc_context *counters);
 
-int64_t read_page_faults(struct hpc_context *counters);
 int64_t read_rbc(struct hpc_context *counters);
+
+#ifdef HPC_ENABLE_EXTRA_PERF_COUNTERS
+int64_t read_page_faults(struct hpc_context *counters);
 int64_t read_rbc_down(struct hpc_context *counters);
 int64_t read_hw_int(struct hpc_context* counters);
 int64_t read_insts(struct hpc_context *counters);
+#endif
 
 #endif /* HPC_H_ */

--- a/src/share/trace.h
+++ b/src/share/trace.h
@@ -103,10 +103,12 @@ struct trace_frame {
 	STRUCT_DELIMITER(end_event_info);
 
 	STRUCT_DELIMITER(begin_exec_info);
+	int64_t rbc;
+#ifdef HPC_ENABLE_EXTRA_PERF_COUNTERS
 	int64_t hw_interrupts;
 	int64_t page_faults;
-	int64_t rbc;
 	int64_t insts;
+#endif
 
 	struct user_regs_struct recorded_regs;
 	STRUCT_DELIMITER(end_exec_info);

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -646,10 +646,8 @@ int compare_register_files(Task* t,
 	}
 
 	assert_exec(t, !bail_error || !err,
-		    "Fatal register mismatch\n"
-		    "    (rbc/rec:%lld/%lld; irc/rec:%lld/%lld)",
-		    read_rbc(t->hpc), t->trace.rbc,
-		    read_insts(t->hpc), t->trace.insts);
+		    "Fatal register mismatch (rbc/rec:%lld/%lld)",
+		    read_rbc(t->hpc), t->trace.rbc);
 
 	if (!err && mismatch_behavior == LOG_MISMATCHES) {
 		log_info("(register files are the same for %s and %s)",


### PR DESCRIPTION
Resolves #279 (part 1).
