### PR TITLE
Drop all parent breakpoints in fork() child and fix test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(BASIC_TESTS
   clone
   condvar_stress
   crash
+  exec_self
   exit_group
   fadvise
   fault_in_code_page

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -588,6 +588,13 @@ static void process_clone(Task* t,
 	new_task->set_data_from_trace();
 	new_task->set_data_from_trace();
 	new_task->set_data_from_trace();
+	if (!(CLONE_VM & flags)) {
+		// It's hard to imagine a scenario in which it would
+		// be useful to inherit breakpoints (along with their
+		// refcounts) across a non-VM-sharing clone, but for
+		// now we never want to do this.
+		new_task->vm()->destroy_all_breakpoints();
+	}
 
 	struct user_regs_struct r = t->regs();
 	/* set the ebp register to the recorded value -- it should not

--- a/src/test/break_exec.run
+++ b/src/test/break_exec.run
@@ -1,3 +1,3 @@
 source `dirname $0`/util.sh break_exec "$@"
-record prctl_name
-debug prctl_name generic_break
+record exec_self
+debug exec_self generic_break

--- a/src/test/exec_self.c
+++ b/src/test/exec_self.c
@@ -1,0 +1,24 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static void breakpoint(void) {
+	int break_here = 1;
+	(void)break_here;
+}
+
+int main(int argc, char *argv[]) {
+	test_assert(argc == 1 || (argc == 2 && !strcmp("self", argv[1])));
+
+	if (argc != 2) {
+		atomic_printf("exec(%s, 'self') ...\n", argv[0]);
+
+		breakpoint();
+		/* No syscalls in between here. */
+		execlp(argv[0], argv[0], "self", NULL);
+		test_assert("Not reached" && 0);
+	}
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/exec_self.run
+++ b/src/test/exec_self.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh simple "$@"
+compare_test EXIT-SUCCESS

--- a/src/test/prctl_name.c
+++ b/src/test/prctl_name.c
@@ -12,11 +12,6 @@ const char thread_name[] = "thread";
 const char fork_child_name[] = "fchild";
 const char exec_child_name[] = "echild";
 
-static void breakpoint(void) {
-	int break_here = 1;
-	(void)break_here;
-}
-
 static void assert_prname_is(const char* tag, const char* name) {
 	char prname[PRNAME_NUM_BYTES] = { 0 };
 	test_assert(0 == prctl(PR_GET_NAME, prname));
@@ -49,8 +44,6 @@ static void* thread(void* unused) {
 	prctl(PR_SET_NAME, fork_child_name);
 	assert_prname_is("fork child", fork_child_name);
 
-	breakpoint();
-	/* No syscalls in between here. */
 	execl(exe_image, exe_image, "exec child", NULL);
 	test_assert("Not reached" && 0);
 


### PR DESCRIPTION
#858 part 2.
