### PR TITLE
Fix the case in which a user restarts to an event before the previous -g...

### DIFF
--- a/src/test/goto_event.py
+++ b/src/test/goto_event.py
@@ -1,0 +1,17 @@
+from rrutil import *
+
+send_gdb('b bad_breakpoint\n')
+expect_gdb('Breakpoint 1')
+
+send_gdb('b good_breakpoint\n')
+expect_gdb('Breakpoint 2')
+
+send_gdb('c\n')
+# If we hit bad_breakpoint, then we never continue and never reach
+# good_breakpoint.
+expect_gdb('Breakpoint 2, good_breakpoint')
+
+restart_replay(1)
+expect_gdb('Breakpoint 2, good_breakpoint')
+
+ok()

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -34,8 +34,11 @@ def iterlines_both():
 def last_match():
     return gdb_rr.match
 
-def restart_replay():
-    send_gdb('r\n')
+def restart_replay(event=0):
+    if event:
+        send_gdb('r %d\n'%(event))
+    else:
+        send_gdb('r\n')
     expect_gdb('Start it from the beginning')
     send_gdb('y\n')
 

--- a/src/types.h
+++ b/src/types.h
@@ -49,7 +49,7 @@ typedef unsigned char byte;
 //
 // We force choosers to specify which they mean, and default to the
 // much more useful (and probably common) exec() definition.
-enum { CREATED_EXEC, CREATED_FORK };
+enum { CREATED_DEFAULT = 0, CREATED_EXEC, CREATED_FORK };
 
 struct flags {
 	/* Max counter value before the scheduler interrupts a tracee. */


### PR DESCRIPTION
... target existed.

Resolves #910.
