### PR TITLE
Skip past intervening frames when looking for the syscall exit frame.

### DIFF
--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -316,7 +316,9 @@ static bool is_failed_syscall(Task* t, const struct trace_frame* frame)
 {
 	struct trace_frame next_frame;
 	if (STATE_SYSCALL_ENTRY == frame->ev.state) {
-		next_frame = t->ifstream().peek_frame();
+		next_frame = t->ifstream().peek_to(t->rec_tid,
+						   EventType(frame->ev.type),
+						   STATE_SYSCALL_EXIT);
 		frame = &next_frame;
 	}
 	return SYSCALL_FAILED(frame->recorded_regs.eax);

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -425,6 +425,24 @@ TraceIfstream::peek_frame()
 	return frame;
 }
 
+struct trace_frame
+TraceIfstream::peek_to(pid_t pid, EventType type, int state)
+{
+	AutoRestoreState restore(*this);
+	struct trace_frame frame;
+	while (good()) {
+		*this >> frame;
+		if (frame.tid == pid
+		    && frame.ev.type == type
+		    && frame.ev.state == state) {
+			return frame;
+		}
+	}
+	FATAL() <<"Unable to find requested frame in stream";
+	// Unreachable
+	return frame;
+}
+
 void
 TraceIfstream::rewind()
 {

--- a/src/trace.h
+++ b/src/trace.h
@@ -254,6 +254,13 @@ public:
 	struct trace_frame peek_frame();
 
 	/**
+	 * Peek ahead in the stream to find the next trace frame that
+	 * matches the requested parameters. Returns the frame if one
+	 * was found, and issues a fatal error if not.
+	 */
+	struct trace_frame peek_to(pid_t pid, EventType type, int state);
+
+	/**
 	 * Restore the state of this to what it was just after
 	 * |open()|.
 	 */


### PR DESCRIPTION
Wasn't sure if you wanted peek_to to be fallible or not so I went with the signature you described. I can change it to return a bool for success and take a trace_frame& out-param if you prefer.
