### PR TITLE
Remove Task::event, now that it's redundant with the event stack.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1796,7 +1796,6 @@ void rec_process_syscall(Task *t)
 		// The new tracee just "finished" a clone that was
 		// started by its parent.  It has no pending events,
 		// so it can be context-switched out.
-		new_task->event = SYS_clone;
 		new_task->switchable = 1;
 
 		break;

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -385,7 +385,6 @@ void __ptrace_cont(Task *t)
 	t->cont_syscall();
 
 	t->child_sig = t->pending_sig();
-	t->event = t->regs().orig_eax;
 
 	/* check if we are synchronized with the trace -- should never fail */
 	int rec_syscall = t->trace.recorded_regs.orig_eax;

--- a/src/task.cc
+++ b/src/task.cc
@@ -968,7 +968,7 @@ Task::Task(pid_t _tid, pid_t _rec_tid, int _priority)
 	, switchable(), pseudo_blocked(), succ_event_counter(), unstable()
 	, priority(_priority)
 	, scratch_ptr(), scratch_size()
-	, event(), flushed_syscallbuf()
+	, flushed_syscallbuf()
 	, delay_syscallbuf_reset(), delay_syscallbuf_flush()
 	  // These will be initialized when the syscall buffer is.
 	, desched_fd(-1), desched_fd_child(-1)
@@ -1256,7 +1256,7 @@ Task::is_sig_ignored(int sig) const
 bool
 Task::is_syscall_restart()
 {
-	int syscallno = event;
+	int syscallno = regs().orig_eax;
 	bool must_restart = (SYS_restart_syscall == syscallno);
 	bool is_restart = false;
 	const struct user_regs_struct* old_regs = &ev->syscall.regs;

--- a/src/task.h
+++ b/src/task.h
@@ -1567,7 +1567,6 @@ public:
 	void* scratch_ptr;
 	ssize_t scratch_size;
 
-	int event;
 	/* Nonzero after the trace recorder has flushed the
 	 * syscallbuf.  When this happens, the recorder must prepare a
 	 * "reset" of the buffer, to zero the record count, at the


### PR DESCRIPTION
#293.  Been waiting for an excuse to do this for a looong time.  Trying to keep this synced up with the event stack was a massive PITA.
