### PR TITLE
Tag each emulated file with replayer PID to avoid collisions.

### DIFF
--- a/src/emufs.cc
+++ b/src/emufs.cc
@@ -46,8 +46,8 @@ EmuFile::create(const char* orig_path, const struct stat& est)
 	replace_char(tag, '/', '\\');
 
 	stringstream name;
-	name << "rr-emufs-dev-" << est.st_dev << "-inode-" << est.st_ino
-	     << "-" << tag;
+	name << "rr-emufs-"<< getpid() <<"-dev-" << est.st_dev
+	     << "-inode-" << est.st_ino << "-" << tag;
 	shr_ptr f(new EmuFile(create_shmem_segment(name.str().c_str(),
 						   est.st_size), est));
 	LOG(debug) <<"created emulated file for "<< orig_path

--- a/src/recorder_sched.cc
+++ b/src/recorder_sched.cc
@@ -22,6 +22,8 @@
 #include "session.h"
 #include "task.h"
 
+using namespace std;
+
 /**
  * The currently scheduled task. This may be NULL if the last scheduled task
  * has been destroyed.
@@ -41,11 +43,11 @@ static Task*
 get_next_task_with_same_priority(Task* t)
 {
 	auto tasks = Session::current()->tasks_by_priority();
-	auto it = tasks.find(std::make_pair(t->priority, t));
+	auto it = tasks.find(make_pair(t->priority, t));
 	assert(it != tasks.end());
 	++it;
 	if (it == tasks.end() || it->first != t->priority) {
-		it = tasks.lower_bound(std::make_pair(t->priority, nullptr));
+		it = tasks.lower_bound(make_pair(t->priority, nullptr));
 	}
 	return it->second;
 }
@@ -69,11 +71,11 @@ find_next_runnable_task(int* by_waitpid)
 		same_priority_start != tasks.end();) {
 		int priority = same_priority_start->first;
 		auto same_priority_end =
-			tasks.lower_bound(std::make_pair(same_priority_start->first + 1, nullptr));
+			tasks.lower_bound(make_pair(same_priority_start->first + 1, nullptr));
 
 		auto begin_at = same_priority_start;
 	        if (current && priority == current->priority) {
-			begin_at = tasks.find(std::make_pair(priority, current));
+			begin_at = tasks.find(make_pair(priority, current));
 		}
 
 		auto task_iterator = begin_at;


### PR DESCRIPTION
Resolves #1099.
