### PR TITLE
explicitly call ::bind to distinguish from std::bind

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1158,7 +1158,7 @@ int retrieve_fd(Task* t, struct current_state_buffer* state, int fd)
 	if (listen_sock < 0) {
 		FATAL() <<"Failed to create listen socket";
 	}
-	if (bind(listen_sock, (struct sockaddr*)&socket_addr, sizeof(socket_addr))) {
+	if (::bind(listen_sock, (struct sockaddr*)&socket_addr, sizeof(socket_addr))) {
 		FATAL() <<"Failed to bind listen socket";
 	}
 	if (listen(listen_sock, 1)) {


### PR DESCRIPTION
We have |using namespace std;| in this file and that seems to cause conflicts in the GCC used on the Travis CI build machines when resolving |bind|.  For instance, the Travis CI build for my push for #1211:

https://travis-ci.org/mozilla/rr/builds/29445278

Attempt to fix this by explicitly picking which |bind| we're calling.  We'll see what the build machines think of it.
