### PR TITLE
Add Task::cont*() helpers, and remove the old ones.

### DIFF
--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -324,7 +324,7 @@ static void validate_args(int syscall, int state, Task* t)
  */
 static void goto_next_syscall_emu(Task *t)
 {
-	sys_ptrace_sysemu(t);
+	t->cont_sysemu();
 	sys_waitpid(t->tid, &(t->status));
 
 	int sig = signal_pending(t->status);
@@ -372,7 +372,7 @@ static void finish_syscall_emu(Task *t)
 {
 	struct user_regs_struct regs;
 	t->get_regs(&regs);
-	sys_ptrace_sysemu_singlestep(t);
+	t->cont_sysemu_singlestep();
 	sys_waitpid(t->tid, &(t->status));
 	t->set_regs(regs);
 
@@ -384,7 +384,7 @@ static void finish_syscall_emu(Task *t)
  */
 void __ptrace_cont(Task *t)
 {
-	sys_ptrace_syscall(t);
+	t->cont_syscall();
 	sys_waitpid(t->tid, &t->status);
 
 	t->child_sig = signal_pending(t->status);

--- a/src/share/sys.cc
+++ b/src/share/sys.cc
@@ -165,21 +165,6 @@ void sys_ptrace(Task* t, int request, void *addr, void *data)
 		    request, tid, addr, data);
 }
 
-void sys_ptrace_syscall(Task* t)
-{
-	sys_ptrace(t, PTRACE_SYSCALL, 0, 0);
-}
-
-void sys_ptrace_cont(pid_t pid)
-{
-	ptrace(PTRACE_CONT, pid, 0, 0);
-}
-
-void sys_ptrace_cont_sig(pid_t pid, int sig)
-{
-	ptrace(PTRACE_CONT, pid, 0, (void*)sig);
-}
-
 /**
  * Detaches the child process from monitoring. This method must only be
  * invoked, if the thread exits. We do not check errors here, since the
@@ -188,21 +173,6 @@ void sys_ptrace_cont_sig(pid_t pid, int sig)
 void sys_ptrace_detach(pid_t pid)
 {
 	ptrace(PTRACE_DETACH, pid, 0, 0);
-}
-
-void sys_ptrace_syscall_sig(Task* t, int sig)
-{
-	sys_ptrace(t, PTRACE_SYSCALL, 0, (void*)sig);
-}
-
-void sys_ptrace_sysemu(Task* t)
-{
-	sys_ptrace(t, PTRACE_SYSEMU, 0, 0);
-}
-
-void sys_ptrace_sysemu_singlestep(Task* t)
-{
-	sys_ptrace(t, PTRACE_SYSEMU_SINGLESTEP, 0, 0);
 }
 
 int sys_ptrace_peekdata(pid_t pid, long addr, long* value)
@@ -238,16 +208,6 @@ void sys_ptrace_setup(Task* t)
 		/* No seccomp on the system, try without (this has to succeed) */
 		sys_ptrace(t, PTRACE_SETOPTIONS, 0, (void*) flags);
 	}
-}
-
-void sys_ptrace_singlestep(Task* t)
-{
-	sys_ptrace(t, PTRACE_SINGLESTEP, 0, 0);
-}
-
-void sys_ptrace_singlestep_sig(Task* t, int sig)
-{
-	sys_ptrace(t, PTRACE_SINGLESTEP, 0, (void*) sig);
 }
 
 void sys_ptrace_traceme()

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -28,20 +28,12 @@ void goto_next_event(Task *t);
 
 void sys_ptrace(Task* t, int request, void* addr, void* data);
 void sys_ptrace_setup(Task* t);
-void sys_ptrace_singlestep(Task* t);
-void sys_ptrace_singlestep_sig(Task* t, int sig);
-void sys_ptrace_sysemu(Task* t);
-void sys_ptrace_sysemu_singlestep(Task* t);
 void sys_ptrace_traceme(void);
-void sys_ptrace_cont(pid_t pid);
-void sys_ptrace_cont_sig(pid_t pid, int sig);
-void sys_ptrace_syscall_sig(Task* pid, int sig);
 /* Return zero on success, -1 on error. */
 int sys_ptrace_peekdata(pid_t pid, long addr, long* value);
 unsigned long sys_ptrace_getmsg(Task* t);
 void sys_ptrace_getsiginfo(Task* t, siginfo_t* sig);
 void sys_ptrace_detach(pid_t pid);
-void sys_ptrace_syscall(Task* t);
 
 /**
  * Block until the status of |pid| changes.  Write the new status into

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -272,7 +272,7 @@ const char* ptrace_event_name(int event);
  * Return the symbolic name of the PTRACE_ |request|, or "???REQ" if
  * unknown.
  */
-const char* ptrace_req_name(enum __ptrace_request request);
+const char* ptrace_req_name(int request);
 
 /**
  * Return the symbolic name of |sig|, f.e. "SIGILL", or "???signal" if


### PR DESCRIPTION
#801.  Semantics-preserving refactoring.
