### PR TITLE
Fail gracefully on reads of address 0xffffffff.

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -1922,7 +1922,7 @@ Task::is_desched_sig_blocked()
 static off64_t to_offset(void* addr)
 {
 	off64_t offset = (uintptr_t)addr;
-	assert(offset < numeric_limits<unsigned long>::max());
+	assert(offset <= off64_t(numeric_limits<unsigned long>::max()));
 	return offset;
 }
 

--- a/src/test/read_bad_mem.py
+++ b/src/test/read_bad_mem.py
@@ -9,4 +9,7 @@ expect_gdb('Breakpoint 1, main')
 send_gdb('p *0xf\n')
 expect_gdb('Cannot access memory at address 0xf')
 
+send_gdb('p *0xffffffff\n')
+expect_gdb('Cannot access memory at address 0xffffffff')
+
 ok()


### PR DESCRIPTION
Resolves #942.
