### PR TITLE
move syscallno into Task

### DIFF
--- a/src/emufs.cc
+++ b/src/emufs.cc
@@ -215,8 +215,9 @@ AutoGc::AutoGc(ReplaySession& session, int syscallno, int state)
 		      && (SYS_close == syscallno
 			  || SYS_munmap == syscallno)) {
 	if (is_gc_point) {
+		assert(SYS_close == syscallno || SYS_munmap == syscallno);
 		LOG(debug) <<"emufs gc required because of syscall `"
-			   << syscallname(syscallno) <<"'";
+			   << (SYS_close == syscallno ? "close" : "munmap") <<"'";
 	}
 }
 

--- a/src/event.cc
+++ b/src/event.cc
@@ -283,7 +283,7 @@ Event::str() const
 		ss << ": " << desched_state_name(Desched().state);
 		// This is null during replay.
 		if (Desched().rec) {
-			ss <<"; "<< syscallname(Desched().rec->syscallno);
+			ss <<"; "<< Desched().rec->syscallno;
 		}
 		break;
 	case EV_SIGNAL:
@@ -295,7 +295,7 @@ Event::str() const
 		break;
 	case EV_SYSCALL:
 	case EV_SYSCALL_INTERRUPTION:
-		ss << ": " << syscallname(Syscall().no);
+		ss << ": " << Syscall().no;
 		break;
 	default:
 		// No auxiliary information.

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -318,7 +318,7 @@ static void handle_desched_event(Task* t, const siginfo_t* si)
 	t->ev().Syscall().state = EXITING_SYSCALL;
 
 	LOG(debug) <<"  resuming (and probably switching out) blocked `"
-		   << syscallname(call) <<"'";
+		   << t->syscallname(call) <<"'";
 }
 
 static int is_deterministic_signal(const siginfo_t* si)
@@ -478,7 +478,7 @@ static int go_to_a_happy_place(Task* t, siginfo_t* si)
 		if (t->is_untraced_syscall()
 		    && t->desched_rec()) {
 			LOG(debug) <<"  tracee interrupted by desched of "
-				   << syscallname(t->desched_rec()->syscallno);
+				   << t->syscallname(t->desched_rec()->syscallno);
 			goto happy_place;
 		}
 		if (initial_hdr.locked && !hdr->locked) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -596,8 +596,8 @@ static int set_up_scratch_for_syscallbuf(Task* t, int syscallno)
 
 	assert(rec);
 	ASSERT(t, syscallno == rec->syscallno)
-		<< "Syscallbuf records syscall "<< syscallname(rec->syscallno)
-		<<", but expecting "<< syscallname(syscallno);
+		<< "Syscallbuf records syscall "<< t->syscallname(rec->syscallno)
+		<<", but expecting "<< t->syscallname(syscallno);
 
 	reset_scratch_pointers(t);
 	t->ev().Syscall().tmp_data_ptr =
@@ -762,7 +762,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 			r.set_arg4((uintptr_t)off_out2);
 		}
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -785,7 +785,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 			r.set_arg3((uintptr_t)offset2);
 		}
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -885,7 +885,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		scratch += (size_t)r.arg3();
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -946,7 +946,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		}
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -967,7 +967,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		}
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -997,7 +997,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		scratch += nfds * sizeof(*fds);
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 		/* |fds| is an inout param, so we need to copy over
 		 * the source data. */
@@ -1028,7 +1028,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 
 			if (!can_use_scratch(t, scratch)) {
 				return abort_scratch(t,
-						     syscallname(syscallno));
+						     t->syscallname(syscallno));
 			}
 
 			t->set_regs(r);
