### PR TITLE
Have Task manage its mem fd.

### DIFF
--- a/src/share/sys.cc
+++ b/src/share/sys.cc
@@ -62,18 +62,6 @@ void sys_close(int filedes)
 	}
 }
 
-int sys_open_child_mem(Task* t)
-{
-	char path[PATH_MAX];
-	int fd;
-
-	snprintf(path, sizeof(path) - 1, "/proc/%d/mem", t->tid);
-	fd = open(path, O_RDWR);
-	assert_exec(t, fd >= 0, "Failed to open %s", path);
-
-	return fd;
-}
-
 pid_t sys_fork()
 {
 	pid_t pid = fork();

--- a/src/share/sys.h
+++ b/src/share/sys.h
@@ -19,7 +19,6 @@ int sys_open(const char* path, int flags, mode_t mode);
 int sys_mkpath(const char *path, mode_t mode);
 void sys_fclose(FILE* file);
 pid_t sys_fork(void);
-int sys_open_child_mem(Task* t);
 void sys_kill(int pid, int msg);
 void sys_exit(void);
 void sys_start_trace(const char* executable, char** fake_argv, char** envp);


### PR DESCRIPTION
Semantics-preserving refactoring down the road of #801 / #802.

Turns out we can't away from reopening that fd.  My first patch had the fd opened on demand, but the reopen was still required.  Oh well.
