### PR TITLE
Potpourri of fixes for issues uncovered in ubuntu 13.10.

### DIFF
--- a/src/debugger_gdb.cc
+++ b/src/debugger_gdb.cc
@@ -655,7 +655,6 @@ static dbg_threadid_t parse_threadid(const char* str, char** endptr)
 	assert('.' == *endp);
 	str = endp + 1;
 	t.tid = strtol(str, &endp, 16);
-	assert(endp && '\0' == *endp);
 
 	*endptr = endp;
 	return t;
@@ -844,7 +843,13 @@ static int process_vpacket(struct dbg_context* dbg, char* payload)
 			dbg->req.type = DREQ_STEP;
 			if (args) {
 				dbg->req.target = parse_threadid(args, &args);
-				assert('\0' == *args || !strcmp(args, ";c"));
+				// If we get a step request for a
+				// thread, we just assume that
+				// requests for all other threads are
+				// 'c' (if any).  That's all we can
+				// support anyway.
+				assert('\0' == *args
+				       || args == strstr(args, ";c"));
 			} else {
 				dbg->req.target = dbg->resume_thread;
 			}

--- a/src/task.cc
+++ b/src/task.cc
@@ -556,7 +556,7 @@ AddressSpace::check_segment_iterator(void* pvas, Task* t,
 				   info.inode), info.name);
 
 	if (vas->INITING_KERNEL == vas->phase) {
-		assert(kr == vas->r ||
+		assert(kr == vas->r
 		       // XXX not-so-pretty hack.  If the mapped file
 		       // lives in our replayer's emulated fs, then it
 		       // will have a real system device/inode
@@ -565,7 +565,8 @@ AddressSpace::check_segment_iterator(void* pvas, Task* t,
 		       // we rely on quick access to the recorded
 		       // (i.e. emulated in replay) device/inode for
 		       // gc.  So this suffices for now.
-		       string::npos != kr.fsname.find(SHMEM_FS "/rr-emufs"));
+		       || string::npos != kr.fsname.find(SHMEM_FS "/rr-emufs")
+		       || string::npos != kr.fsname.find(SHMEM_FS2 "/rr-emufs"));
 		vas->km = km;
 		vas->phase = vas->MERGING_KERNEL;
 		return CONTINUE_ITERATING;

--- a/src/test/threaded_syscall_spam.c
+++ b/src/test/threaded_syscall_spam.c
@@ -25,9 +25,8 @@ static void syscall_spam(void) {
 
 static void unblock_signals(void) {
 	sigset_t set;
-	atomic_printf("%d: unblocking all signals...\n", sys_gettid());
 	sigfillset(&set);
-	pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+	test_assert(0 == pthread_sigmask(SIG_UNBLOCK, &set, NULL));
 	atomic_printf("  %d: unblocked all sigs\n", sys_gettid());
 }
 
@@ -47,9 +46,9 @@ int main(int argc, char** argv) {
 
 	atomic_printf("Running 2^%d iterations in two threads\n", num_its);
 
+	atomic_printf("parent %d: blocking all sigs ...\n", getpid());
 	sigfillset(&set);
 	test_assert(0 == pthread_sigmask(SIG_BLOCK, &set, NULL));
-	atomic_puts("parent: blocked all sigs");
 
 	pthread_create(&t, NULL, thread, NULL);
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1096,7 +1096,7 @@ bool is_now_contended_pi_futex(Task* t, void* futex, uint32_t* next_val)
 	bool now_contended = (owner_tid != 0 && owner_tid != t->rec_tid
 			      && !(val & FUTEX_WAITERS));
 	if (now_contended) {
-		debug("[%d] %d: futex %p is %ld, so WAITERS bit will be set",
+		debug("[%d] %d: futex %p is %d, so WAITERS bit will be set",
 		      get_global_time(), t->tid, futex, val);
 		*next_val = (owner_tid & FUTEX_TID_MASK) | FUTEX_WAITERS;
 	}
@@ -1171,7 +1171,10 @@ static bool is_tmp_file(const char* path)
 {
 	struct statfs sfs;
 	statfs(path, &sfs);
-	return TMPFS_MAGIC == sfs.f_type;
+	return (TMPFS_MAGIC == sfs.f_type
+		// In observed configurations of Ubuntu 13.10, /tmp is
+		// a folder in the / fs, not a separate tmpfs.
+		|| path == strstr(path, "/tmp/"));
 }
 
 bool should_copy_mmap_region(const char* filename, const struct stat* stat,

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,7 @@ struct trace_frame;
 	 || -ERESTARTNOHAND == (eax) || -ERESTARTSYS == (eax))
 
 #define SHMEM_FS "/dev/shm"
+#define SHMEM_FS2 "/run/shm"
 
 /* The syscallbuf shared with tracees is created with this prefix
  * followed by the tracee tid, then immediately unlinked and shared


### PR DESCRIPTION
- /run/shm is used for shm segments
- /tmp isn't a tmpfs, but rather a directory under /
- handle newly seen step-thread command format

A non-ubuntu-related fix is included, in which a thread spinning on a
spinlock inside a blocked-signal critical section livelocks rr.

Resolves #921.  Resolves #920.  Resolves #919.
