### PR TITLE
include guard fix

### DIFF
--- a/src/debugger_gdb.h
+++ b/src/debugger_gdb.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef DBG_GDB_H_
-#define DBG_GDB_H_
+#ifndef RR_DBG_GDB_H_
+#define RR_DBG_GDB_H_
 
 #include <stddef.h>
 #include <sys/types.h>

--- a/src/emufs.h
+++ b/src/emufs.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef EMUFS_H_
-#define EMUFS_H_
+#ifndef RR_EMUFS_H_
+#define RR_EMUFS_H_
 
 #include <map>
 #include <memory>
@@ -136,4 +136,4 @@ private:
 	const bool is_gc_point;
 };
 
-#endif  // EMUFS_H
+#endif  // RR_EMUFS_H

--- a/src/event.h
+++ b/src/event.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef EVENT_H_
-#define EVENT_H_
+#ifndef RR_EVENT_H_
+#define RR_EVENT_H_
 
 #include <assert.h>
 #include <sys/user.h>

--- a/src/hpc.h
+++ b/src/hpc.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef HPC_H_
-#define HPC_H_
+#ifndef RR_HPC_H_
+#define RR_HPC_H_
 
 #ifndef _GNU_SOURCE
 # define _GNU_SOURCE 1

--- a/src/log.h
+++ b/src/log.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef LOG_H
-#define LOG_H
+#ifndef RR_LOG_H
+#define RR_LOG_H
 
 #include <iostream>
 
@@ -177,4 +177,4 @@ inline static T& prepare_log_stream(T&& stream, LogLevel level,
  */
 #define HEX(_v) ((void*)(uintptr_t)_v)
 
-#endif // LOG_H
+#endif // RR_LOG_H

--- a/src/preload/seccomp-bpf.h
+++ b/src/preload/seccomp-bpf.h
@@ -11,8 +11,8 @@
  * The code may be used by anyone for any purpose, and can serve as a
  * starting point for developing applications using mode 2 seccomp.
  */
-#ifndef _SECCOMP_BPF_H_
-#define _SECCOMP_BPF_H_
+#ifndef RR_SECCOMP_BPF_H_
+#define RR_SECCOMP_BPF_H_
 
 #define _GNU_SOURCE 1
 #include <stdio.h>
@@ -130,4 +130,4 @@ struct seccomp_data {
 #define TRACE_PROCESS \
 	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_TRACE)
 
-#endif /* _SECCOMP_BPF_H_ */
+#endif /* RR_SECCOMP_BPF_H_ */

--- a/src/preload/syscall_buffer.h
+++ b/src/preload/syscall_buffer.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef SYSCALL_BUFFER_H_
-#define SYSCALL_BUFFER_H_
+#ifndef RR_SYSCALL_BUFFER_H_
+#define RR_SYSCALL_BUFFER_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -201,4 +201,4 @@ inline static int is_blacklisted_filename(const char* filename)
 }
 #endif
 
-#endif /* SYSCALL_BUFFER_H_ */
+#endif /* RR_SYSCALL_BUFFER_H_ */

--- a/src/record_signal.h
+++ b/src/record_signal.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef __HANDLE_SIGNAL_H__
-#define __HANDLE_SIGNAL_H__
+#ifndef RR_HANDLE_SIGNAL_H__
+#define RR_HANDLE_SIGNAL_H__
 
 #include <signal.h>
 
@@ -15,4 +15,4 @@ struct flags;
  */
 void handle_signal(Task* t, siginfo_t* si = nullptr);
 
-#endif /* __HANDLE_SIGNAL_H__ */
+#endif /* RR_HANDLE_SIGNAL_H__ */

--- a/src/record_syscall.h
+++ b/src/record_syscall.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef PROCESS_SYSCALL_H_
-#define PROCESS_SYSCALL_H_
+#ifndef RR_PROCESS_SYSCALL_H_
+#define RR_PROCESS_SYSCALL_H_
 
 #include "types.h"
 #include "util.h"
@@ -36,4 +36,4 @@ void rec_prepare_restart_syscall(Task* t);
  */
 void rec_process_syscall(Task* t);
 
