### PR TITLE
Followup: recvmsg flags are passed through socketcall arg, not registers...

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -372,15 +372,14 @@ static int prepare_socketcall(Task* t, int would_need_scratch)
 	case SYS_RECVMSG: {
 		struct user_regs_struct r = t->regs();
 		byte* argsp = (byte*)r.ecx;
-		int flags = r.edx;
-		if (flags & MSG_DONTWAIT) {
+		struct recvmsg_args args;
+		t->read_mem(argsp, &args);
+		if (args.flags & MSG_DONTWAIT) {
 			return 0;
 		}
 		if (!would_need_scratch) {
 			return 1;
 		}
-		struct recvmsg_args args;
-		t->read_mem(argsp, &args);
 		struct msghdr msg;
 		t->read_mem((byte*)args.msg, &msg);
 
@@ -441,8 +440,11 @@ static int prepare_socketcall(Task* t, int would_need_scratch)
 		return 1;
 	}
 	case SYS_SENDMSG: {
-		int flags = r.edx;
-		return !(flags & MSG_DONTWAIT);
+		struct user_regs_struct r = t->regs();
+		byte* argsp = (byte*)r.ecx;
+		struct recvmsg_args args;
+		t->read_mem(argsp, &args);
+		return !(args.flags & MSG_DONTWAIT);
 	}
 	default:
 		return 0;

--- a/src/recorder_sched.cc
+++ b/src/recorder_sched.cc
@@ -148,9 +148,9 @@ Task* rec_sched_get_active_thread(Task* t, int* by_waitpid)
 #ifdef MONITOR_UNSWITCHABLE_WAITS
 			wait_duration = now_sec() - start;
 			if (wait_duration >= 0.010) {
-				warn("Waiting for unswitchable %s took %g ms",
-				     strevent(current->event),
-				     1000.0 * wait_duration);
+				log_warn("Waiting for unswitchable %s took %g ms",
+					 strevent(current->event),
+					 1000.0 * wait_duration);
 			}
 #endif
 			*by_waitpid = 1;


### PR DESCRIPTION
....

Resolves #192, for real this time.
