### PR TITLE
Set the query and resume threads to the just-stopped thread.

### DIFF
--- a/src/debugger_gdb.cc
+++ b/src/debugger_gdb.cc
@@ -970,7 +970,7 @@ static int process_packet(struct dbg_context* dbg)
 		assert('\0' == *payload);
 
 		debug("gdb selecting %d.%d",
-		      dbg->req.target.tid, dbg->req.target.pid);
+		      dbg->req.target.pid, dbg->req.target.tid);
 
 		ret = 1;
 		break;
@@ -1267,6 +1267,14 @@ void dbg_notify_stop(struct dbg_context* dbg, dbg_threadid_t thread, int sig)
 		return;
 	}
 	send_stop_reply_packet(dbg, thread, sig);
+
+	// This isn't documented in the gdb remote protocol, but if we
+	// don't do this, gdb will sometimes continue to send requests
+	// for the previously-stopped thread when it obviously intends
+	// to making requests about the stopped thread.
+	debug("forcing query/resume thread to %d.%d", thread.pid, thread.tid);
+	dbg->query_thread = thread;
+	dbg->resume_thread = thread;
 
 	consume_request(dbg);
 }

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -1696,7 +1696,8 @@ static void replay_one_trace_frame(struct dbg_context* dbg, Task* t)
 
 		if (TRAP_BKPT_USER ==
 		    t->vm()->get_breakpoint_type_at_ip(t->ip())) {
-			debug("  hit debugger breakpoint");
+			debug("  %d(rec:%d): hit debugger breakpoint at ip %p",
+			      t->tid, t->rec_tid, t->ip());
 			/* SW breakpoint: $ip is just past the
 			 * breakpoint instruction.  Move $ip back
 			 * right before it. */

--- a/src/test/goto_event.c
+++ b/src/test/goto_event.c
@@ -12,7 +12,8 @@ static void second_breakpoint(void) {
 	(void)break_here;
 }
 
-static void child(int num_syscalls) {
+static void* child_thread(void* num_syscallsp) {
+	int num_syscalls = (uintptr_t)num_syscallsp;
 	int i;
 
 	first_breakpoint();
@@ -25,6 +26,16 @@ static void child(int num_syscalls) {
 	}
 
 	second_breakpoint();
+
+	return NULL;
+}
+
+static void child(int num_syscalls) {
+	pthread_t t;
+
+	test_assert(0 == pthread_create(&t, NULL, child_thread,
+					(void*)(uintptr_t)num_syscalls));
+	pthread_join(t, NULL);
 
 	exit(0);
 }


### PR DESCRIPTION
Resolves #931.

Almost trivial fix, but it takes forever to work with the FF test suites :/.
