### PR TITLE
Allow tests that show CPUID divergences to opt-in to CPU binding.

### DIFF
--- a/src/test/async_signal_syscalls_100.run
+++ b/src/test/async_signal_syscalls_100.run
@@ -1,5 +1,9 @@
 source `dirname $0`/util.sh
 
+# It's relatively easy to reproduce a CPUID divergence caused by lack
+# of CPU binding.
+GLOBAL_OPTIONS="$GLOBAL_OPTIONS_BIND_CPU"
+
 # Ensure that the test records some USR_SCHED interrupt events.
 timeslice=100
 RECORD_ARGS="-c$timeslice"

--- a/src/test/breakpoint_overlap.run
+++ b/src/test/breakpoint_overlap.run
@@ -1,4 +1,9 @@
 source `dirname $0`/util.sh
+
+# It's relatively easy to reproduce a CPUID divergence caused by lack
+# of CPU binding.
+GLOBAL_OPTIONS="$GLOBAL_OPTIONS_BIND_CPU"
+
 RECORD_ARGS="-c100"
 record breakpoint_overlap "3 4"
 # Don't use pipes here since we need 'debug' to run in the same bash process

--- a/src/test/syscallbuf_timeslice_250.run
+++ b/src/test/syscallbuf_timeslice_250.run
@@ -1,5 +1,9 @@
 source `dirname $0`/util.sh
 
+# It's relatively easy to reproduce a CPUID divergence caused by lack
+# of CPU binding.
+GLOBAL_OPTIONS="$GLOBAL_OPTIONS_BIND_CPU"
+
 RECORD_ARGS="-c250"
 
 record syscallbuf_timeslice

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -80,11 +80,19 @@ function usage {
     echo Usage: "util.sh TESTNAME [LIB_ARG] [OBJDIR]"
 }
 
+DEFAULT_FLAGS="-s --check-cached-mmaps"
 # Don't bind record/replay tracees to the same logical CPU.  When we
 # do that, the tests take impractically long to run.
 #
 # TODO: find a way to run faster with CPU binding
-GLOBAL_OPTIONS="-u -s --check-cached-mmaps"
+GLOBAL_OPTIONS="-u $DEFAULT_FLAGS"
+# ... but tests that DO want CPU binding can override the default by
+# setting
+#
+#   GLOBAL_OPTIONS="$GLOBAL_OPTIONS_BIND_CPU"
+#
+# just after sourcing this file.
+GLOBAL_OPTIONS_BIND_CPU="$DEFAULT_FLAGS"
 
 LIB_ARG=$1
 OBJDIR=$2


### PR DESCRIPTION
Resolves #1221.

Not a very elegant fix but seems to do the trick on my machine.
