### PR TITLE
Clean up task tree with SIGKILL, properly.

### DIFF
--- a/src/task.h
+++ b/src/task.h
@@ -551,9 +551,10 @@ struct TaskGroup : public HasTaskSet {
 	static shr_ptr create(Task* t);
 
 	const pid_t tgid;
+	const pid_t real_tgid;
 
 private:
-	TaskGroup(pid_t tgid);
+	TaskGroup(pid_t tgid, pid_t real_tgid);
 
 	TaskGroup(const TaskGroup&);
 	TaskGroup operator=(const TaskGroup&);
@@ -1308,8 +1309,10 @@ public:
 	/** Return the task group this belongs to. */
 	TaskGroup::shr_ptr task_group() { return tg; }
 
-	/** Return the id of this task's thread group. */
-	pid_t tgid() const;
+	/** Return the id of this task's recorded thread group. */
+	pid_t tgid() const { return tg->tgid; }
+	/** Return id of real OS task group. */
+	pid_t real_tgid() const { return tg->real_tgid; }
 
 	/**
 	 * Call this after the tracee successfully makes a


### PR DESCRIPTION
Resolves #775.

Turns out SIGKILL wasn't working previously for a dumb reason: rr was targeting the _recorded_ tgid with its `tgkill()` call.  With that stupid bug fixed, SIGKILL works more or less as I expected.
