### PR TITLE
delete dead defines from types.h

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -13,14 +13,6 @@
 
 #include <string>
 
-#define CHECK_ALIGNMENT(addr) 	assert(((long int)(addr) & 0x3) == 0)
-
-#define PTR_SIZE		(sizeof(void*))
-#define INT_SIZE		(sizeof(int))
-
-#define UUL_COLUMN_SIZE 	20
-#define LI_COLUMN_SIZE 		11
-
 typedef unsigned char byte;
 
 /**


### PR DESCRIPTION
None of these #defines are actually used.  CHECK_ALIGNMENT, PTR_SIZE,
and INT_SIZE could be actively harmful to a proper 32/64-bit-aware
codebase.
