### PR TITLE
share code between _{un,}traced_raw_syscall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # *-* Mode: cmake; *-*
 
 cmake_minimum_required(VERSION 2.8.5)
-project(rr)
+project(rr C CXX ASM)
 
 enable_testing()
 set(BUILD_SHARED_LIBS ON)
@@ -18,6 +18,7 @@ set(rr_VERSION_PATCH 1)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -O0 -g3 -Wall -Werror -m32 -Wstrict-prototypes")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -pthread -O0 -g3 -Wall -Werror -m32")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -g3 -m32")
 
 # Disable PIC.
 string(REGEX REPLACE "-fPIC" ""
@@ -27,6 +28,8 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 
 add_library(rrpreload
   src/preload/preload.c
+  src/preload/traced_syscall.S
+  src/preload/untraced_syscall.S
 )
 
 add_executable(rr

--- a/src/preload/traced_syscall.S
+++ b/src/preload/traced_syscall.S
@@ -1,0 +1,3 @@
+#define RAW_SYSCALL_FUNCTION _traced_raw_syscall
+#define SYSCALL_ENTRY_POINT get_traced_syscall_entry_point
+#include "traced_syscall_shared.S"

--- a/src/preload/traced_syscall_shared.S
+++ b/src/preload/traced_syscall_shared.S
@@ -1,0 +1,68 @@
+#ifndef RAW_SYSCALL_FUNCTION
+#error must define RAW_SYSCALL_FUNCTION before including this file
+#endif
+#ifndef SYSCALL_ENTRY_POINT
+#error must define SYSCALL_ENTRY_POINT before including this file
+#endif
+
+#define ENTRY_POINT_IP .L##RAW_SYSCALL_FUNCTION##entry_point_ip
+
+	.text
+	.globl RAW_SYSCALL_FUNCTION
+	.type RAW_SYSCALL_FUNCTION, @function
+RAW_SYSCALL_FUNCTION:	/* syscallno = 4(%esp) */
+	.cfi_startproc
+	pushl %ebx	/* syscallno = 8(%esp) */
+	.cfi_adjust_cfa_offset 4
+	.cfi_rel_offset %ebx, 0
+	pushl %esi	/* syscallno = 12(%esp) */
+	.cfi_adjust_cfa_offset 4
+	.cfi_rel_offset %esi, 0
+	pushl %edi	/* syscallno = 16(%esp) */
+	.cfi_adjust_cfa_offset 4
+	.cfi_rel_offset %edi, 0
+	pushl %ebp	/* syscallno = 20(%esp) */
+	.cfi_adjust_cfa_offset 4
+	.cfi_rel_offset %ebp, 0
+
+	movl 20(%esp), %eax /* %eax = syscallno */
+	movl 24(%esp), %ebx /* %ebx = a0 */
+	movl 28(%esp), %ecx /* %ecx = a1 */
+	movl 32(%esp), %edx /* %edx = a2 */
+	movl 36(%esp), %esi /* %esi = a3 */
+	movl 40(%esp), %edi /* %edi = a4 */
+	movl 44(%esp), %ebp /* %ebp = a5 */
+
+	int $0x80		/* syscall() */
+	/* When the tracee is in the traced syscall, its $ip will be
+	 * the value of this label.  We need to be able to recognize
+	 * when the tracees are in traced syscalls. */
+ENTRY_POINT_IP:
+
+	popl %ebp
+	.cfi_adjust_cfa_offset -4
+	.cfi_restore %ebp
+	popl %edi
+	.cfi_adjust_cfa_offset -4
+	.cfi_restore %edi
+	popl %esi
+	.cfi_adjust_cfa_offset -4
+	.cfi_restore %esi
+	popl %ebx
+	.cfi_adjust_cfa_offset -4
+	.cfi_restore %ebx
+	ret
+	.cfi_endproc
+	.size RAW_SYSCALL_FUNCTION, . - RAW_SYSCALL_FUNCTION
+
+	.globl SYSCALL_ENTRY_POINT
+	.type SYSCALL_ENTRY_POINT, @function
+SYSCALL_ENTRY_POINT:
+	call .L1
+.L1:
+	pop %eax
+	addl $(ENTRY_POINT_IP - .L1), %eax
+	ret
+	.size SYSCALL_ENTRY_POINT, . - SYSCALL_ENTRY_POINT
+
+#undef ENTRY_POINT_IP

--- a/src/preload/untraced_syscall.S
+++ b/src/preload/untraced_syscall.S
@@ -1,0 +1,3 @@
+#define RAW_SYSCALL_FUNCTION _untraced_raw_syscall
+#define SYSCALL_ENTRY_POINT get_untraced_syscall_entry_point
+#include "traced_syscall_shared.S"


### PR DESCRIPTION
This change addresses the TODO in preload.c that suggests we'd like to
share code between these two functions.  As a pleasant side effect, it
moves from top-level asms to .S files, which makes the correspondence
between the syscall functions and their corresponding entry point
fetches more obvious.

The comment surrounding the TODO notes that we don't generate the shared
functions from a macro because that would hinder debuggability.  It's
worth pointing out that GCC's assembler annotates the lines for
traced_raw_syscall (resp. the other functions so defined) as coming from
traced_syscall_shared.S.  I don't think this hinders debuggability too
much, but it does make it so you have to pay a little more attention to
what function you stopped in, rather than just the file your debugger
shows you stopping in.
