### PR TITLE
PTRACE_INTERRUPT tracees that don't receive the time-slice interrupt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(BASIC_TESTS
   munmap_discontinuous
   mutex_pi_stress
   nanosleep
+  no_mask_timeslice
   pause
   perf_event
   poll_sig_race

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -48,6 +48,7 @@ static void handle_ptrace_event(Task** tp)
 	switch (event) {
 
 	case PTRACE_EVENT_NONE:
+	case PTRACE_EVENT_STOP:
 		break;
 
 	case PTRACE_EVENT_CLONE:

--- a/src/task.h
+++ b/src/task.h
@@ -1684,6 +1684,13 @@ private:
 	 */
 	void xptrace(int request, void* addr, void* data);
 
+	/**
+	 * The rbc interrupt has failed to stop the Task currently
+	 * being |wait()|ed, so the alarm() we programmed has fired.
+	 * PTRACE_INTERRUPT the runaway tracee.
+	 */
+	static void handle_runaway(int sig);
+
 	// The address space of this task.
 	std::shared_ptr<AddressSpace> as;
 	// The set of signals that are currently blocked.


### PR DESCRIPTION
Resolves #971.  Resolves #922.
