### PR TITLE
Fix getsockopt().

### DIFF
--- a/src/recorder/rec_process_event.cc
+++ b/src/recorder/rec_process_event.cc
@@ -1169,7 +1169,7 @@ static void process_socketcall(Task* t, int call, byte* base_addr)
 	 *  int getsockopt(int sockfd, int level, int optname, const void *optval, socklen_t* optlen);
 	 */
 	case SYS_GETSOCKOPT: {
-		struct { long sockfd; long level;
+		struct { long sockfd; long level; int optname;
 			void* optval; socklen_t* optlen; } args;
 		t->read_mem(base_addr, &args);
 		socklen_t optlen = t->read_word((byte*)args.optlen);


### PR DESCRIPTION
Regressed by 5f585e4777da518a575876eb5d006ba245a0578b.  Really need those tests.
