### PR TITLE
Save events to a single trace file.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,8 +5,6 @@
 
 #include <inttypes.h>
 
-#define MAX_TRACE_ENTRY_SIZE	8000001
-
 /**
  * The following parameters define the default scheduling parameters.
  * The recorder scheduler basically works as follows

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -429,7 +429,8 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 		/* TODO: is there any reason a restart_syscall can't
 		 * be interrupted by a signal and itself restarted? */
 		may_restart = (syscallno != SYS_restart_syscall
-			       /** */
+			       // SYS_pause is either interrupted or
+			       // never returns.  It doesn't restart.
 			       && syscallno != SYS_pause
 			       && SYSCALL_MAY_RESTART(retval));
 		/* no need to process the syscall in case its


### PR DESCRIPTION
Resolves #930.

There was a fencepost bug here that I didn't feel was worth fixing.
