### PR TITLE
The right env var is _RR_TRACE_DIR.

### DIFF
--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -65,7 +65,7 @@ function onexit {
     else
         echo Test $TESTNAME failed, leaving behind $workdir.
         echo To replay the failed test, run
-        echo " " _RR_WORK_DIR="$workdir" rr replay
+        echo " " _RR_TRACE_DIR="$workdir" rr replay
     fi
 }
 


### PR DESCRIPTION
@passimm if you were already following the instructions printed after the test failed (#656), this bug would cause the wrong environment to be used and you would see the "/root/.rr/latest-trace/version' not found" error.
