### PR TITLE
Use the Task::write*() helpers.

### DIFF
--- a/src/replayer/rep_process_event.cc
+++ b/src/replayer/rep_process_event.cc
@@ -597,25 +597,10 @@ static void process_clone(Task* t,
 	t->set_data_from_trace();
 	t->set_data_from_trace();
 
-	size_t size;
-	byte* rec_addr;
-	byte* data = (byte*)read_raw_data(&(t->trace), &size, &rec_addr);
-	if (data != NULL ) {
-		write_child_data_n(new_task, size, rec_addr, data);
-		free(data);
-	}
-
-	data = (byte*)read_raw_data(&(t->trace), &size, &rec_addr);
-	if (data != NULL ) {
-		write_child_data_n(new_task, size, rec_addr, data);
-		free(data);
-	}
-
-	data = (byte*)read_raw_data(&(t->trace), &size, &rec_addr);
-	if (data != NULL ) {
-		write_child_data_n(new_task, size, rec_addr, data);
-		free(data);
-	}
+	new_task->trace = t->trace;
+	new_task->set_data_from_trace();
+	new_task->set_data_from_trace();
+	new_task->set_data_from_trace();
 
 	struct user_regs_struct r = t->regs();
 	/* set the ebp register to the recorded value -- it should not
@@ -653,7 +638,7 @@ static void process_futex(Task* t, int state, struct rep_trace_step* step,
 				// since we emulate SYS_futex in
 				// replay, we need to set it ourselves
 				// here.
-				t->write_word(futex, next_val);
+				t->write_mem(futex, next_val);
 			}
 		}
 		step->action = TSTEP_ENTER_SYSCALL;
@@ -1723,14 +1708,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		 * ebx register is not zero. in this case, no recorded
 		 * data needs to be injected */
 		if (check == 0) {
-			size_t size;
-			byte* rec_addr;
-			byte* data = (byte*)read_raw_data(&(t->trace),
-							  &size, &rec_addr);
-			if (data) {
-				write_child_data(t, size, rec_addr, data);
-				free(data);
-			}
+			t->set_data_from_trace();
 		}
 
 		init_scratch_memory(t);

--- a/src/share/ipc.h
+++ b/src/share/ipc.h
@@ -44,10 +44,4 @@ void read_child_usr(Task *t, void *dest, void *src, size_t size);
 void* read_child_data_checked(Task *t, size_t size, byte* addr, ssize_t *read_bytes);
 ssize_t checked_pread(Task* t, byte* buf, size_t size, off_t offset);
 
-void write_child_code(Task* t, void* addr, long code);
-void write_child_data_n(Task* t, ssize_t size, byte* addr,
-			const byte* data);
-void write_child_data(Task* t, ssize_t size, byte* addr,
-		      const byte* data);
-
 #endif /* __IPC_H__ */

--- a/src/share/task.h
+++ b/src/share/task.h
@@ -1308,20 +1308,26 @@ public:
 
 	/**
 	 * Write |val| to |child_addr|.
-	 */
-	template<typename T>
-	void write_mem(const byte* child_addr, const T* val) {
-		return write_bytes_helper(child_addr, sizeof(*val),
-					  reinterpret_cast<const byte*>(val));
-	}
-
-	/**
-	 * Write |word| to |child_addr| in this address space.
 	 *
 	 * NB: doesn't use the ptrace API, so safe to use even when
 	 * the tracee isn't at a trace-stop.
 	 */
-	void write_word(const byte* child_addr, long word);
+	template<typename T>
+	void write_mem(const byte* child_addr, const T& val) {
+		return write_bytes_helper(child_addr, sizeof(val),
+					  reinterpret_cast<const byte*>(&val));
+	}
+
+	/**
+	 * Don't use these helpers directly; use the safer and more
+	 * convenient variants above.
+	 *
+	 * Read/write the number of bytes that the template wrapper
+	 * inferred.
+	 */
+	void read_bytes_helper(const byte* addr, ssize_t buf_size, byte* buf);
+	void write_bytes_helper(const byte* addr,
+				ssize_t buf_size, const byte* buf);
 
 	/** Return an iterator at the beginning of the task map. */
 	static Map::const_iterator begin();
@@ -1548,14 +1554,6 @@ private:
 	 * Either the request succeeds, or this doesn't return.
 	 */
 	void xptrace(int request, void* addr, void* data);
-
-	/**
-	 * Read/write the number of bytes that the template wrapper
-	 * inferred.
-	 */
-	void read_bytes_helper(const byte* addr, ssize_t buf_size, byte* buf);
-	void write_bytes_helper(const byte* addr,
-				ssize_t buf_size, const byte* buf);
 
 	/* The address space of this task. */
 	std::shared_ptr<AddressSpace> as;

--- a/src/share/util.h
+++ b/src/share/util.h
@@ -290,12 +290,14 @@ const char* syscallname(int syscall);
  */
 int clone_flags_to_task_flags(int flags_arg);
 
+static const byte syscall_insn[] = { 0xcd, 0x80 };
+
 // TODO: RAII-ify me and helpers below.
 struct current_state_buffer {
 	pid_t pid;
 	struct user_regs_struct regs;
 	int code_size;
-	byte* code_buffer;
+	byte code_buffer[sizeof(syscall_insn)];
 	byte* start_addr;
 };
 


### PR DESCRIPTION
Along the #801 / #802 road.  Took too long because there was a nasty little bug with an inferred template param.
