### PR TITLE
Use memory map cache in debugging code #656

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -276,18 +276,8 @@ AddressSpace::dump() const
 	for (auto it = mem.begin(); it != mem.end(); ++it) {
 		const Mapping& m = it->first;
 		const MappableResource& r = it->second;
-		fprintf(stderr,
-			"%08lx-%08lx %c%c%c%c %08llx %02llx:%02llx %-10ld %s %s (f:0x%x d:0x%llx i:%ld)\n",
-			reinterpret_cast<long>(m.start),
-			reinterpret_cast<long>(m.end),
-			(PROT_READ & m.prot) ? 'r' : '-',
-			(PROT_WRITE & m.prot) ? 'w' : '-',
-			(PROT_EXEC & m.prot) ? 'x' : '-',
-			(MAP_SHARED & m.flags) ? 's' : 'p',
-			m.offset,
-			r.id.dev_major(), r.id.dev_minor(), r.id.disp_inode(),
-			r.fsname.c_str(), r.id.special_name(),
-			m.flags, r.id.device, r.id.inode);
+		fprintf(stderr, "%s %s\n", m.str().c_str(),
+				r.str().c_str());
 	}
 }
 

--- a/src/task.h
+++ b/src/task.h
@@ -234,6 +234,24 @@ struct Mapping {
 			       offset);
 	}
 
+	/**
+	 * Dump a representation of |this| to a string in a format
+	 * similar to the former part of /proc/[tid]/maps.
+	*/
+	std::string str() const {
+		char str[200];
+		sprintf(str,
+			"%08lx-%08lx %c%c%c%c %08llx",
+			reinterpret_cast<long>(start),
+			reinterpret_cast<long>(end),
+			(PROT_READ & prot) ? 'r' : '-',
+			(PROT_WRITE & prot) ? 'w' : '-',
+			(PROT_EXEC & prot) ? 'x' : '-',
+			(MAP_SHARED & flags) ? 's' : 'p',
+			offset);
+		return str;
+	}
+
 	void* const start;
 	void* const end;
 	const int prot;
@@ -289,6 +307,21 @@ struct MappableResource {
 		return MappableResource(FileId(id.dev_major(), id.dev_minor(),
 					       id.disp_inode()),
 					fsname.c_str());
+	}
+
+	/**
+	 * Dump a representation of |this| to a string in a format
+	 * similar to the tail part of /proc/[tid]/maps. Some extra
+	 * informations are put in a '()'.
+	*/
+	std::string str() const {
+		char str[200];
+		sprintf(str,
+			"%02llx:%02llx %-10ld %s %s (d:0x%llx i:%ld)",
+			id.dev_major(), id.dev_minor(), id.disp_inode(),
+			fsname.c_str(), id.special_name(), id.device, 
+			id.inode);
+		return str;
 	}
 
 	static MappableResource anonymous() {


### PR DESCRIPTION
This change lets dump-process-memory and checksum use memory map cache rather than look up /proc/pid/mmap. pls help review it. Thanks!
