### PR TITLE
use __rdtsc to execute the rdtsc instruction

### DIFF
--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -12,6 +12,7 @@
 #include <syscall.h>
 #include <sys/mman.h>
 #include <sys/user.h>
+#include <x86intrin.h>
 
 #include "preload/syscall_buffer.h"
 
@@ -26,9 +27,7 @@ static void handle_siginfo(Task* t, siginfo_t* si);
 
 static __inline__ unsigned long long rdtsc(void)
 {
-	unsigned hi, lo;
-	__asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
-	return ((unsigned long long) lo) | (((unsigned long long) hi) << 32);
+	return __rdtsc();
 }
 
 /**

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -49,6 +49,7 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
+#include <x86intrin.h>
 
 #include <rr/rr.h>
 
@@ -135,9 +136,7 @@ inline static void check_data(void* buf, size_t len)
  * Return the current value of the time-stamp counter.
  */
 inline static uint64_t rdtsc(void) {
-	uint32_t hi, lo;
-	__asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
-	return (uint64_t)hi << 32 | (uint64_t)lo;
+	return __rdtsc();
 }
 
 #endif /* RRUTIL_H */


### PR DESCRIPTION
Anything that eliminates inline assembly is a good thing.  As a small
bonus, __rdtsc() is defined by Intel, so this code works on all
compilers that implement Intel-compatible intrinsics.
