### PR TITLE
runnable_state_changed() doesn't need t->event to create syscall events ...

### DIFF
--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -752,7 +752,7 @@ static void runnable_state_changed(Task* t, siginfo_t* si)
 		// We just entered a syscall.
 		check_rbc(t);
 		if (!maybe_restart_syscall(t)) {
-			push_syscall(t, t->event);
+			push_syscall(t, t->regs().orig_eax);
 			rec_before_record_syscall_entry(t, t->ev->syscall.no);
 		}
 		assert_exec(t, EV_SYSCALL == t->ev->type,


### PR DESCRIPTION
...anymore.
#293.  Should have gone with last commit, but I'd like to keep this separate from the upcoming changes.
