### PR TITLE
Add Task::read_c_str() helper, and remove old one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set(BASIC_TESTS
   fcntl_owner_ex
   flock
   fork_syscalls
+  getcwd
   goto_event
   hello
   ignored_async_usr1

--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -2083,18 +2083,18 @@ void rec_process_syscall(Task *t)
 	 * int open(const char *pathname, int flags, mode_t mode)
 	 */
 	case SYS_open: {
-		char* pathname = read_child_str(t, (byte*)t->regs().ebx);
-		if (is_blacklisted_filename(pathname)) {
+		string pathname = t->read_c_str((const byte*)t->regs().ebx);
+		if (is_blacklisted_filename(pathname.c_str())) {
 			/* NB: the file will still be open in the
 			 * process's file table, but let's hope this
 			 * gross hack dies before we have to worry
 			 * about that. */
-			log_warn("Cowardly refusing to open %s", pathname);
+			log_warn("Cowardly refusing to open %s",
+				 pathname.c_str());
 			struct user_regs_struct r = t->regs();
 			r.eax = -ENOENT;
 			t->set_regs(r);
 		}
-		free(pathname);
 		break;
 	}
 

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -54,6 +54,4 @@ size_t set_child_data(Task* t);
 
 void set_return_value(Task* context);
 
-char* read_child_str(Task* t, byte* addr);
-
 #endif /* __IPC_H__ */

--- a/src/share/task.cc
+++ b/src/share/task.cc
@@ -1170,6 +1170,30 @@ Task::post_exec()
 	prname = prname_from_exe_image(as->exe_image());
 }
 
+string
+Task::read_c_str(const byte* child_addr)
+{
+	// XXX handle invalid C strings
+	string str;
+	while (true) {
+		// We're only guaranteed that [child_addr,
+		// end_of_page) is mapped.
+		const byte* end_of_page = ceil_page_size(child_addr + 1);
+		ssize_t nbytes = end_of_page - child_addr;
+		char buf[nbytes];
+
+		read_bytes_helper(child_addr, nbytes,
+				  reinterpret_cast<byte*>(buf));
+		for (int i = 0; i < nbytes; ++i) {
+			if ('\0' == buf[i]) {
+				return str;
+			}
+			str += buf[i];
+		}
+		child_addr = end_of_page;
+	}
+}
+
 long
 Task::read_word(const byte* child_addr)
 {

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -1175,6 +1175,12 @@ public:
 	}
 
 	/**
+	 * Read and return the C string located at |child_addr| in
+	 * this address space.
+	 */
+	std::string read_c_str(const byte* child_addr);
+
+	/**
 	 * Return the word at |child_addr| in this address space.
 	 *
 	 * NB: doesn't use the ptrace API, so safe to use even when

--- a/src/share/trace.cc
+++ b/src/share/trace.cc
@@ -688,15 +688,13 @@ void record_child_str(Task* t, byte* child_ptr)
 	(void)state;
 
 	print_header(event, child_ptr);
-	char* buf = read_child_str(t, child_ptr);
-	size_t len = strlen(buf) + 1;
-	fprintf(syscall_header, "%11d\n", len);
-	size_t bytes_written = fwrite(buf, 1, len, raw_data);
+	string str = t->read_c_str(child_ptr);
+	fprintf(syscall_header, "%11d\n", str.size());
+	size_t bytes_written = fwrite(str.c_str(), 1, str.size(), raw_data);
 	(void)bytes_written;
-	overall_raw_bytes += len;
+	overall_raw_bytes += str.size();
 
-	assert(bytes_written == len);
-	free(buf);
+	assert(bytes_written == str.size());
 
 	// new raw data file
 	if (overall_raw_bytes > MAX_RAW_DATA_SIZE)

--- a/src/share/util.cc
+++ b/src/share/util.cc
@@ -514,6 +514,12 @@ size_t ceil_page_size(size_t sz)
 	return (sz + page_size() - 1) & page_mask;
 }
 
+const byte* ceil_page_size(const byte* addr)
+{
+	uintptr_t ceil = ceil_page_size((uintptr_t)addr);
+	return (const byte*)ceil;
+}
+
 void print_inst(Task* t)
 {
 	int size;

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -302,10 +302,11 @@ struct current_state_buffer {
 void mprotect_child_region(Task* t, byte* addr, int prot);
 
 /**
- * Return |sz| rounded up to the nearest multiple of the system
- * |page_size()|.
+ * Return the argument rounded up to the nearest multiple of the
+ * system |page_size()|.
  */
 size_t ceil_page_size(size_t sz);
+const byte* ceil_page_size(const byte* addr);
 
 /**
  * Return true if the pointer or size is a multiple of the system

--- a/src/test/getcwd.c
+++ b/src/test/getcwd.c
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	ssize_t pagesize = sysconf(_SC_PAGESIZE);
+	ssize_t two_pages_size = 2 * pagesize;
+	void* two_pages = mmap(NULL, two_pages_size, PROT_READ | PROT_WRITE,
+			   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	void* two_pages_end = two_pages + two_pages_size;
+	char* cwd;
+	char *expected_cwd;
+
+	test_assert(argc == 2);
+	expected_cwd = argv[1];
+
+	test_assert(two_pages != (void*)-1);
+	/* Make the value returned into |path| overlap two physical
+	 * pages. */
+	cwd = two_pages + pagesize - 3;
+	test_assert(cwd == getcwd(cwd, two_pages_end - (void*)cwd));
+	atomic_printf("current working directory is %s; should be %s\n",
+		      cwd, expected_cwd);
+	test_assert(!strcmp(cwd, expected_cwd));
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/getcwd.run
+++ b/src/test/getcwd.run
@@ -1,0 +1,6 @@
+test=getcwd
+source `dirname $0`/util.sh $test "$@"
+
+record $test "$PWD"
+replay
+check EXIT-SUCCESS

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <linux/limits.h>
 #include <linux/perf_event.h>
 #include <poll.h>
 #include <pthread.h>


### PR DESCRIPTION
This is part of the ancillary plan with #801 and #802, to modernize {ipc,sys}{c,h}, but doesn't technically fit with either one.
