### PR TITLE
Null-terminate the lines in arg_env to ensure environment variable value...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ set(CUSTOM_TESTS
   cont_signal
   dead_thread_target
   deliver_async_signal_during_syscalls
+  env-newline
   execp
   fork_exec_info_thr
   get_thread_list

--- a/src/test/env-newline.run
+++ b/src/test/env-newline.run
@@ -1,0 +1,4 @@
+export BADENV='hello
+kitty'
+source `dirname $0`/util.sh simple "$@"
+compare_test EXIT-SUCCESS

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -168,11 +168,11 @@ void record_argv_envp(int argc, char* argv[], char* envp[])
 	}
 
 	/* print argc */
-	fprintf(arg_env, "%d\n", argc);
+	fprintf(arg_env, "%d%c", argc, 0);
 
 	/* print arguments to file */
 	for (i = 0; i < argc; i++) {
-		fprintf(arg_env, "%s\n", argv[i]);
+		fprintf(arg_env, "%s%c", argv[i], 0);
 	}
 
 	/* figure out the length of envp */
@@ -180,10 +180,10 @@ void record_argv_envp(int argc, char* argv[], char* envp[])
 	while (envp[i] != NULL) {
 		i++;
 	}
-	fprintf(arg_env, "%d\n", i);
+	fprintf(arg_env, "%d%c", i, 0);
 
 	for (j = 0; j < i; j++) {
-		fprintf(arg_env, "%s\n", envp[j]);
+		fprintf(arg_env, "%s%c", envp[j], 0);
 	}
 	fclose(arg_env);
 }
@@ -537,16 +537,12 @@ void load_recorded_env(const char* trace_path,
 	char buf[8192];
 
 	/* the first line contains argc */
-	read_line(arg_env, buf, sizeof(buf), "arg_env");
+	read_null_terminated(arg_env, buf, sizeof(buf), "arg_env");
 	*argc = str2li(buf, LI_COLUMN_SIZE);
 
 	/* followed by argv */
 	for (int i = 0; i < *argc; ++i) {
-		read_line(arg_env, buf, sizeof(buf), "arg_env");
-		int len = strlen(buf);
-		assert(len < 8192);
-		/* overwrite the newline */
-		buf[len - 1] = '\0';
+		read_null_terminated(arg_env, buf, sizeof(buf), "arg_env");
 		argv->push_back(strdup(buf));
 	}
 
@@ -555,16 +551,12 @@ void load_recorded_env(const char* trace_path,
 	*exe_image = argv->at(0);
 
 	/* now, read the number of environment entries */
-	read_line(arg_env, buf, sizeof(buf), "arg_env");
+	read_null_terminated(arg_env, buf, sizeof(buf), "arg_env");
 	int envc = str2li(buf, LI_COLUMN_SIZE);
 
 	/* followed by argv */
 	for (int i = 0; i < envc; i++) {
-		read_line(arg_env, buf, sizeof(buf), "arg_env");
-		int len = strlen(buf);
-		assert(len < 8192);
-		/* overwrite the newline */
-		buf[len - 1] = '\0';
+		read_null_terminated(arg_env, buf, sizeof(buf), "arg_env");
 		envp->push_back(strdup(buf));
 	}
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -674,6 +674,23 @@ void read_line(FILE* file, char* buf, int size, const char* name)
 	}
 }
 
+void read_null_terminated(FILE* file, char* buf, int size, const char* name)
+{
+	while (size > 1) {
+		int ch = getc(file);
+		if (ch == EOF) {
+			fatal("Failed to read line from %s into buf %p (size %d)",
+				name, buf, size);
+		}
+		if (ch == 0) {
+			break;
+		}
+		*buf++ = ch;
+		size--;
+	}
+	*buf = 0;
+}
+
 /**
  * Dump |buf_len| words in |buf| to |out|, starting with a line
  * containing |label|.  See |dump_binary_data()| for a description of

--- a/src/util.h
+++ b/src/util.h
@@ -142,6 +142,7 @@ uint64_t str2ull(const char* start, size_t max_size);
 long int str2li(const char* start, size_t max_size);
 byte* str2x(const char* start, size_t max_size);
 void read_line(FILE* file, char* buf, int size, const char* name);
+void read_null_terminated(FILE* file, char* buf, int size, const char* name);
 
 void print_register_file_tid(Task* t);
 void print_register_file(const struct user_regs_struct* regs);


### PR DESCRIPTION
...s containing embedded newlines round-trip correctly. Resolves #1018.
