### PR TITLE
Restart replay without doing the exec() dance.

### DIFF
--- a/src/debugger_gdb.h
+++ b/src/debugger_gdb.h
@@ -118,7 +118,7 @@ enum DbgRequestType{
 	/* gdb host detaching from stub.  No parameters. */
 	DREQ_DETACH,
 
-	/* Uses params.restart. */
+	/* Uses params.restart_event. */
 	DREQ_RESTART,
 };
 
@@ -139,10 +139,7 @@ struct dbg_request {
 
 		DbgRegister reg;
 
-		struct {
-			int event;
-			short port;
-		} restart;
+		int restart_event;
 	};
 };
 
@@ -194,12 +191,6 @@ struct dbg_context* dbg_await_client_connection(const char* addr,
  * |params_pipe_fd|.
  */
 void dbg_launch_debugger(int params_pipe_fd);
-
-/**
- * Notify the debug server that replay is about to be restarted, and
- * it should prepare any state necessary to restore post-exec.
- */
-void dbg_prepare_restore_after_exec_restart(struct dbg_context* dbg);
 
 /**
  * Call this when the target of |req| is needed to fulfill the

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1228,6 +1228,7 @@ static void process_execve(Task* t)
 		return;
 	}
 
+	t->session().after_exec();
 	t->post_exec();
 
 	long* stack_ptr = (long*)t->regs().esp;

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -541,7 +541,8 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 		 * restart_syscall */
 		if (!may_restart) {
 			rec_process_syscall(t);
-			if (rr_flags()->check_cached_mmaps) {
+			if (t->session().can_validate()
+			    && rr_flags()->check_cached_mmaps) {
 				t->vm()->verify(t);
 			}
 		} else {

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -118,7 +118,7 @@ static void validate_args(int syscall, int state, Task* t)
 {
 	/* don't validate anything before execve is done as the actual
 	 * process did not start prior to this point */
-	if (!t->replay_session().can_validate()) {
+	if (!t->session().can_validate()) {
 		return;
 	}
 	assert_child_regs_are(t, &t->trace.recorded_regs);
@@ -436,7 +436,7 @@ static void process_execve(Task* t, struct trace_frame* trace, int state,
 	 * that the address space layout for the replay tasks will
 	 * (should!) be the same as for the recorded tasks.  So we can
 	 * start validating registers at events. */
-	t->replay_session().after_exec();
+	t->session().after_exec();
 
 	bool check = t->regs().ebx;
 	/* if the execve comes from a vfork system call the ebx

--- a/src/session.cc
+++ b/src/session.cc
@@ -148,3 +148,18 @@ ReplaySession::create(int argc, char* argv[])
 	session->trace_ifstream = TraceIfstream::open(argc, argv);
 	return session;
 }
+
+void
+ReplaySession::restart()
+{
+	kill_all_tasks();
+	assert(tasks().size() == 0 && vms().size() == 0);
+	last_debugged_task = nullptr;
+	tgid_debugged = 0;
+	tracees_consistent = false;
+
+	gc_emufs();
+	assert(emufs().size() == 0);
+
+	trace_ifstream->rewind();
+}

--- a/src/task.cc
+++ b/src/task.cc
@@ -741,9 +741,11 @@ AddressSpace::verify(Task* t) const
 AddressSpace::AddressSpace(Task* t, Session& session)
 	: is_clone(false), session(session), vdso_start_addr()
 {
-	iterate_memory_map(t, populate_address_space, this,
-			   kNeverReadSegment, NULL);
-	assert(vdso_start_addr);
+	if (session.can_validate()) {
+		iterate_memory_map(t, populate_address_space, this,
+				   kNeverReadSegment, NULL);
+		assert(vdso_start_addr);
+	}
 }
 
 AddressSpace::AddressSpace(const AddressSpace& o)

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -425,6 +425,17 @@ TraceIfstream::peek_frame()
 	return frame;
 }
 
+void
+TraceIfstream::rewind()
+{
+	events.seekg(0);
+	data.seekg(0);
+	data_header.seekg(0);
+	mmaps.seekg(0);
+	global_time = 0;
+	assert(good());
+}
+
 /*static*/ TraceIfstream::shr_ptr
 TraceIfstream::open(int argc, char** argv)
 {

--- a/src/trace.h
+++ b/src/trace.h
@@ -254,6 +254,12 @@ public:
 	struct trace_frame peek_frame();
 
 	/**
+	 * Restore the state of this to what it was just after
+	 * |open()|.
+	 */
+	void rewind();
+
+	/**
 	 * Open and return the trace specified by the command line
 	 * spec |argc| / |argv|.  These are just the portion of the
 	 * args that specify the trace, not the entire command line.

--- a/src/util.cc
+++ b/src/util.cc
@@ -74,6 +74,14 @@ struct flags* rr_flags_for_init(void)
 	return NULL;		/* not reached */
 }
 
+void update_replay_target(pid_t process, int event)
+{
+	flags.target_process = process;
+	if (event > 0) {
+		flags.goto_event = event;
+	}
+}
+
 // FIXME this function assumes that there's only one address space.
 // Should instead only look at the address space of the task in
 // question.

--- a/src/util.h
+++ b/src/util.h
@@ -125,6 +125,12 @@ const struct flags* rr_flags(void);
 struct flags* rr_flags_for_init(void);
 
 /**
+ * Update the |rr_flags()| execution-target parameters to |process|
+ * and |event| (if > 0).
+ */
+void update_replay_target(pid_t process, int event = -1);
+
+/**
  * Return zero if |reg1| matches |reg2|.  Passing EXPECT_MISMATCHES
  * indicates that the caller is using this as a general register
  * compare and nothing special should be done if the register files


### PR DESCRIPTION
Instead, this change has replay restart itself "inline", by resetting
the state of the replay session (which also rewinds all the replay
files).  Then replay continues on normally with the newly reset
session.
#603
