### PR TITLE
Add new __kernel_vsyscall() offset seen in linux 3.15.3.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1416,7 +1416,8 @@ static void* locate_and_verify_kernel_vsyscall(Task* t)
 	// these offsets.
 	const ssize_t known_offsets[] = {
 		0x414,		// x86 native kernel ca. 3.12.10-300
-		0x420		// x86 process on x64 kernel
+		0x420,		// x86 process on x64 kernel
+		0xb30,		// x86 process on x64 kernel ca. 3.15.3-200
 	};
 	for (size_t i = 0; i < ALEN(known_offsets); ++i) {
 		void* addr = (byte*)vdso_start + known_offsets[i];


### PR DESCRIPTION
Resolves #1214.  Review isn't really meaningful for this patch so I'm going to directly merge it.
