### PR TITLE
Include null terminator in string recorded by Task::record_remote_str.

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -1459,7 +1459,7 @@ void
 Task::record_remote_str(void* str)
 {
 	string s = read_c_str(str);
-	record_data(this, str, s.size(), s.c_str());
+	record_data(this, str, s.size() + 1, s.c_str());
 }
 
 string

--- a/src/test/getcwd.c
+++ b/src/test/getcwd.c
@@ -18,10 +18,15 @@ int main(int argc, char *argv[]) {
 	/* Make the value returned into |path| overlap two physical
 	 * pages. */
 	cwd = two_pages + pagesize - 3;
+	/* Fill pages with non-zeroes to ensure the returned string is
+	 * properly null-terminated */
+	memset(two_pages, 0xFF, two_pages_size);
 	test_assert(cwd == getcwd(cwd, two_pages_end - (void*)cwd));
 	atomic_printf("current working directory is %s; should be %s\n",
 		      cwd, expected_cwd);
 	test_assert(!strcmp(cwd, expected_cwd));
+	/* Make sure we didn't write too many bytes */
+	test_assert((unsigned char)cwd[strlen(cwd) + 1] == 0xFF);
 
 	atomic_puts("EXIT-SUCCESS");
 	return 0;


### PR DESCRIPTION
This fixes a regression introduced by commit 2ccd42.
