### PR TITLE
Reply to gdb's detach request so the client shuts down more quickly.

### DIFF
--- a/src/debugger_gdb.cc
+++ b/src/debugger_gdb.cc
@@ -1409,6 +1409,15 @@ void dbg_reply_watchpoint_request(struct dbg_context* dbg, int code)
 	consume_request(dbg);
 }
 
+void dbg_reply_detach(struct dbg_context* dbg)
+{
+	assert(DREQ_DETACH <= dbg->req.type);
+
+	write_packet(dbg, "OK");
+
+	consume_request(dbg);
+}
+
 void dbg_destroy_context(struct dbg_context** dbg)
 {
 	struct dbg_context* d;

--- a/src/debugger_gdb.h
+++ b/src/debugger_gdb.h
@@ -300,6 +300,15 @@ void dbg_reply_get_thread_list(struct dbg_context* dbg,
 void dbg_reply_watchpoint_request(struct dbg_context* dbg, int code);
 
 /**
+ * DREQ_DETACH was processed.
+ *
+ * There's no functional reason to reply to the detach request.
+ * However, some versions of gdb expect a response and time out
+ * awaiting it, wasting developer time.
+ */
+void dbg_reply_detach(struct dbg_context* dbg);
+
+/**
  * Destroy a gdb debugging context created by
  * |dbg_await_client_connection()|.  It's legal to pass a null |*dbg|.
  * The passed-in outparam is nulled on return.

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -1803,6 +1803,7 @@ static void replay_one_trace_frame(struct dbg_context* dbg, Task* t)
 
 	if (DREQ_DETACH == req.type) {
 		log_info("(debugger detached from us, rr exiting)");
+		dbg_reply_detach(dbg);
 		dbg_destroy_context(&dbg);
 		exit(0);
 	}


### PR DESCRIPTION
Resolves #841.

Oddly, I never saw this in my x86 VM.
