### PR TITLE
Support TIOCGWINSZ ioctl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ set(BASIC_TESTS
   threaded_syscall_spam
   threads
   tiocinq
+  tiocgwinsz
   truncate
   uname
   unjoined_thread

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -731,6 +731,7 @@ static void process_ioctl(Task* t, int state, struct rep_trace_step* step)
 	switch (request) {
 	case TCGETS:
 	case TIOCINQ:
+	case TIOCGWINSZ:
 		step->syscall.num_emu_args = 1;
 		return;
 	}

--- a/src/test/tiocgwinsz.c
+++ b/src/test/tiocgwinsz.c
@@ -1,0 +1,16 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	int ret;
+	struct winsize w;
+
+	memset(&w, 0x5a, sizeof(w));
+	ret = ioctl(STDIN_FILENO, TIOCGWINSZ, &w);
+	atomic_printf("TIOCWINSZ returned {row:%d col:%d} (ret:%d)\n",
+		      w.ws_row, w.ws_col, ret);
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/tiocgwinsz.run
+++ b/src/test/tiocgwinsz.run
@@ -1,0 +1,6 @@
+testname=tiocgwinsz
+source `dirname $0`/util.sh $testname "$@"
+
+record $testname
+replay $replayflags
+check EXIT-SUCCESS


### PR DESCRIPTION
Other parts of gecko use this, but I don't think it's contributing to #876.  Using that as an excuse to fix it though.