@@ -1071,7 +1071,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		scratch += maxevents * sizeof(*events);
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		/* (Unlike poll(), the |events| param is a pure
@@ -1095,7 +1095,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 
 
 	case SYS_epoll_pwait:
-		FATAL() <<"Unhandled syscall "<< syscallname(syscallno);
+		FATAL() <<"Unhandled syscall "<< t->syscallname(syscallno);
 		return 1;
 
 	/* The following two syscalls enable context switching not for
@@ -1120,7 +1120,7 @@ int rec_prepare_syscall(Task* t, void** kernel_sync_addr, uint32_t* sync_val)
 		}
 
 		if (!can_use_scratch(t, scratch)) {
-			return abort_scratch(t, syscallname(syscallno));
+			return abort_scratch(t, t->syscallname(syscallno));
 		}
 
 		t->set_regs(r);
@@ -2728,7 +2728,7 @@ void rec_process_syscall(Task *t)
 
 	default:
 		print_register_file_tid(t);
-		FATAL() <<"Unhandled syscall "<< syscallname(syscallno)
+		FATAL() <<"Unhandled syscall "<< t->syscallname(syscallno)
 			<<"("<< syscallno <<")";
 		break;		/* not reached */
 	}

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -424,9 +424,9 @@ static void maybe_discard_syscall_interruption(Task* t, int ret)
 		syscall_not_restarted(t);
 	} else if (0 < ret) {
 		ASSERT(t, syscallno == ret)
-			<<"Interrupted call was "<< syscallname(syscallno)
+			<<"Interrupted call was "<< t->syscallname(syscallno)
 			<<" and sigreturn claims to be restarting "
-			<< syscallname(ret);
+			<< t->syscallname(ret);
 	}
 }
 
@@ -518,17 +518,17 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 			       || SYS_exit_group == syscallno
 			       || SYS_exit == syscallno
 			       || SYS__sysctl == syscallno)))
-			<< "Exiting syscall "<< syscallname(syscallno)
+			<< "Exiting syscall "<< t->syscallname(syscallno)
 			<<" but retval is -ENOSYS, usually only seen at entry";
 
 		LOG(debug) <<"  original_syscallno:"<< t->regs().original_syscallno()
