### PR TITLE
Build fix

### DIFF
--- a/src/hpc.h
+++ b/src/hpc.h
@@ -9,7 +9,7 @@
 
 #include <assert.h>
 #include <err.h>
-#include <linux/perf_event.h>
+#include <perfmon/perf_event.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/util.cc
+++ b/src/util.cc
@@ -17,7 +17,7 @@
 #include <linux/ipc.h>
 #include <linux/magic.h>
 #include <linux/net.h>
-#include <linux/perf_event.h>
+#include <perfmon/perf_event.h>
 #include <malloc.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
I got the following build error. The problem seems to be that both `linux/perf_event.h` and `perfmon/perf_event.h` are included. The solution is not to include `linux/perf_event.h`.

This is with libpfm-4.4.0 (Ubuntu 13.10).

```
In file included from /usr/include/perfmon/pfmlib_perf_event.h:26:0,
                 from /home/tinuviel/github/mozilla/rr/src/hpc.cc:8:
/usr/include/perfmon/perf_event.h:431:7: error: redefinition of ‘union perf_mem_data_src’
 union perf_mem_data_src {
       ^
In file included from /home/tinuviel/github/mozilla/rr/src/hpc.h:12:0,
                 from /home/tinuviel/github/mozilla/rr/src/hpc.cc:3:
/usr/include/linux/perf_event.h:627:7: error: previous definition of ‘union perf_mem_data_src’
 union perf_mem_data_src {
       ^
```
