### PR TITLE
New threads aren't non-switchable, so waitpid() them before scheduling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ set(BASIC_TESTS
   tiocinq
   truncate
   uname
+  unjoined_thread
   user_ignore_sig
 )
 

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1527,6 +1527,11 @@ void rec_process_syscall(Task *t)
 		pop_syscall(new_task);
 
 		init_scratch_memory(new_task);
+		// The new tracee just "finished" a clone that was
+		// started by its parent.  It has no pending events,
+		// so it can be context-switched out.
+		new_task->event = SYS_clone;
+		new_task->switchable = 1;
 
 		break;
 	}

--- a/src/recorder_sched.cc
+++ b/src/recorder_sched.cc
@@ -81,22 +81,24 @@ find_next_runnable_task(int* by_waitpid)
 			Task* t = task_iterator->second;
 
 			if (t->unstable) {
-				debug("  %d is unstable, going to waitpid(-1)", tid);
+				debug("  %d is unstable, going to waitpid(-1)",
+				      t->tid);
 				return NULL;
 			}
 
 			if (!t->may_be_blocked()) {
-				debug("  %d isn't blocked", tid);
+				debug("  %d isn't blocked", t->tid);
 				return t;
 			}
 
-			debug("  %d is blocked on %s, checking status ...", tid,
+			debug("  %d is blocked on %s, checking status ...",
+			      t->tid,
 			      strevent(t->event));
 			if ((t->pseudo_blocked && t->wait())
 			    || t->try_wait()) {
 				t->pseudo_blocked = 0;
 				*by_waitpid = 1;
-				debug("  ready with status 0x%x", t->status);
+				debug("  ready with status 0x%x", t->status());
 				return t;
 			}
 			debug("  still blocked");
@@ -152,7 +154,7 @@ Task* rec_sched_get_active_thread(Task* t, int* by_waitpid)
 			}
 #endif
 			*by_waitpid = 1;
-			debug("  new status is 0x%x", current->status);
+			debug("  new status is 0x%x", current->status());
 		}
 		return current;
 	}

--- a/src/test/unjoined_thread.c
+++ b/src/test/unjoined_thread.c
@@ -1,0 +1,18 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static void* thread(void* unused) {
+	sleep(-1);
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	pthread_t t;
+
+	pthread_create(&t, NULL, thread, NULL);
+	/* Don't join |t|. */
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/unjoined_thread.run
+++ b/src/test/unjoined_thread.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh unjoined_thread "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
Resolves #694.

This is a little bit of a sneaky fix, but threads dying before they run is an edge case so I'm not too embarrassed.
