### PR TITLE
Add support for the getsid syscall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(BASIC_TESTS
   fork_syscalls
   getcwd
   getgroups
+  getsid
   goto_event
   hello
   ignored_async_usr1

--- a/src/syscall_defs.h
+++ b/src/syscall_defs.h
@@ -846,7 +846,14 @@ SYSCALL_DEF_UNSUPPORTED(readv)
  */
 SYSCALL_DEF_IRREG(writev, EMU)
 
-SYSCALL_DEF_UNSUPPORTED(getsid)
+/**
+ * pid_t getsid(pid_t pid);
+ *
+ * getsid(0) returns the session ID of the calling process.  getsid(p)
+ * returns the session ID of the process with process ID p.  (The session
+ * ID of a process is the process group ID of the session leader.)
+ */
+SYSCALL_DEF0(getsid, EMU)
 
 /**
  *  int fdatasync(int fd)

--- a/src/test/getsid.c
+++ b/src/test/getsid.c
@@ -1,0 +1,19 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char *argv[]) {
+	pid_t sid1;
+	pid_t sid2;
+
+	sid1 = getsid(0);
+	sid2 = getsid(sid1);
+	atomic_printf("getsid(0) session ID: %d\n", sid1);
+	atomic_printf("getsid(getsid(0)) session ID: %d\n", sid2);
+
+	if (sid1 == sid2) {
+		atomic_puts("EXIT-SUCCESS");
+	}
+
+	return 0;
+}

--- a/src/test/getsid.run
+++ b/src/test/getsid.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh setsid "$@"
+compare_test EXIT-SUCCESS


### PR DESCRIPTION
This is small step towards fixing issue #1053. Midnight Commander uses getsid() syscall so it doesn't fall into category "syscalls that no-one ever uses in practice".
