### PR TITLE
Override XShmCreateImage to return null in tracees.

### DIFF
--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -1893,3 +1893,17 @@ int XShmQueryExtension(void* dpy)
 {
 	return 0;
 }
+
+/** Make sure XShmCreateImage returns null in case an application doesn't do
+    extension checks first. */
+void *XShmCreateImage(register void *dpy,
+	register void *visual,
+	unsigned int depth,
+	int format,
+	char *data,
+	void *shminfo,
+	unsigned int width,
+	unsigned int height)
+{
+	return 0;
+}


### PR DESCRIPTION
Some tracees may try to create XShm images without checking
XShmQueryExtension first, and we should force them to bail out
as early as possible, before they try to create SysV shmem
objects that we can't (or don't want to) handle.
