### PR TITLE
Kill all tracees at abnormal trace termination.

### DIFF
--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -1517,6 +1517,7 @@ static void handle_interrupted_trace(struct dbg_context* dbg,
 		log_info("Processing last round of debugger requests.");
 		process_debugger_requests(dbg, t);
 	}
+	Task::killall();
 	log_info("Exiting.");
 	exit(0);
 }


### PR DESCRIPTION
Resolves #935.
