### PR TITLE
Stash signals received while processing desched signals.

### DIFF
--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -290,11 +290,8 @@ static void handle_desched_event(Task* t, const siginfo_t* si)
 			continue;
 		}
 
-		// TODO: queue multiple pending signals
-		fatal(
-"Sorry, %s became pending while processing %s.\n"
-"    Multiple pending signals aren't supported currently, aborting.",
-signalname(sig), signalname(si->si_signo));
+		debug("  stashing %s ...", signalname(sig));
+		t->stash_sig();
 	}
 
 	if (t->is_disarm_desched_event_syscall()) {


### PR DESCRIPTION
Resolves #215.

I'm pretty tired atm, but couldn't think of a way to write a reasonably good rr test for this.  I don't know why the problem manifests so reliably on FF browser-element tests.  But anyway, for now I'm using those to test this fix.
