### PR TITLE
Make aborts due to tracees calling ptrace() leave behind debuggable trac...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(BASIC_TESTS
   prctl_name
   priority
   prw
+  ptrace
   rdtsc
   save_data_fd
   sched_setaffinity
@@ -189,6 +190,7 @@ set(CUSTOM_TESTS
   break_int3
   break_mmap_private
   break_msg
+  break_ptrace
   break_rdtsc
   break_sigreturn
   break_sync_signal

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -41,6 +41,7 @@
 
 #include "dbg.h"
 #include "drm.h"
+#include "recorder.h"		// for terminate_recording()
 #include "recorder_sched.h"
 #include "sys.h"
 #include "task.h"
@@ -491,9 +492,6 @@ int rec_prepare_syscall(Task* t, byte** kernel_sync_addr, uint32_t* sync_val)
 	}
 
 	switch (syscallno) {
-	case SYS_ptrace:
-		fatal("Ptrace not yet implemented.  We need to go deeper.");
-
 	case SYS_splice: {
 		struct user_regs_struct r = t->regs();
 		loff_t* off_in = (loff_t*)r.ecx;
@@ -746,6 +744,20 @@ int rec_prepare_syscall(Task* t, byte** kernel_sync_addr, uint32_t* sync_val)
 		t->set_regs(r);
 		return 1;
 	}
+
+	case SYS_ptrace:
+		fprintf(stderr,
+"\n"
+"rr: internal recorder error:\n"
+"  ptrace() is not yet supported.  We need to go deeper.\n"
+"\n"
+"  Your trace is being synced and will be available for replay when\n"
+"  this process exits.\n"
+			);
+		terminate_recording(t);
+		fatal("Not reached");
+		return 0;
+
 
 	case SYS_epoll_pwait:
 		fatal("Unhandled syscall %s", strevent(syscallno));

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -4,7 +4,16 @@
 #define RECORDER_H_
 
 struct flags;
+class Task;
 
 void record(void);
+
+/**
+ * Record a trace-termination event, sync the trace files, and shut
+ * down.  The |t| argument allows this to give task context to the
+ * trace-termination event.  It should be the most-recently-known
+ * executed task.
+ */
+void terminate_recording(Task* t = nullptr);
 
 #endif /* RECORDER_H_ */

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1485,6 +1485,22 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		}
 		return;
 
+	case SYS_ptrace:
+		step->syscall.emu = 1;
+		if (STATE_SYSCALL_ENTRY == state) {
+			step->action = TSTEP_ENTER_SYSCALL;
+			return;
+		}
+		// ptrace isn't supported yet, but we bend over
+		// backwards to make traces that contain ptrace aborts
+		// as pleasantly debuggable as possible.  This is
+		// because several crash-monitoring systems use ptrace
+		// to generate crash reports, and those are exactly
+		// the kinds of events users will want to debug.
+		assert_exec(t, false,
+			    "Should have reached trace termination.");
+		return;		// not reached
+
 	case SYS_quotactl:
 		step->syscall.emu = 1;
 		step->syscall.emu_ret = 1;

--- a/src/syscall_defs.h
+++ b/src/syscall_defs.h
@@ -838,6 +838,18 @@ SYSCALL_DEF(EMU, pwrite64, 0)
 SYSCALL_DEF(EXEC, prlimit64, 1)
 
 /**
+ *  long ptrace(enum __ptrace_request request, pid_t pid,
+ *              void *addr, void *data);
+ *
+ * The ptrace() system call provides a means by which one process (the
+ * "tracer") may observe and control the execution of another process
+ * (the "tracee"), and examine and change the tracee's memory and
+ * registers.  It is primarily used to implement breakpoint debugging
+ * and system call tracing.
+ */
+SYSCALL_DEF(IRREGULAR, ptrace, -1)
+
+/**
  *  int quotactl(int cmd, const char *special, int id, caddr_t addr);
  *
  * The quotactl() call manipulates disk quotas.  The cmd argument

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -27,6 +27,7 @@
 #include <sys/mman.h>
 #include <sys/msg.h>
 #include <sys/prctl.h>
+#include <sys/ptrace.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -567,10 +567,11 @@ void record_event(Task *t)
 	}
 }
 
-void record_trace_termination_event()
+void record_trace_termination_event(Task* t)
 {
 	struct trace_frame frame;
 	memset(&frame, 0, sizeof(frame));
+	frame.tid = t ? t->tid : 0;
 	frame.global_time = global_time++;
 	frame.stop_reason = USR_TRACE_TERMINATION;
 	write_trace_frame(&frame);

--- a/src/trace.h
+++ b/src/trace.h
@@ -184,9 +184,10 @@ void record_parent_data(Task *t, size_t len, void *addr, void *buf);
 void record_event(Task* t);
 /**
  * Record that the trace will be ending abnormally early, usually
- * because of an interrupting signal.
+ * because of an interrupting signal.  |t| was the last task known to
+ * have run, and it may be nullptr.
  */
-void record_trace_termination_event();
+void record_trace_termination_event(Task* t);
 void record_mmapped_file_stats(struct mmapped_file *file);
 /**
  * Return the current global time.  This is approximately the number


### PR DESCRIPTION
...es.

Resolves #859.
