### PR TITLE
Make Task::regs() the single source of truth for register state.

### DIFF
--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -26,44 +26,6 @@ extern "C" {
 /* This size counts the header along with record data. */
 #define SYSCALLBUF_BUFFER_SIZE (1 << 20)
 
-/* TODO: convert the following macros into task.h helpers. */
-
-/**
- * True if |_eip| is an $ip within the syscallbuf library.  This *does
- * not* imply that $ip is at a buffered syscall; use the macro below
- * for that.
- */
-#define SYSCALLBUF_IS_IP_IN_LIB(_eip, _t)				\
-	((uintptr_t)(_t)->syscallbuf_lib_start <= (uintptr_t)(_eip)	\
-	 && (uintptr_t)(_eip) < (uintptr_t)(_t)->syscallbuf_lib_end)
-
-/**
- * True when |_eip| is just before a syscall trap instruction for a
- * traced syscall made by the syscallbuf code.  Callers may assume
- * |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
- *
- * |int $0x80| is |5d 80|, so the magic-looking |2| below is
- * |sizeof(int $0x80)|.
- */
-#define SYSCALLBUF_IS_IP_ENTERING_TRACED_SYSCALL(_eip, _t)		\
-	((uintptr_t)(_eip) + 2 == (uintptr_t)(_t)->traced_syscall_ip)	\
-
-/**
- * True when |_eip| is at a traced syscall made by the syscallbuf
- * code.  Callers may assume |SYSCALLBUF_IS_IP_IN_LIB()| is implied by
- * this.
- */
-#define SYSCALLBUF_IS_IP_TRACED_SYSCALL(_eip, _t)			\
-	((uintptr_t)(_eip) == (uintptr_t)(_t)->traced_syscall_ip)	\
-
-/**
- * True when |_eip| is at a buffered (and therefore untraced) syscall,
- * i.e. one initiated by a libc wrapper in the library.  Callers may
- * assume |SYSCALLBUF_IS_IP_IN_LIB()| is implied by this.
- */
-#define SYSCALLBUF_IS_IP_UNTRACED_SYSCALL(_eip, _t)			\
-	((uintptr_t)(_eip) == (uintptr_t)(_t)->untraced_syscall_ip)	\
-
 /* "Magic" (rr-implemented) syscall that we use to initialize the
  * syscallbuf.
  *

--- a/src/share/ipc.cc
+++ b/src/share/ipc.cc
@@ -32,8 +32,7 @@ size_t set_child_data(Task *t)
 
 void set_return_value(Task* t)
 {
-	struct user_regs_struct r;
-	t->get_regs(&r);
+	struct user_regs_struct r = t->regs();
 	r.eax = t->trace.recorded_regs.eax;
 	t->set_regs(r);
 }

--- a/src/share/trace.cc
+++ b/src/share/trace.cc
@@ -488,7 +488,7 @@ static void collect_execution_info(Task* t, struct trace_frame* frame)
 	frame->page_faults = read_page_faults(t->hpc);
 	frame->insts = read_insts(t->hpc);
 #endif
-	t->get_regs(&frame->recorded_regs);
+	frame->recorded_regs = t->regs();
 }
 
 /**

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -50,6 +50,12 @@ struct trace_frame;
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
 #define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
 
+/* The tracee doesn't open the desched event fd during replay, so it
+ * can't be shared to this process.  We pretend that the tracee shared
+ * this magic fd number with us and then give it a free pass for fd
+ * checks that include this fd. */
+#define REPLAY_DESCHED_EVENT_FD -123
+
 /**
  * Collecion of data describing a mapped memory segment, as parsed
  * from /proc/[tid]/maps on linux.
@@ -122,7 +128,7 @@ byte* str2x(const char* start, size_t max_size);
 void read_line(FILE* file, char* buf, int size, const char* name);
 
 void print_register_file_tid(Task* t);
-void print_register_file(struct user_regs_struct* regs);
+void print_register_file(const struct user_regs_struct* regs);
 
 /**
  * Create a file named |filename| and dump |buf_len| words in |buf| to
@@ -332,25 +338,6 @@ void record_struct_mmsghdr(Task* t, struct mmsghdr* child_mmsghdr);
 void restore_struct_msghdr(Task* t, struct msghdr* child_msghdr);
 /** Like restore_struct_msghdr(), but for mmsghdr. */
 void restore_struct_mmsghdr(Task* t, struct mmsghdr* child_mmsghdr);
-
-/**
- * Return nonzero if |t|'s current registers |regs| indicate that
- * |t| is at an arm-desched-event or disarm-desched-event syscall.
- */
-int is_desched_event_syscall(Task* t,
-			     const struct user_regs_struct* regs);
-/**
- * Return nonzero if |t|'s current registers |regs| indicate that
- * |t| is at an arm-desched-event syscall.
- */
-int is_arm_desched_event_syscall(Task* t,
-				 const struct user_regs_struct* regs);
-/**
- * Return nonzero if |t|'s current registers |regs| indicate that
- * |t| is at a disarm-desched-event syscall.
- */
-int is_disarm_desched_event_syscall(Task* t,
-				    const struct user_regs_struct* regs);
 
 /**
  * Return true if a FUTEX_LOCK_PI operation on |futex| done by |t|


### PR DESCRIPTION
This is the target simplification for #801.  I'm going to spend a few more minutes seeing if we can de-duplicate some of the go-to-X local helpers across the rr tree, but punt long and far if that looks hard.