-			   <<" ("<< syscallname(syscallno) <<"); return val:"
+			   <<" ("<< t->syscallname(syscallno) <<"); return val:"
 			   << t->regs().syscall_result();
 
 		/* a syscall_restart ending is equivalent to the
 		 * restarted syscall ending */
 		if (t->ev().Syscall().is_restart) {
-			LOG(debug) <<"  exiting restarted "<< syscallname(syscallno);
+			LOG(debug) <<"  exiting restarted "<< t->syscallname(syscallno);
 		}
 
 		/* TODO: is there any reason a restart_syscall can't
@@ -548,7 +548,7 @@ static void syscall_state_changed(Task* t, int by_waitpid)
 				t->vm()->verify(t);
 			}
 		} else {
-			LOG(debug) <<"  may restart "<< syscallname(syscallno)
+			LOG(debug) <<"  may restart "<< t->syscallname(syscallno)
 				   <<" (from retval "<< retval <<")";
 
 			rec_prepare_restart_syscall(t);

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -223,8 +223,8 @@ static void goto_next_syscall_emu(Task *t)
 		}
 
 		ASSERT(t, current_syscall == rec_syscall)
-			<<"Should be at `"<< syscallname(rec_syscall)
-			<<"', instead at `"<< syscallname(current_syscall) <<"'";
+			<<"Should be at `"<< t->syscallname(rec_syscall)
+			<<"', instead at `"<< t->syscallname(current_syscall) <<"'";
 	}
 	t->child_sig = 0;
 }
@@ -249,8 +249,8 @@ static void __ptrace_cont(Task *t)
 	int rec_syscall = t->current_trace_frame().recorded_regs.original_syscallno();
 	int current_syscall = t->regs().original_syscallno();
 	ASSERT(t, current_syscall == rec_syscall)
-		<<"Should be at "<< syscallname(rec_syscall)
-		<<", but instead at "<< syscallname(current_syscall);
+		<<"Should be at "<< t->syscallname(rec_syscall)
+		<<", but instead at "<< t->syscallname(current_syscall);
 }
 
 void rep_maybe_replay_stdio_write(Task* t)
@@ -349,7 +349,7 @@ static void maybe_noop_restore_syscallbuf_scratch(Task* t)
 {
 	if (t->is_untraced_syscall()) {
 		LOG(debug) <<"  noop-restoring scratch for write-only desched'd "
-			   << syscallname(t->regs().original_syscallno());
+			   << t->syscallname(t->regs().original_syscallno());
 		t->set_data_from_trace();
 	}
 }
@@ -1305,7 +1305,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 	const Registers* rec_regs = &trace->recorded_regs;
 	AutoGc maybe_gc(t->replay_session(), syscall, state);
 
-	LOG(debug) <<"processing "<< syscallname(syscall) <<" ("
+	LOG(debug) <<"processing "<< t->syscallname(syscall) <<" ("
 		   << statename(state) <<")";
 
 	if (STATE_SYSCALL_EXIT == state
@@ -1317,7 +1317,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 		// event to see which syscall we're trying to restart.
 		if (interrupted_restart) {
 			syscall = t->ev().Syscall().no;
-			LOG(debug) <<"  interrupted "<< syscallname(syscall)
+			LOG(debug) <<"  interrupted "<< t->syscallname(syscall)
 				   <<" interrupted again";
 		}
 		// During recording, when a syscall exits with a
@@ -1355,7 +1355,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 			t->ev().Syscall().regs = t->regs();
 		}
 		step->action = TSTEP_RETIRE;
-		LOG(debug) <<"  "<< syscallname(syscall) <<" interrupted by "
+		LOG(debug) <<"  "<< t->syscallname(syscall) <<" interrupted by "
 			   << rec_regs->syscall_result() <<" at "<< (void*)rec_regs->ip()
 			   <<", may restart";
 		return;
@@ -1370,7 +1370,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 			void* intr_ip = (void*)t->ev().Syscall().regs.ip();
 			void* cur_ip = (void*)t->ip();
 
-			LOG(debug) <<"'restarting' "<< syscallname(syscall)
+			LOG(debug) <<"'restarting' "<< t->syscallname(syscall)
 				   <<" interrupted by "<< t->ev().Syscall().regs.syscall_result()
 				   <<" at "<< intr_ip <<"; now at "<< cur_ip;
 			if (cur_ip == intr_ip) {
@@ -1383,7 +1383,7 @@ void rep_process_syscall(Task* t, struct rep_trace_step* step)
 			}
 		} else {
 			t->pop_syscall_interruption();
-			LOG(debug) <<"exiting restarted "<< syscallname(syscall);
+			LOG(debug) <<"exiting restarted "<< t->syscallname(syscall);
 		}
 	}
 

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -738,7 +738,7 @@ static void continue_or_step(Task* t, int stepi, int64_t rbc_period = 0)
 	ASSERT(t, child_sig_gt_zero)
 		<< "Replaying `"<< Event(t->current_trace_frame().ev)
 		<<"': expecting tracee signal or trap, but instead at `"
-		<< syscallname(t->regs().original_syscallno()) <<"' (rcb: "
+		<< t->syscallname(t->regs().original_syscallno()) <<"' (rcb: "
 		<< t->rbc_count() <<")";
 }
 
@@ -1325,7 +1325,7 @@ static int skip_desched_ioctl(Task* t,
 			      t->is_disarm_desched_event_syscall());
 	ASSERT(t, is_desched_syscall)
 		<<"Failed to reach desched ioctl; at "
-		<< syscallname(t->regs().original_syscallno()) <<"("<< t->regs().arg1()
+		<< t->syscallname(t->regs().original_syscallno()) <<"("<< t->regs().arg1()
 		<<", "<< t->regs().arg2() <<") instead";
 	/* Emulate a return value of "0".  It's OK for us to hard-code
 	 * that value here, because the syscallbuf lib aborts if a
@@ -1384,8 +1384,8 @@ static void assert_at_buffered_syscall(Task* t, int syscallno)
 	ASSERT(t, t->is_untraced_syscall())
 		<< "Bad ip "<< t->ip() <<": should have been buffered-syscall ip";
 	ASSERT(t, t->regs().original_syscallno() == syscallno)
-		<< "At "<< syscallname(t->regs().original_syscallno())
-		<<"; should have been at "<< syscallname(syscallno)
+		<< "At "<< t->syscallname(t->regs().original_syscallno())
+		<<"; should have been at "<< t->syscallname(syscallno)
 		<<"("<< syscallno <<")";
 }
 
@@ -1473,7 +1473,7 @@ static int flush_one_syscall(Task* t, int stepi)
 		// We'll check at syscall entry that the recorded and
 		// replayed record values match.
 
-		LOG(debug) <<"Replaying buffered `"<< syscallname(call)
+		LOG(debug) <<"Replaying buffered `"<< t->syscallname(call)
 			   <<"' (ret:"<< rec_rec->ret <<") which does"
 			   << (!rec_rec->desched ? " not" : "")
 			   <<" use desched event";

--- a/src/task.cc
+++ b/src/task.cc
@@ -23,6 +23,7 @@
 #include "hpc.h"
 #include "log.h"
 #include "session.h"
+#include "syscalls.h"
 #include "util.h"
 
 #define NUM_X86_DEBUG_REGS 8
@@ -3178,4 +3179,51 @@ Task::spawn(const struct args_env& ae, Session& session, pid_t rec_tid)
 	t->open_mem_fd();
 	return t;
 
+}
+
+const char*
+Task::syscallname(int syscall) const
+{
+	switch (syscall) {
+#define SYSCALLNO_X86(num)
+#define CASE(_name) 					\
+		case static_cast<int>(SyscallsX86::_name): return #_name;
+#define SYSCALL_DEF0(_name, _)				\
+		CASE(_name)
+#define SYSCALL_DEF1(_name, _, _1, _2)			\
+		CASE(_name)
+#define SYSCALL_DEF1_DYNSIZE(_name, _, _1, _2)		\
+		CASE(_name)
+#define SYSCALL_DEF1_STR(_name, _, _1)			\
+		CASE(_name)
+#define SYSCALL_DEF2(_name, _, _1, _2, _3, _4)		\
+		CASE(_name)
+#define SYSCALL_DEF3(_name, _, _1, _2, _3, _4, _5, _6)	\
+		CASE(_name)
+#define SYSCALL_DEF4(_name, _, _1, _2, _3, _4, _5, _6, _7, _8)	\
+		CASE(_name)
+#define SYSCALL_DEF_IRREG(_name, _)			\
+		CASE(_name)
+#define SYSCALL_DEF_UNSUPPORTED(_name)			\
+		CASE(_name)
+
+#include "syscall_defs.h"
+
+#undef SYSCALLNO_X86
+#undef CASE
+#undef SYSCALL_DEF0
+#undef SYSCALL_DEF1
+#undef SYSCALL_DEF1_DYNSIZE
+#undef SYSCALL_DEF1_STR
+#undef SYSCALL_DEF2
+#undef SYSCALL_DEF3
+#undef SYSCALL_DEF4
+#undef SYSCALL_DEF_IRREG
+#undef SYSCALL_DEF_UNSUPPORTED
+
+	case SYS_restart_syscall:
+		return "restart_syscall";
+	default:
+		return "<unknown-syscall>";
+	}
 }

--- a/src/task.h
+++ b/src/task.h
@@ -1572,6 +1572,11 @@ public:
 	 */
 	void open_mem_fd_if_needed();
 
+	/**
+	 * Return the name of the given syscall.
+	 */
+	const char* syscallname(int syscallno) const;
+
 	/* State only used during recording. */
 
 	/* The running count of events that have been recorded for

--- a/src/util.h
+++ b/src/util.h
@@ -303,12 +303,6 @@ const char* ptrace_req_name(int request);
 const char* signalname(int sig);
 
 /**
- * Return the symbolic name of |syscall|, f.e. "read", or "???syscall"
- * if unknown.
- */
-const char* syscallname(int syscall);
-
-/**
  * Return true iff replaying |syscallno| will never ever require
  * actually executing it, i.e. replay of |syscallno| is always
  * emulated.


### PR DESCRIPTION
x86 and x86-64 have wildly disparate syscall numbering schemes, so
anything dealing with syscall numbers is going to have to acquire some
32/64-bit awareness.  This patch is merely the first step in doing so.
Task seems like the best place to put the interface, even if the actual
implementation might not live on Task in the future.

I don't know that the changes to `Event` are the best, but I didn't see a good way of getting a `Task` handle at that point.
