### PR TITLE
Save the event at the debug target so that we can eventually recognize w...

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -76,7 +76,9 @@ struct flags* rr_flags_for_init(void)
 
 void update_replay_target(pid_t process, int event)
 {
-	flags.target_process = process;
+	if (process > 0) {
+		flags.target_process = process;
+	}
 	if (event > 0) {
 		flags.goto_event = event;
 	}

--- a/src/util.h
+++ b/src/util.h
@@ -126,9 +126,10 @@ struct flags* rr_flags_for_init(void);
 
 /**
  * Update the |rr_flags()| execution-target parameters to |process|
- * and |event| (if > 0).
+ * and |event|.  Either parameter can be < 0 to mean "don't update
+ * this flag".
  */
-void update_replay_target(pid_t process, int event = -1);
+void update_replay_target(pid_t process, int event);
 
 /**
  * Return zero if |reg1| matches |reg2|.  Passing EXPECT_MISMATCHES


### PR DESCRIPTION
...hen checkpoints are stale.
#603
