### PR TITLE
Make wait()ing after resuming execution default, and add explicitly nonb...

### DIFF
--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -325,7 +325,6 @@ static void validate_args(int syscall, int state, Task* t)
 static void goto_next_syscall_emu(Task *t)
 {
 	t->cont_sysemu();
-	t->wait();
 
 	int sig = t->pending_sig();
 	/* SIGCHLD is pending, do not deliver it, wait for it to
@@ -373,7 +372,6 @@ static void finish_syscall_emu(Task *t)
 	struct user_regs_struct regs;
 	t->get_regs(&regs);
 	t->cont_sysemu_singlestep();
-	t->wait();
 	t->set_regs(regs);
 
 	t->force_status(0);
@@ -385,7 +383,6 @@ static void finish_syscall_emu(Task *t)
 void __ptrace_cont(Task *t)
 {
 	t->cont_syscall();
-	t->wait();
 
 	t->child_sig = t->pending_sig();
 	t->get_regs(&t->regs);

--- a/src/replayer/replayer.cc
+++ b/src/replayer/replayer.cc
@@ -608,8 +608,7 @@ static int cont_syscall_boundary(Task* t, int emu, int stepi)
 	} else {
 		resume_how = RESUME_SYSCALL;
 	}
-	t->resume_execution(resume_how);
-	t->wait();
+	t->resume_execution(resume_how, RESUME_WAIT);
 
 	switch ((t->child_sig = t->pending_sig())) {
 	case 0:
@@ -645,7 +644,6 @@ static void step_exit_syscall_emu(Task *t)
 	t->get_regs(&regs);
 
 	t->cont_sysemu_singlestep();
-	t->wait();
 
 	t->set_regs(regs);
 
@@ -722,8 +720,7 @@ static void continue_or_step(Task* t, int stepi)
 		 * should be neglible. */
 		resume_how = RESUME_SYSCALL;
 	}
-	t->resume_execution(resume_how);
-	t->wait();
+	t->resume_execution(resume_how, RESUME_WAIT);
 
 	t->child_sig = t->pending_sig();
 

--- a/src/share/task.cc
+++ b/src/share/task.cc
@@ -1095,10 +1095,14 @@ Task::read_word(const byte* child_addr)
 	return word;
 }
 
-void
-Task::resume_execution(ResumeRequest how, int sig)
+bool
+Task::resume_execution(ResumeRequest how, WaitRequest wait_how, int sig)
 {
 	xptrace(how, nullptr, (void*)(uintptr_t)sig);
+	if (RESUME_NONBLOCKING == wait_how) {
+		return true;
+	}
+	return wait();
 }
 
 void

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -1447,12 +1447,10 @@ void pop_tmp_mem(Task* t, struct current_state_buffer* state,
 static void advance_syscall(Task* t)
 {
 	t->cont_syscall();
-	t->wait();
 
 	/* Skip past a seccomp trace, if we happened to see one. */
 	if (t->is_ptrace_seccomp_event()) {
 		t->cont_syscall();
-		t->wait();
 	}
 	assert(t->ptrace_event() == 0);
 }
@@ -1485,7 +1483,7 @@ long remote_syscall(Task* t, struct current_state_buffer* state,
 		    syscallname(syscallno), syscallname(callregs.orig_eax));
 
 	/* Start running the syscall. */
-	t->cont_syscall();
+	t->cont_syscall_nonblocking();
 	if (WAIT == wait) {
 		return wait_remote_syscall(t, state, syscallno);
 	}


### PR DESCRIPTION
...locking resume helpers.
#801.
