### PR TITLE
Track "rbc slop" in Task so that we can copy it when checkpointing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ set(CUSTOM_TESTS
   break_sync_signal
   break_thread
   break_time_slice
+  checkpoint_async_signal_syscalls_1000
   checkpoint_simple
   cont_signal
   dead_thread_target

--- a/src/event.cc
+++ b/src/event.cc
@@ -216,6 +216,25 @@ Event::has_exec_info() const
 }
 
 bool
+Event::has_rbc_slop() const
+{
+	switch (type()) {
+	case EV_SYSCALLBUF_ABORT_COMMIT:
+	case EV_SYSCALLBUF_FLUSH:
+	case EV_SYSCALLBUF_RESET:
+		return true;
+	case EV_DESCHED:
+		// ARM_DESCHED events are like the SYSCALLBUF_* events
+		// in that they weren't actually observed during
+		// recording, only inferred, so we don't have any
+		// reference to assert against during replay.
+		return (ARMING_DESCHED_EVENT == Desched().state);
+	default:
+		return false;
+	}
+}
+
+bool
 Event::is_signal_event() const
 {
 	switch (event_type) {

--- a/src/event.h
+++ b/src/event.h
@@ -325,6 +325,11 @@ struct Event {
 	bool has_exec_info() const;
 
 	/**
+	 * See long comment at |Task::maybe_save_rbc_slop()|.
+	 */
+	bool has_rbc_slop() const;
+
+	/**
 	 * Return true if this is one of the indicated type of events.
 	 */
 	bool is_signal_event() const;

--- a/src/task.cc
+++ b/src/task.cc
@@ -1526,6 +1526,26 @@ Task::may_be_blocked() const
 }
 
 void
+Task::maybe_save_rbc_slop(const Event& ev)
+{
+	if (!ev.has_rbc_slop()) {
+		reset_hpc(this, 0);
+		rbc_slop = 0;
+	}
+	rbc_slop = read_rbc(hpc);
+}
+
+void
+Task::adjust_for_rbc_slop(int64_t* target)
+{
+	assert(*target >= rbc_slop);
+
+	*target -= rbc_slop;
+	reset_hpc(this, 0);
+	rbc_slop = 0;
+}
+
+void
 Task::maybe_update_vm(int syscallno, int state)
 {
 	// We have to use the recorded_regs during replay because they
@@ -2432,6 +2452,7 @@ Task::copy_state(Task* from)
 	blocked_sigs = from->blocked_sigs;
 	pending_events = from->pending_events;
 	trace = from->trace;
+	rbc_slop = from->rbc_slop;
 }
 
 void

--- a/src/test/checkpoint_async_signal_syscalls_1000.run
+++ b/src/test/checkpoint_async_signal_syscalls_1000.run
@@ -1,0 +1,14 @@
+timeslice=1000
+RECORD_ARGS="-c$timeslice"
+
+source `dirname $0`/util.sh checkpoint_async_signal_syscalls_1000 "$@"
+
+record async_signal_syscalls 9
+
+# TODO: use |rr dump -r| to calculate dynamically
+num_events=750
+stride=75
+for i in $(seq 1 $stride $num_events); do
+    echo Checkpointing at event $i ...
+    debug async_signal_syscalls restart_finish "-g $i"
+done


### PR DESCRIPTION
Resolves #1154.  Resolves #1155.

This is the bug I thought #1141 was.