-#endif /* PROCESS_SYSCALL_H_ */
+#endif /* RR_PROCESS_SYSCALL_H_ */

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef RECORDER_H_
-#define RECORDER_H_
+#ifndef RR_RECORDER_H_
+#define RR_RECORDER_H_
 
 #include <string>
 
@@ -23,4 +23,4 @@ void record(const char* rr_exe, int argc, char* argv[], char** envp);
  */
 void terminate_recording(Task* t = nullptr);
 
-#endif /* RECORDER_H_ */
+#endif /* RR_RECORDER_H_ */

--- a/src/recorder_sched.h
+++ b/src/recorder_sched.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef REC_SCHED_H_
-#define REC_SCHED_H_
+#ifndef RR_REC_SCHED_H_
+#define RR_REC_SCHED_H_
 
 class Task;
 
@@ -19,4 +19,4 @@ Task* rec_sched_get_active_thread(Task* t, int* by_waitpid);
 
 void rec_sched_deregister_thread(Task** t);
 
-#endif /* REC_SCHED_H_ */
+#endif /* RR_REC_SCHED_H_ */

--- a/src/replay_syscall.h
+++ b/src/replay_syscall.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef REP_PROCESS_EVENT_H_
-#define REP_PROCESS_EVENT_H_
+#ifndef RR_REP_PROCESS_EVENT_H_
+#define RR_REP_PROCESS_EVENT_H_
 
 #include "trace.h"
 
@@ -30,4 +30,4 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step);
  */
 void rep_maybe_replay_stdio_write(Task* t);
 
-#endif /* REP_PROCESS_EVENT_H_ */
+#endif /* RR_REP_PROCESS_EVENT_H_ */

--- a/src/replayer.h
+++ b/src/replayer.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef REPLAYER_H_
-#define REPLAYER_H_
+#ifndef RR_REPLAYER_H_
+#define RR_REPLAYER_H_
 
 #include "types.h"
 #include "util.h"
@@ -140,4 +140,4 @@ struct rep_trace_step {
 	};
 };
 
-#endif /* REPLAYER_H_ */
+#endif /* RR_REPLAYER_H_ */

--- a/src/task.h
+++ b/src/task.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef TASK_H_
-#define TASK_H_
+#ifndef RR_TASK_H_
+#define RR_TASK_H_
 
 // Define linux-specific flags in mman.h.
 #define __USE_MISC 1
@@ -1709,4 +1709,4 @@ private:
 	Task operator=(Task&) = delete;
 };
 
-#endif /* TASK_H_ */
+#endif /* RR_TASK_H_ */

--- a/src/trace.h
+++ b/src/trace.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef TRACE_H_
-#define TRACE_H_
+#ifndef RR_TRACE_H_
+#define RR_TRACE_H_
 
 #include <linux/limits.h>
 #include <sys/stat.h>
@@ -271,4 +271,4 @@ private:
 	{}
 };
 
-#endif /* TRACE_H_ */
+#endif /* RR_TRACE_H_ */

--- a/src/types.h
+++ b/src/types.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef TYPES_H_
-#define TYPES_H_
+#ifndef RR_TYPES_H_
+#define RR_TYPES_H_
 
 #include <linux/limits.h>
 #include <stddef.h>
@@ -143,4 +143,4 @@ struct recvmsg_args {
 	long flags;
 };
 
-#endif /* TYPES_H_ */
+#endif /* RR_TYPES_H_ */

--- a/src/util.h
+++ b/src/util.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
 
-#ifndef UTIL_H_
-#define UTIL_H_
+#ifndef RR_UTIL_H_
+#define RR_UTIL_H_
 
 #include <errno.h>
 #include <fcntl.h>
@@ -547,4 +547,4 @@ void destroy_buffers(Task* t, int flags);
  */
 void monkeypatch_vdso(Task* t);
 
-#endif /* UTIL_H_ */
+#endif /* RR_UTIL_H_ */


### PR DESCRIPTION
all include guards are prefixed "RR_" to follow a unified naming convention. Issue #1024
