### PR TITLE
make default_action return an enum, rather than an int

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -977,7 +977,7 @@ bool is_now_contended_pi_futex(Task* t, void* futex, uint32_t* next_val)
 	return now_contended;
 }
 
-int default_action(int sig)
+signal_action default_action(int sig)
 {
 	if (SIGRTMIN <= sig && sig <= SIGRTMAX) {
 		return TERMINATE;
@@ -1022,7 +1022,7 @@ int default_action(int sig)
 	CASE(WINCH, IGNORE);
 	default:
 		FATAL() <<"Unknown signal "<< sig;
-		return -1;	// not reached
+		return TERMINATE;	// not reached
 #undef CASE
 	}
 }
@@ -1030,7 +1030,7 @@ int default_action(int sig)
 bool possibly_destabilizing_signal(Task* t, int sig)
 {
 	sig_handler_t disp = t->signal_disposition(sig);
-	int action = default_action(sig);
+	signal_action action = default_action(sig);
 	// If the diposition is IGN or user handler, then the signal
 	// won't be fatal.  So we only need to check for DFL.
 	return SIG_DFL == disp && (DUMP_CORE == action || TERMINATE == action);

--- a/src/util.h
+++ b/src/util.h
@@ -388,8 +388,8 @@ void restore_struct_mmsghdr(Task* t, struct mmsghdr* child_mmsghdr);
 bool is_now_contended_pi_futex(Task* t, void* futex, uint32_t* next_val);
 
 /** Return the default action of |sig|. */
-enum { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
-int default_action(int sig);
+enum signal_action { DUMP_CORE, TERMINATE, CONTINUE, STOP, IGNORE };
+signal_action default_action(int sig);
 
 /**
  * Return true if |sig| may cause the status of other tasks to change


### PR DESCRIPTION
More descriptive types are always good.  Giving the enums names also
helps ensure they don't get used in unexpected places.
