### PR TITLE
Set LD_PRELOAD to an absolute path for librrpreload.so so users don't ha...

### DIFF
--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -65,7 +65,7 @@ static void copy_envp(char** envp)
 		}
 	}
 	// LD_PRELOAD the syscall interception lib
-	if (rr_flags()->syscall_buffer_lib_path) {
+	if (rr_flags()->syscall_buffer_lib_path.length() > 0) {
 		string ld_preload = "LD_PRELOAD=";
 		// Our preload lib *must* come first
 		ld_preload += rr_flags()->syscall_buffer_lib_path;
@@ -156,14 +156,12 @@ static void ensure_preload_lib_will_load(const char* rr_exe,
 		fatal("Failed to wait for %s child", rr_exe);
 	}
 	if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+		const struct flags* flags = rr_flags();
 		fprintf(stderr,
 "\n"
 "rr: error: Unable to preload the '%s' library.\n"
-"  Ensure that the library is in your LD_LIBRARY_PATH.  If you installed rr\n"
-"  from a distribution package, then the package or your system was not\n"
-"  configured correctly.\n"
 "\n",
-			SYSCALLBUF_LIB_FILENAME);
+			flags->syscall_buffer_lib_path.c_str());
 		exit(EX_CONFIG);
 	}
 }

--- a/src/types.h
+++ b/src/types.h
@@ -11,6 +11,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <string>
+
 #define CHECK_ALIGNMENT(addr) 	assert(((long int)(addr) & 0x3) == 0)
 
 #define PTR_SIZE		(sizeof(void*))
@@ -61,7 +63,7 @@ struct flags {
 	int option;
 	bool redirect;
 	bool use_syscall_buffer;
-	const char* syscall_buffer_lib_path;
+	std::string syscall_buffer_lib_path;
 	int dump_on;	// event
 	int dump_at;	// global time
 	int checksum;
@@ -93,7 +95,32 @@ struct flags {
 	// format.
 	bool raw_dump;
 	// Only open a debug socket, don't launch the debugger too.
- 	bool dont_launch_debugger;
+	bool dont_launch_debugger;
+
+	flags()
+	  : max_rbc(0)
+	  , max_events(0)
+	  , ignore_sig(0)
+	  , option(0)
+	  , redirect(false)
+	  , use_syscall_buffer(false)
+	  , syscall_buffer_lib_path("")
+	  , dump_on(0)
+	  , dump_at(0)
+	  , checksum(0)
+	  , dbgport(0)
+	  , wait_secs(0)
+	  , verbose(false)
+	  , cpu_unbound(false)
+	  , force_enable_debugger(false)
+	  , mark_stdio(false)
+	  , check_cached_mmaps(false)
+	  , goto_event(0)
+	  , target_process(0)
+	  , process_created_how(0)
+	  , raw_dump(false)
+	  , dont_launch_debugger(false)
+	{}
 };
 
 struct msghdr;

--- a/src/util.cc
+++ b/src/util.cc
@@ -49,7 +49,7 @@ using namespace std;
 
 #define NUM_MAX_MAPS 1024
 
-struct flags flags = { 0 };
+struct flags flags;
 
 const struct flags* rr_flags(void)
 {


### PR DESCRIPTION
...ve to set LD_LIBRARY_PATH.

Distributions that want to put librrpreload.so somewhere other than
bin/../lib will just need to patch this function to return their desired
hardcoded path.
