### PR TITLE
Only use <=1/2 available user processes during fork_stress test.

### DIFF
--- a/src/test/fork_stress.c
+++ b/src/test/fork_stress.c
@@ -2,7 +2,7 @@
 
 #include "rrutil.h"
 
-#define NUM_ITERATIONS 500
+#define NUM_ITERATIONS 250
 
 int main(int argc, char *argv[]) {
 	int i;


### PR DESCRIPTION
Resolves #1218.

My test system has a process limit of 1024 user processes, and has ~250 running in the steady state.  I _think_ it turned out that this test was running in parallel with another instance of itself (either record or replay).  Two in parallel can create up to 1000 processes, which exceeds the ulimit and causes lots of things to break.

This rather cowardly fix makes it so that two parallel records/replays of this test can create at most 500 user processes, which is hopefully less than half the ulimit on common configs.

r? @rocallahan do you think this will make the test ineffective?  I.e. was 500 chosen by experiment?

(I started a more complicated patch that harvested processes in chunks, but it wasn't preventing the bug for some reason and I don't feel like tracking that down atm.)
