### PR TITLE
When exec'ing a 64-bit image (not currently supported by rr),

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ install(TARGETS rr rrpreload
 #
 # Alphabetical, please.
 set(BASIC_TESTS
+  64bit_child
   abort_nonmain
   accept
   alarm

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -567,6 +567,29 @@ static bool prep_futex_lock_pi(Task* t, byte* futex,
 	return true;
 }
 
+static bool exec_file_supported(const string& filename)
+{
+	/* All this function does is reject 64-bit ELF binaries. Everything
+	   else we (optimistically) indicate support for. Missing or corrupt
+	   files will cause execve to fail normally. When we support 64-bit,
+	   this entire function can be removed. */
+	int fd = open(filename.c_str(), O_RDONLY);
+	if (fd < 0) {
+		return true;
+	}
+	char header[5];
+	bool ok = true;
+	if (read(fd, header, sizeof(header)) == sizeof(header)) {
+		if (header[0] == ELFMAG0 && header[1] == ELFMAG1 &&
+		    header[2] == ELFMAG2 && header[3] == ELFMAG3 &&
+		    header[4] == ELFCLASS64) {
+			ok = false;
+		}
+	}
+	close(fd);
+	return ok;
+}
+
 int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 {
 	int syscallno = t->ev().Syscall().no;
@@ -672,6 +695,30 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		destroy_buffers(t, (DESTROY_ALREADY_AT_EXIT_SYSCALL |
 				    DESTROY_NEED_EXIT_SYSCALL_RESTART));
 		return 0;
+
+	case SYS_execve: {
+		struct user_regs_struct r =  t->regs();
+		string filename = t->read_c_str((void*)r.ebx);
+		// We can't use push_arg_ptr/pop_arg_ptr to save and restore
+		// ebx because execs get special ptrace events that clobber
+		// the trace event for this system call.
+		t->exec_saved_ebx = r.ebx;
+		uintptr_t end = r.ebx + filename.length();
+		if (filename[0] != '/') {
+			char buf[PATH_MAX];
+			snprintf(buf, sizeof(buf),
+			         "/proc/%d/cwd/%s", t->real_tgid(),
+			         filename.c_str());
+			filename = buf;
+		}
+		if (!exec_file_supported(filename)) {
+			// Force exec to fail with ENOENT by advancing ebx to
+			// the null byte
+			r.ebx = end;
+			t->set_regs(r);
+		}
+		return 0;
+	}
 
 	case SYS_fcntl64:
 		switch (t->regs().ecx) {
@@ -1162,10 +1209,41 @@ static void finish_restoring_some_scratch(Task* t, byte* iter, void** data)
 	return finish_restoring_scratch_slack(t, iter, data, ALLOW_SLACK);
 }
 
+static int successful_execs = 0;
+
 static void process_execve(Task* t)
 {
+	struct user_regs_struct r = t->regs();
+	if (SYSCALL_FAILED(r.eax)) {
+		if (successful_execs == 0) {
+			fprintf(stderr,
+"\n"
+"rr: error:\n"
+"  Initial exec() of image %s failed.\n",
+				get_exe_image().c_str());
+			if (r.ebx == t->exec_saved_ebx) {
+				fprintf(stderr,
+"  Most likely it doesn't exist or isn't in your $PATH.  Terminating recording.\n"
+"\n");
+			} else {
+				fprintf(stderr,
+"  It is a 64-bit image and rr does not support that yet.  Terminating recording.\n"
+"\n");
+			}
+			terminate_recording(t);
+		} else if (r.ebx != t->exec_saved_ebx) {
+			log_warn("Failed attempt to execve 64-bit image (not yet supported by rr)");
+		}
+		// Restore EBX, which we might have clobbered
+		r.ebx = t->exec_saved_ebx;
+		t->set_regs(r);
+		return;
+	}
+
+	++successful_execs;
+
 	// XXX what does this signifiy?
-	if (t->regs().ebx != 0) {
+	if (r.ebx != 0) {
 		return;
 	}
 

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -659,16 +659,7 @@ static void check_rbc(Task* t)
 	}
 	int fd = t->regs().ebx;
 	if (-1 != fd) {
-		fprintf(stderr,
-"\n"
-"rr: error:\n"
-"  Unexpected `write(%d, ...)' call from first tracee process.\n"
-"  Most likely, the executable image `%s' doesn't exist or isn't\n"
-"  in your $PATH.  Terminating recording.\n"
-"\n",
-			fd, exe_image.c_str());
-		terminate_recording(t);
-		return;
+		fatal("Unexpected `write' call from first tracee process.");
 	}
 
 	int64_t rbc = read_rbc(t->hpc);
@@ -1016,4 +1007,9 @@ void terminate_recording(Task* t)
 
 	log_info("  exiting, goodbye.");
 	exit(0);
+}
+
+const string& get_exe_image()
+{
+	return exe_image;
 }

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -3,6 +3,8 @@
 #ifndef RECORDER_H_
 #define RECORDER_H_
 
+#include <string>
+
 struct flags;
 class Task;
 
@@ -20,5 +22,10 @@ void record(const char* rr_exe, int argc, char* argv[], char** envp);
  * executed task.
  */
 void terminate_recording(Task* t = nullptr);
+
+/**
+ * Return the name of the initial exe image.
+ */
+const std::string& get_exe_image();
 
 #endif /* RECORDER_H_ */

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -445,22 +445,6 @@ static void exit_syscall_emu(Task* t,
 	exit_syscall_emu_ret(t, syscall);
 }
 
-enum { DONT_EMULATE_RETURN = 0, EMULATE_RETURN = 1 };
-static void exit_syscall_exec(Task* t, int syscall,
-			      int num_emu_args, int emu_ret)
-{
-	int i;
-
-	__ptrace_cont(t);
-	for (i = 0; i < num_emu_args; ++i) {
-		t->set_data_from_trace();
-	}
-	if (emu_ret) {
-		t->set_return_value_from_trace(); 
-	}
-	validate_args(syscall, STATE_SYSCALL_EXIT, t);
-}
-
 static void init_scratch_memory(Task* t)
 {
 	/* Initialize the scratchpad as the recorder did, but make it
@@ -614,11 +598,20 @@ static void process_clone(Task* t,
 	step->action = TSTEP_RETIRE;
 }
 
-static void process_execve(Task* t, int state,
+static void process_execve(Task* t, struct trace_frame* trace, int state,
 			   const struct user_regs_struct* rec_regs,
 			   struct rep_trace_step* step)
 {
 	const int syscallno = SYS_execve;
+
+	if (is_failed_syscall(trace)) {
+		/* exec failed, emulate it */
+		step->syscall.emu = 1;
+		step->syscall.emu_ret = 1;
+		step->action = (state == STATE_SYSCALL_ENTRY) ?
+			       TSTEP_ENTER_SYSCALL : TSTEP_EXIT_SYSCALL;
+		return;
+	}
 
 	if (STATE_SYSCALL_ENTRY == state) {
 		// Executed, not emulated.
@@ -627,15 +620,6 @@ static void process_execve(Task* t, int state,
 	}
 
 	step->action = TSTEP_RETIRE;
-
-	if (0 > rec_regs->eax) {
-		/* Failed exec(). */
-		exit_syscall_exec(t, syscallno, 0, DONT_EMULATE_RETURN);
-		assert_exec(t, rec_regs->eax == t->regs().eax,
-			    "Recorded exec() return %ld, but replayed %ld",
-			    rec_regs->eax, t->regs().eax);
-		return;
-	}
 
 	/* we need an additional ptrace syscall, since ptrace is setup
 	 * with PTRACE_O_TRACEEXEC */
@@ -1483,7 +1467,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		return process_clone(t, trace, state, step);
 
 	case SYS_execve:
-		return process_execve(t, state, rec_regs, step);
+		return process_execve(t, trace, state, rec_regs, step);
 
 	case SYS_exit:
 		destroy_buffers(t, DESTROY_DEFAULT);

--- a/src/task.h
+++ b/src/task.h
@@ -1407,6 +1407,9 @@ public:
 	/* Points at the tracee's mapping of the buffer. */
 	void* syscallbuf_child;
 
+	/* The value of ebx passed to the last execve syscall in this task. */
+	int exec_saved_ebx;
+
 private:
 	Task(pid_t tid, pid_t rec_tid, int priority);
 

--- a/src/test/64bit_child.c
+++ b/src/test/64bit_child.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	/* Fork-and-exec 'ls'.
+	   The exec may fail if 'bash' is 64-bit and rr doesn't support
+	   64-bit processes. That's fine; the test should still pass. We're
+	   testing that rr doesn't abort.
+	 */
+	FILE* f = popen("ls", "r");
+	while (1) {
+		int ch = fgetc(f);
+		if (ch < 0) {
+			break;
+		}
+		putchar(ch);
+	}
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/64bit_child.run
+++ b/src/test/64bit_child.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh 64bit_child "$@"
+compare_test 'EXIT-SUCCESS'


### PR DESCRIPTION
cause the exec to fail cleanly without aborting rr.

Also print slightly better messages when the user tries to apply rr
to a 64-bit image directly.

Resolves issue #1043.
