### PR TITLE
Go back to using void* for syscallbuf pointers.

### DIFF
--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -57,9 +57,9 @@ struct rrcall_init_buffers_params {
 	 * replay the same decision that was recorded. */
 	int syscallbuf_enabled;
 	/* Where our traced syscalls will originate. */
-	byte* traced_syscall_ip;
+	void* traced_syscall_ip;
 	/* Where our untraced syscalls will originate. */
-	byte* untraced_syscall_ip;
+	void* untraced_syscall_ip;
 	/* Address of the control socket the child expects to connect
 	 * to. */
 	struct sockaddr_un* sockaddr;
@@ -75,7 +75,7 @@ struct rrcall_init_buffers_params {
 	/* "Out" params. */
 	/* Returned pointer to and size of the shared syscallbuf
 	 * segment. */
-	byte* syscallbuf_ptr;
+	void* syscallbuf_ptr;
 };
 
 /**

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -488,7 +488,7 @@ static int set_up_scratch_for_syscallbuf(Task* t, int syscallno)
 
 	reset_scratch_pointers(t);
 	t->ev->syscall.tmp_data_ptr =
-		t->syscallbuf_child +
+		(byte*)t->syscallbuf_child +
 		(rec->extra_data - (byte*)t->syscallbuf_hdr);
 	/* |rec->size| is the entire record including extra data; we
 	 * just care about the extra data here. */

--- a/src/task.h
+++ b/src/task.h
@@ -1588,21 +1588,21 @@ public:
 
 	/* The instruction pointer from which traced syscalls made by
 	 * the syscallbuf will originate. */
-	byte* traced_syscall_ip;
+	void* traced_syscall_ip;
 	/* The instruction pointer from which untraced syscalls will
 	 * originate, used to determine whether a syscall is being
 	 * made by the syscallbuf wrappers or not. */
-	byte* untraced_syscall_ip;
+	void* untraced_syscall_ip;
 	/* Start and end of the mapping of the syscallbuf code
 	 * section, used to determine whether a tracee's $ip is in the
 	 * lib. */
-	byte* syscallbuf_lib_start;
-	byte* syscallbuf_lib_end;
+	void* syscallbuf_lib_start;
+	void* syscallbuf_lib_end;
 	/* Points at rr's mapping of the (shared) syscall buffer. */
 	struct syscallbuf_hdr* syscallbuf_hdr;
 	size_t num_syscallbuf_bytes;
 	/* Points at the tracee's mapping of the buffer. */
-	byte* syscallbuf_child;
+	void* syscallbuf_child;
 
 private:
 	Task(pid_t tid, pid_t rec_tid, int priority);

--- a/src/util.cc
+++ b/src/util.cc
@@ -1746,7 +1746,8 @@ void destroy_buffers(Task* t, int flags)
 	if (t->syscallbuf_child) {
 		remote_syscall2(t, &state, SYS_munmap,
 				t->syscallbuf_child, t->num_syscallbuf_bytes);
-		t->vm()->unmap(t->syscallbuf_child, t->num_syscallbuf_bytes);
+		t->vm()->unmap((const byte*)t->syscallbuf_child,
+			       t->num_syscallbuf_bytes);
 		remote_syscall1(t, &state, SYS_close, t->desched_fd_child);
 	}
 


### PR DESCRIPTION
#832
