### PR TITLE
The variable 'idx' is used as an array index before it is checked that i...

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -601,7 +601,7 @@ uint64_t str2ull(const char* start, size_t max_size)
 	}
 
 	uint64_t val = 0;
-	while (isdigit(start[idx]) && idx <= ssize_t(max_size)) {
+	while (idx <= ssize_t(max_size) && isdigit(start[idx])) {
 		char tmp_char[2];
 		tmp_char[0] = start[idx];
 		tmp_char[1] = '\0';
@@ -628,7 +628,7 @@ long int str2li(const char* start, size_t max_size)
 	}
 
 	long int val = 0;
-	while (isdigit(start[idx]) && idx <= ssize_t(max_size)) {
+	while (idx <= ssize_t(max_size) && isdigit(start[idx])) {
 		char tmp_char[2];
 		tmp_char[0] = start[idx];
 		tmp_char[1] = '\0';


### PR DESCRIPTION
...s within limits. This can mean that the array might be accessed out of bounds.
