### PR TITLE
Test that attempting to set a watchpoint doesn't destroy the debugging s...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ set(BASIC_TESTS
   unjoined_thread
   user_ignore_sig
   vfork
+  watchpoint
 )
 
 # A "custom test" is a foo.run driver script only, which does

--- a/src/debugger_gdb.cc
+++ b/src/debugger_gdb.cc
@@ -1458,6 +1458,12 @@ void dbg_reply_watchpoint_request(struct dbg_context* dbg, int code)
 	assert(DREQ_WATCH_FIRST <= dbg->req.type
 	       && dbg->req.type <= DREQ_WATCH_LAST);
 
+	if (code) {
+		fprintf(stderr,
+"rr: Warning: attempt to set unhandled watchpoint type.\n"
+"  Use 'del [breakpoint-num]' to clear the watchpoint, or else gdb may \n"
+"  become unusable.\n");
+	}
 	write_packet(dbg, code ? "" : "OK");
 
 	consume_request(dbg);

--- a/src/test/watchpoint.c
+++ b/src/test/watchpoint.c
@@ -1,0 +1,20 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static void breakpoint(void) {
+	int break_here = 1;
+	(void)break_here;
+}
+
+int main(int argc, char *argv[]) {
+	int var = 0;
+
+	breakpoint();
+
+	var = 42;
+	(void)var;
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/watchpoint.py
+++ b/src/test/watchpoint.py
@@ -1,0 +1,28 @@
+from rrutil import *
+
+send_gdb('b breakpoint\n')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c\n')
+expect_gdb('Breakpoint 1, breakpoint')
+
+send_gdb('f 1\n')
+expect_gdb('#1')
+
+send_gdb('p &var\n')
+expect_gdb(r'\$1 = \(int \*\) ')
+
+send_gdb('watch *$1\n')
+expect_gdb('Hardware watchpoint 2')
+
+# TODO: since rr doesn't actually set watchpoints yet, we just ensure
+# that we can clear the watchpoint and continue debugging.
+send_gdb('c\n')
+expect_rr('rr: Warning: attempt to set unhandled watchpoint type.')
+send_gdb('del 2\n')
+
+send_gdb('c\n')
+expect_rr('EXIT-SUCCESS')
+expect_gdb('exited normally')
+
+ok()

--- a/src/test/watchpoint.run
+++ b/src/test/watchpoint.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh watchpoint "$@"
+debug_test


### PR DESCRIPTION
...ession.
#945 part 1.  Turns out that if gdb fails to set a watchpoint, it refuses to continue, hence the big warning printed by rr.  Users have to manually unset the watchpoints.
