### PR TITLE
Simply the default record/replay workflow.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -63,7 +63,7 @@ static void start_dumping(int argc, char* argv[], char** envp)
 {
 	FILE* out = stdout;
 
-	rep_setup_trace_dir(argv[0]);
+	rep_set_up_trace_dir(argc, argv);
 	open_trace_files();
 	rep_init_trace_files();
 
@@ -219,7 +219,7 @@ static void print_usage(void)
 "                             even if it would otherwise be used\n"
 "\n"
 "Syntax for `replay'\n"
-" rr replay [OPTION]... <trace-dir>\n"
+" rr replay [OPTION]... [<trace-dir>]\n"
 "  -a, --autopilot            replay without debugger server\n"
 "  -f, --onfork=<PID>         start a debug server when <PID> has been\n"
 "                             fork()d, AND the target event has been\n"
@@ -235,7 +235,7 @@ static void print_usage(void)
 "                             client too.\n"
 "\n"
 "Syntax for `dump`\n"
-" rr dump [OPTIONS] <trace_dir> <event-spec>...\n"
+" rr dump [OPTIONS] <trace_dir> [<event-spec>...]\n"
 "  Event specs can be either an event number like `127', or a range\n"
 "  like `1000-5000'.  By default, all events are dumped.\n"
 "  -r, --raw                  dump trace frames in a more easily\n"
@@ -477,7 +477,11 @@ int main(int argc, char* argv[])
 
 	assert_prerequisites();
 
-	if (0 > (argi = parse_args(argc, argv, flags)) || argc <= argi) {
+	if (0 > (argi = parse_args(argc, argv, flags))
+	    || argc < argi
+	    // |rr replay| is allowed to have no arguments to replay
+	    // the most recently saved trace.
+	    || (REPLAY != flags->option && argc <= argi)) {
 		print_usage();
 		return 1;
 	}

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -921,7 +921,7 @@ void record(const char* rr_exe, int argc, char* argv[], char** envp)
 	exe_image = argv[0];
 	copy_argv(argc, argv);
 	copy_envp(envp);
-	rec_setup_trace_dir();
+	rec_set_up_trace_dir(argv[0]);
 
 	string env_pair = create_pulseaudio_config();
 	if (!env_pair.empty()) {

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -1867,11 +1867,11 @@ static void serve_replay(int argc, char* argv[], char** envp)
 	CharpVector arg_v;
 	CharpVector env_p;
 
-	load_recorded_env(argv[0], &argc, &exe_image, &arg_v, &env_p);
+	rep_set_up_trace_dir(argc, argv);
+	load_recorded_env(&argc, &exe_image, &arg_v, &env_p);
 
 	init_libpfm();
 
-	rep_setup_trace_dir(argv[0]);
 	open_trace_files();
 	rep_init_trace_files();
 

--- a/src/test/trace_version.run
+++ b/src/test/trace_version.run
@@ -5,28 +5,32 @@ function expect_replay_fail {
     replay
     if [[ $(cat replay.err) == "" ]]; then
 	echo "Test '$TESTNAME' FAILED: replay should have failed, but it succeeded."
+        exit 1
     fi
     echo "  (replay failed as expected)"
 }
 
 record simple
-if [ ! -f "$TRACE_DIR/version" ]; then
+trace_dir="simple-$nonce-0"
+
+if [ ! -f "$trace_dir/version" ]; then
     echo "Test '$TESTNAME' FAILED: version file not found in trace directory."
+    exit 1
 fi;
 
 echo "Moving version file away ..."
-mv "$TRACE_DIR/version" ./version.tmp
+mv "$trace_dir/version" ./version.tmp
 expect_replay_fail
 
 echo "Trying to replay with empty version file ..."
-echo "" > "$TRACE_DIR/version"
+echo "" > "$trace_dir/version"
 expect_replay_fail
 
 echo "Trying to replay with dummy version number ..."
-echo "-42\n" > "$TRACE_DIR/version"
+echo "-42\n" > "$trace_dir/version"
 expect_replay_fail
 
 echo "Restoring trace version file ..."
-mv ./version.tmp "$TRACE_DIR/version"
+mv ./version.tmp "$trace_dir/version"
 replay
 check EXIT-SUCCESS

--- a/src/trace.h
+++ b/src/trace.h
@@ -121,21 +121,15 @@ void record_mmapped_file_stats(struct mmapped_file* file);
 unsigned int get_global_time(void);
 void record_argv_envp(int argc, char* argv[], char* envp[]);
 /**
- * Create a unique directory in which all trace files will be stored.
+ * Create a unique directory named something like "$(basename
+ * exe_path)-$number" in which all trace files will be stored.
  */
-void rec_setup_trace_dir(void);
+void rec_set_up_trace_dir(const char* exe_path);
 
 /**
  * Replaying
  */
 
-/**
- * Return the exe image path, arg vector, and environment variables
- * that were recorded, in |exec_image|, |argv|, |envp| respectively.
- */
-void load_recorded_env(const char* trace_path,
-		       int* argc, std::string* exec_image,
-		       CharpVector* argv, CharpVector* envp);
 /**
  * Read and return the next trace frame.  Succeed or don't return.
  */
@@ -166,6 +160,15 @@ pid_t get_recorded_main_thread(void);
 /**
  * Set the trace directory that will be replayed to |path|.
  */
-void rep_setup_trace_dir(const char* path);
+void rep_set_up_trace_dir(int argc, char** argv);
+
+/**
+ * Return the exe image path, arg vector, and environment variables
+ * that were recorded, in |exec_image|, |argv|, |envp| respectively.
+ *
+ * Must be called after |rep_set_up_trace_dir()|.
+ */
+void load_recorded_env(int* argc, std::string* exec_image,
+		       CharpVector* argv, CharpVector* envp);
 
 #endif /* TRACE_H_ */

--- a/src/util.cc
+++ b/src/util.cc
@@ -102,13 +102,13 @@ int nanosleep_nointr(const struct timespec* ts)
 	}
 }
 
-int probably_not_interactive(void)
+int probably_not_interactive(int fd)
 {
 	/* Eminently tunable heuristic, but this is guaranteed to be
 	 * true during rr unit tests, where we care most about this
 	 * check (to a first degree).  A failing test shouldn't
 	 * hang. */
-	return !isatty(STDERR_FILENO);
+	return !isatty(fd);
 }
 
 void maybe_mark_stdio_write(Task* t, int fd)

--- a/src/util.h
+++ b/src/util.h
@@ -269,7 +269,7 @@ int nanosleep_nointr(const struct timespec* ts);
  * is, there's probably no user watching or interacting with rr), and
  * so asking for user input or other actions is probably pointless.
  */
-int probably_not_interactive(void);
+int probably_not_interactive(int fd = STDERR_FILENO);
 
 /**
  * If |child_fd| is a stdio fd and stdio-marking is enabled, prepend


### PR DESCRIPTION
With this change, traces are saved to ~/.rr/ by default (this can
still be overridden with the _RR_TRACE_DIR env var.)  In addition, a
"latest-trace" symlink is maintained within the saved-trace dir, and
updated with each invocation of |rr record|.  This enables the next
simplification, which is allowing |rr replay| to be specified with no
arguments.  This replays the "latest-trace" symlink in the saved-trace
dir.

And finally, trace directories are now named based on the basename of
the exe path that's recorded.  So for example, |rr record
/usr/bin/firefox| will create a trace directory "firefox-$nonce".

With these changes, users can do the following

```
$ rr record foo
[Saves recording of "foo" to ~/.rr/foo-0.]
$ rr replay
[Replays ~/.rr/latest-trace, which points at ~/.rr/foo-0.]
$ rr record bar
[Saves recording of "foo" to ~/.rr/bar-0.]
$ rr replay
[Replays ~/.rr/latest-trace, which points at ~/.rr/bar-0.]
$ rr replay ~/.rr/foo-0
[Replays ~/.rr/foo-0, which is still saved.]
```

Resolves #1046.
