### PR TITLE
Unstably-exited tasks don't have a ptrace event at killall() time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ set(CUSTOM_TESTS
   parent_no_break_child_bkpt
   parent_no_stop_child_crash
   read_bad_mem
+  restart_unstable
   sanity
   signal_stop
   step1

--- a/src/task.cc
+++ b/src/task.cc
@@ -1894,7 +1894,10 @@ Task::killall()
 			// skip any waitpid()'ing during cleanup.
 			t->unstable = 1;
 		} else {
-			assert(PTRACE_EVENT_EXIT == t->ptrace_event());
+			// If the task participated in an unstable
+			// exit, it's probably already dead by now.
+			assert(t->unstable
+			       || PTRACE_EVENT_EXIT == t->ptrace_event());
 		}
 		// Don't attempt to synchonize on the cleartid futex.
 		// We won't be able to reliably read it, and it's

--- a/src/test/restart_unstable.py
+++ b/src/test/restart_unstable.py
@@ -1,0 +1,11 @@
+from rrutil import *
+
+send_gdb('c\n')
+expect_gdb('exited normally')
+
+restart_replay_at_end()
+
+send_gdb('c\n')
+expect_gdb('exited normally')
+
+ok()

--- a/src/test/restart_unstable.run
+++ b/src/test/restart_unstable.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh restart_unstable "$@"
+record exit_group
+debug exit_group restart_unstable


### PR DESCRIPTION
Resolves #982.
