### PR TITLE
Make writes to the save-data fd work as one would expect them to.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -88,6 +88,23 @@ struct recvfrom_args {
 	socklen_t* addrlen;
 };
 
+void rec_before_record_syscall_entry(Task* t, int syscallno)
+{
+	if (SYS_write != syscallno) {
+		return;
+	}
+	int fd = t->regs().ebx;
+	if (RR_MAGIC_SAVE_DATA_FD != fd) {
+		return;
+	}
+	byte* buf = (byte*)t->regs().ecx;
+	size_t len = t->regs().edx;
+
+	assert_exec(t, buf, "Can't save a null buffer");
+
+	record_child_data(t, len, buf);
+}
+
 /**
  * Read the socketcall args pushed by |t| as part of the syscall in
  * |regs| into the |args| outparam.  Also store the address of the
@@ -3275,22 +3292,7 @@ void rec_process_syscall(Task *t)
 	 * proved to occur after a write() has returned returns the new data. Note that not all file
 	 *  systems are POSIX conforming.
 	 */
-	case SYS_write: {
-		struct user_regs_struct r = t->regs();
-		int fd = r.ebx;
-
-		if (RR_MAGIC_SAVE_DATA_FD == fd) {
-			byte* buf = (byte*)r.ecx;
-			size_t len = r.edx;
-
-			assert_exec(t, buf, "Can't save a null buffer");
-
-			record_child_data(t, len, buf);
-			r.eax = len;
-			t->set_regs(r);
-		}
-		break;
-	}
+	SYS_REC0(write)
 
 	/*
 	 * ssize_t read(int fd, void *buf, size_t count);

--- a/src/record_syscall.h
+++ b/src/record_syscall.h
@@ -9,6 +9,13 @@
 class Task;
 
 /**
+ * Call this just before the recorder is going to store a
+ * syscall-entry event.  If any data needs to be saved at syscall
+ * entry, do it now.
+ */
+void rec_before_record_syscall_entry(Task* t, int syscallno);
+
+/**
  * Prepare |t| to enter its current syscall event.  Return nonzero if
  * a context-switch is allowed for |t|, 0 if not.
  *

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -597,6 +597,7 @@ static void runnable_state_changed(Task* t)
 		/* We just entered a syscall. */
 		if (!maybe_restart_syscall(t)) {
 			push_syscall(t, t->event);
+			rec_before_record_syscall_entry(t, t->ev->syscall.no);
 		}
 		assert_exec(t, EV_SYSCALL == t->ev->type,
 			    "Should be at syscall event.");

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1276,6 +1276,14 @@ static void maybe_verify_tracee_saved_data(Task* t,
 	free(rec_buf);
 }
 
+void rep_after_enter_syscall(Task* t, int syscallno)
+{
+	if (SYS_write != syscallno) {
+		return;
+	}
+	maybe_verify_tracee_saved_data(t, &t->trace.recorded_regs);
+}
+
 /**
  * Call this hook just before exiting a syscall.  Often Task
  * attributes need to be updated based on the finishing syscall.
@@ -1637,11 +1645,6 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		 * so we might have saved 0 bytes of scratch after a
 		 * desched. */
 		maybe_noop_restore_syscallbuf_scratch(t);
-		if (SYS_write == syscall) {
-			// TODO: we only support tracee-saved data
-			// through write for now.
-			maybe_verify_tracee_saved_data(t, rec_regs);
-		}
 		return;
 
 	case SYS_rrcall_init_buffers:

--- a/src/replay_syscall.h
+++ b/src/replay_syscall.h
@@ -8,6 +8,12 @@
 class Task;
 struct rep_trace_step;
 
+/**
+ * Call this when |t| has just entered a syscall.  At this point, data
+ * saved at |rec_before_record_syscall_entry()| can be restored.
+ */
+void rep_after_enter_syscall(Task* t, int syscallno);
+
 /* |redirect_stdio| is nonzero if output written to stdout/stderr
  * during recording should be tee'd during replay, zero otherwise. */
 void rep_process_syscall(Task* t, struct rep_trace_step* step);

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -1692,6 +1692,9 @@ static void replay_one_trace_frame(struct dbg_context* dbg, Task* t)
 		exit(0);
 	}
 
+	if (TSTEP_ENTER_SYSCALL == step.action) {
+		rep_after_enter_syscall(t, step.syscall.no);
+	}
 	if (STATE_SYSCALL_EXIT == t->trace.state
 	    && rr_flags()->check_cached_mmaps) {
 		t->vm()->verify(t);

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -122,10 +122,8 @@ inline static pid_t sys_gettid(void) {
  */
 inline static void check_data(void* buf, size_t len)
 {
-	int nwritten = syscall(SYS_write, RR_MAGIC_SAVE_DATA_FD, buf, len);
-	atomic_printf("Wrote %d bytes to magic fd; expected %d\n",
-		      nwritten, len);
-	test_assert(len == nwritten);
+	syscall(SYS_write, RR_MAGIC_SAVE_DATA_FD, buf, len);
+	atomic_printf("Wrote %d bytes to magic fd\n", len);
 }
 
 /**

--- a/src/util.cc
+++ b/src/util.cc
@@ -741,10 +741,8 @@ byte* str2x(const char* start, size_t max_size)
 void read_line(FILE* file, char* buf, int size, const char* name)
 {
 	if (feof(file) || fgets(buf, size, file) == NULL) {
-		printf("error reading line in file: %s  -- bailing out\n", name);
-		printf("buf: %p  size: %d\n",buf,size);
-		perror("");
-		exit(-1);
+		fatal("Failed to read line from %s into buf %p (size %d)",
+		      name, buf, size);
 	}
 }
 


### PR DESCRIPTION
#876.  It's not as useful to record the buffer at exit of write, because any number of events can occur in the intervening time and possibly change buffer contents.
