### PR TITLE
Make the 64bit_child test work on 32-bit systems.

### DIFF
--- a/src/test/64bit_child.c
+++ b/src/test/64bit_child.c
@@ -3,12 +3,12 @@
 #include "rrutil.h"
 
 int main(int argc, char *argv[]) {
-	/* Fork-and-exec 'ls'.
+	/* Fork-and-exec 'echo'.
 	   The exec may fail if 'bash' is 64-bit and rr doesn't support
 	   64-bit processes. That's fine; the test should still pass. We're
 	   testing that rr doesn't abort.
 	 */
-	FILE* f = popen("ls", "r");
+	FILE* f = popen("echo -n", "r");
 	while (1) {
 		int ch = fgetc(f);
 		if (ch < 0) {


### PR DESCRIPTION
Resolves #1066.
