### PR TITLE
Gracefully fail to set invalid breakpoints.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ set(BASIC_TESTS
 set(CUSTOM_TESTS
   async_signal_syscalls_100
   async_signal_syscalls_1000
+  bad_breakpoint
   break_block
   break_clock
   break_clone

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -350,15 +350,16 @@ static struct dbg_request process_debugger_requests(struct dbg_context* dbg,
 						  target->child_sig);
 			continue;
 		}
-		case DREQ_SET_SW_BREAK:
+		case DREQ_SET_SW_BREAK: {
 			ASSERT(target,
 			       (req.mem.len ==
 				sizeof(AddressSpace::breakpoint_insn)))
 				<< "Debugger setting bad breakpoint insn";
-			target->vm()->set_breakpoint(req.mem.addr,
-						     TRAP_BKPT_USER);
-			dbg_reply_watchpoint_request(dbg, 0);
+			bool ok = target->vm()->set_breakpoint(req.mem.addr,
+							       TRAP_BKPT_USER);
+			dbg_reply_watchpoint_request(dbg, ok ? 0 : 1);
 			continue;
+		}
 		case DREQ_REMOVE_SW_BREAK:
 			target->vm()->remove_breakpoint(req.mem.addr,
 							TRAP_BKPT_USER);

--- a/src/task.h
+++ b/src/task.h
@@ -529,7 +529,7 @@ public:
 	void remove_breakpoint(void* addr, TrapType type);
 
 	/** Ensure a breakpoint of |type| is set at |addr|. */
-	void set_breakpoint(void* addr, TrapType type);
+	bool set_breakpoint(void* addr, TrapType type);
 
 	/**
 	 * Destroy all breakpoints in this VM, regardless of their

--- a/src/test/bad_breakpoint.py
+++ b/src/test/bad_breakpoint.py
@@ -1,0 +1,7 @@
+from rrutil import *
+
+restart_replay()
+send_gdb('c\n')
+expect_rr('EXIT-SUCCESS')
+
+ok()

--- a/src/test/bad_breakpoint.run
+++ b/src/test/bad_breakpoint.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh bad_breakpoint "$@"
+record simple
+for i in $(seq 15 25); do
+    echo Replaying to event $i ...
+    debug simple bad_breakpoint "-g $i"
+done


### PR DESCRIPTION
Found while working on #603.  In some circumstances, gdb requests breakpoints on unmapped memory.
