### PR TITLE
Expose x87 and SSE registers to gdb.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(BASIC_TESTS
   flock
   fork_child_crash
   fork_stress
+  fxregs
   getgroups
   getsid
   int3

--- a/src/registers.cc
+++ b/src/registers.cc
@@ -10,6 +10,60 @@
 #include "log.h"
 #include "util.h"
 
+// This is the byte offset at which the ST0-7 register data begins
+// with an xsave (or fxsave) block.
+static const int st_regs_offset = 32;
+// NB: each STx register holds 10 bytes of actual data, but each
+// occupies 16 bytes of space within (f)xsave, presumably for
+// alignment purposes.
+static const int st_reg_space = 16;
+
+// Byte offset at which the XMM0-7 register data begins with (f)xsave.
+static const int xmm_regs_offset = 160;
+static const int xmm_reg_space = 16;
+
+// Look up the byte offset in an (f)xsave region at which one of the
+// named fxsave DebuggerRegisters begins.  These registers begin at
+// DREG_FIRST_FXSAVE_REG and end at DREG_LAST_FXSAVE_REG.
+//
+// To find an offset in the array, index it by
+//
+//   fxsave_reg_offset[regname - DREG_FIRST_FXSAVE_REG]|
+//
+static const int fxsave_reg_offset[] = {
+	// DREG_ST0-DREG_ST7
+	st_regs_offset + st_reg_space * 0,
+	st_regs_offset + st_reg_space * 1,
+	st_regs_offset + st_reg_space * 2,
+	st_regs_offset + st_reg_space * 3,
+	st_regs_offset + st_reg_space * 4,
+	st_regs_offset + st_reg_space * 5,
+	st_regs_offset + st_reg_space * 6,
+	st_regs_offset + st_reg_space * 7,
+
+	0,			// DREG_FCTRL
+	2,			// DREG_FSTAT
+	4,			// DREG_FTAG
+	12,			// DREG_FISEG
+	8,			// DREG_FIOFF
+	20,			// DREG_FOSEG
+	16,			// DREG_FOOFF
+	6,			// DREG_FOP
+
+	// DREG_XMM0-DREG_XMM7
+	xmm_regs_offset + xmm_reg_space * 0,
+	xmm_regs_offset + xmm_reg_space * 1,
+	xmm_regs_offset + xmm_reg_space * 2,
+	xmm_regs_offset + xmm_reg_space * 3,
+	xmm_regs_offset + xmm_reg_space * 4,
+	xmm_regs_offset + xmm_reg_space * 5,
+	xmm_regs_offset + xmm_reg_space * 6,
+	xmm_regs_offset + xmm_reg_space * 7,
+
+	// DREG_MXCSR
+	24,
+};
+
 void Registers::print_register_file(FILE* f) const
 {
 	fprintf(f, "Printing register file:\n");
@@ -152,8 +206,9 @@ static size_t copy_register_value(uint8_t* buf, T src)
 size_t Registers::read_register(uint8_t* buf, unsigned int regno,
 				bool* defined) const
 {
-	*defined = true;
 	assert(regno < total_registers());
+
+	*defined = true;
 	switch (regno) {
 	case DREG_EAX:
 		return copy_register_value(buf, eax);
@@ -187,61 +242,11 @@ size_t Registers::read_register(uint8_t* buf, unsigned int regno,
 		return copy_register_value(buf, xfs);
 	case DREG_GS:
 		return copy_register_value(buf, xgs);
-	case DREG_ST0:
-	case DREG_ST1:
-	case DREG_ST2:
-	case DREG_ST3:
-	case DREG_ST4:
-	case DREG_ST5:
-	case DREG_ST6:
-	case DREG_ST7:
-		*defined = false;
-		/* Yes, really.  If somehow we ever support x87 values in
-		 * the debugger, we will have to be careful about how we
-		 * format our bits here.
-		 */
-		return 10;
-	case DREG_FCTRL:
-	case DREG_FSTAT:
-	case DREG_FTAG:
-	case DREG_FISEG:
-	case DREG_FOSEG:
-	case DREG_FOP:
-		*defined = false;
-		return 2;
-	case DREG_FIOFF:
-	case DREG_FOOFF:
-		*defined = false;
-		return 4;
 	case DREG_ORIG_EAX:
 		return copy_register_value(buf, orig_eax);
-	case DREG_XMM0:
-	case DREG_XMM1:
-	case DREG_XMM2:
-	case DREG_XMM3:
-	case DREG_XMM4:
-	case DREG_XMM5:
-	case DREG_XMM6:
-	case DREG_XMM7:
-		*defined = false;
-		return 16;
-	case DREG_MXCSR:
-		*defined = false;
-		return 4;
-	case DREG_YMM0H:
-	case DREG_YMM1H:
-	case DREG_YMM2H:
-	case DREG_YMM3H:
-	case DREG_YMM4H:
-	case DREG_YMM5H:
-	case DREG_YMM6H:
-	case DREG_YMM7H:
-		*defined = false;
-		return 16;
-	default:
-		assert(false);
-		return 0;
-  }
+	}
+	*defined = false;
+	return 0;
 }
 
 template<typename T>
@@ -296,6 +301,85 @@ Registers::write_register(unsigned reg_name,
 
 	// TODO remainder of register set
 	default:
-		FATAL() <<"Unknown register name "<< reg_name;
+		FATAL() <<"Unhandled register name "<< reg_name;
 	}
+}
+
+size_t
+ExtraRegisters::read_register(uint8_t* buf, unsigned int regno,
+			      bool* defined) const
+{
+	size_t num_bytes;
+	switch (regno) {
+	case DREG_ST0:
+	case DREG_ST1:
+	case DREG_ST2:
+	case DREG_ST3:
+	case DREG_ST4:
+	case DREG_ST5:
+	case DREG_ST6:
+	case DREG_ST7:
+		num_bytes = 10;
+		break;
+	case DREG_FCTRL:
+	case DREG_FSTAT:
+	case DREG_FTAG:
+	case DREG_FISEG:
+	case DREG_FOSEG:
+	case DREG_FOP:
+		// NB: these registers only occupy 2 bytes of space in
+		// the (f)xsave region, but gdb's default x86 target
+		// config expects us to send back 4 bytes of data for
+		// each.
+		num_bytes = 4;
+		break;
+	case DREG_FIOFF:
+	case DREG_FOOFF:
+		num_bytes = 4;
+		break;
+	case DREG_XMM0:
+	case DREG_XMM1:
+	case DREG_XMM2:
+	case DREG_XMM3:
+	case DREG_XMM4:
+	case DREG_XMM5:
+	case DREG_XMM6:
+	case DREG_XMM7:
+		num_bytes = 16;
+		break;
+	case DREG_MXCSR:
+		num_bytes = 4;
+		break;
+	case DREG_YMM0H:
+	case DREG_YMM1H:
+	case DREG_YMM2H:
+	case DREG_YMM3H:
+	case DREG_YMM4H:
+	case DREG_YMM5H:
+	case DREG_YMM6H:
+	case DREG_YMM7H:
+		// TODO: support AVX registers
+		*defined = false;
+		return 16;
+	default:
+		*defined = false;
+		return 0;
+	}
+	assert(num_bytes > 0);
+	assert(regno >= DREG_FIRST_FXSAVE_REG);
+	size_t fxsave_idx = regno - DREG_FIRST_FXSAVE_REG;
+	assert(fxsave_idx < ALEN(fxsave_reg_offset));
+
+	if (empty()) {
+		*defined = false;
+		return num_bytes;
+	}
+
+	*defined = true;
+	ssize_t offset = fxsave_reg_offset[fxsave_idx];
+	assert(offset >= 0);
+	assert(offset + num_bytes <= data.size());
+
+	memcpy(buf, data.data() + offset, num_bytes);
+	return num_bytes;
 }

--- a/src/registers.h
+++ b/src/registers.h
@@ -13,6 +13,34 @@
 
 #include "types.h"
 
+// Various things the GDB stub needs to know about.
+enum DebuggerRegister {
+	DREG_EAX, DREG_ECX, DREG_EDX, DREG_EBX,
+	DREG_ESP, DREG_EBP, DREG_ESI, DREG_EDI,
+	DREG_EIP, DREG_EFLAGS,
+	DREG_CS, DREG_SS, DREG_DS, DREG_ES, DREG_FS, DREG_GS,
+
+	DREG_FIRST_FXSAVE_REG,
+	DREG_ST0 = DREG_FIRST_FXSAVE_REG, DREG_ST1, DREG_ST2, DREG_ST3,
+	DREG_ST4, DREG_ST5, DREG_ST6, DREG_ST7,
+	// These are the names GDB gives the registers.
+	DREG_FCTRL, DREG_FSTAT, DREG_FTAG, DREG_FISEG,
+	DREG_FIOFF, DREG_FOSEG, DREG_FOOFF, DREG_FOP,
+	DREG_XMM0, DREG_XMM1, DREG_XMM2, DREG_XMM3,
+	DREG_XMM4, DREG_XMM5, DREG_XMM6, DREG_XMM7,
+	DREG_MXCSR,
+	// XXX the last fxsave reg on *x86*
+	DREG_LAST_FXSAVE_REG = DREG_MXCSR,
+
+	DREG_ORIG_EAX,
+	DREG_NUM_LINUX_I386,
+	DREG_YMM0H, DREG_YMM1H, DREG_YMM2H, DREG_YMM3H,
+	DREG_YMM4H, DREG_YMM5H, DREG_YMM6H, DREG_YMM7H,
+	// Last register we can find in user_regs_struct
+	// (except for orig_eax).
+	DREG_NUM_USER_REGS = DREG_GS + 1,
+};
+
 /**
  * A Registers object contains values for all general-purpose registers.
  * These must include all registers used to pass syscall parameters and return
@@ -120,33 +148,6 @@ public:
 					   const Registers* reg2,
 					   int mismatch_behavior);
 
-	// Various things the GDB stub needs to know about.
-	enum DebuggerRegister {
-		DREG_EAX, DREG_ECX, DREG_EDX, DREG_EBX,
-		DREG_ESP, DREG_EBP, DREG_ESI, DREG_EDI,
-		DREG_EIP, DREG_EFLAGS,
-		DREG_CS, DREG_SS, DREG_DS, DREG_ES, DREG_FS, DREG_GS,
-		/* We can't actually fetch the floating-point-related
-		 * registers, but we record them here so we can
-		 * communicate their sizes accurately.
-		 */
-		DREG_ST0, DREG_ST1, DREG_ST2, DREG_ST3,
-		DREG_ST4, DREG_ST5, DREG_ST6, DREG_ST7,
-		/* These are the names GDB gives the registers.  */
-		DREG_FCTRL, DREG_FSTAT, DREG_FTAG, DREG_FISEG,
-		DREG_FIOFF, DREG_FOSEG, DREG_FOOFF, DREG_FOP,
-		DREG_XMM0, DREG_XMM1, DREG_XMM2, DREG_XMM3,
-		DREG_XMM4, DREG_XMM5, DREG_XMM6, DREG_XMM7,
-		DREG_MXCSR,
-		DREG_ORIG_EAX,
-		DREG_NUM_LINUX_I386,
-		DREG_YMM0H, DREG_YMM1H, DREG_YMM2H, DREG_YMM3H,
-		DREG_YMM4H, DREG_YMM5H, DREG_YMM6H, DREG_YMM7H,
-		/* Last register we can find in user_regs_struct (except for
-		 * orig_eax). */
-		DREG_NUM_USER_REGS = DREG_GS + 1,
-	};
-
 	/**
 	 * Return the total number of registers for this target.
 	 */
@@ -193,6 +194,13 @@ public:
 	int data_size() const { return data.size(); }
 	const byte* data_bytes() const { return data.data(); }
 	bool empty() const { return data.empty(); }
+
+	/**
+	 * Like |Registers::read_register()|, except attempts to read
+	 * the value of an "extra register" (floating point / vector).
+	 */
+	size_t read_register(uint8_t* buf, unsigned int regno,
+			     bool* defined) const;
 
 private:
 	friend class Task;

--- a/src/task.h
+++ b/src/task.h
@@ -615,6 +615,23 @@ public:
 	void record_remote(void* addr, ssize_t num_bytes);
 	void record_remote_str(void* str);
 
+	/**
+	 * Attempt to find the value of |regname| (a DebuggerRegister
+	 * name) in this task, and if so (i) write it to |buf|; (ii)
+	 * set |*defined = true|; (iii) return the size of written
+	 * data.  If |*defined == false|, the value of |buf| is
+	 * meaningless.
+	 *
+	 * This helper can fetch the values of both general-purpose
+	 * and "extra" registers.
+	 *
+	 * NB: |buf| must be large enough to hold the largest register
+	 * value that can be named by |regname|.
+	 *
+	 * TODO: nicer API.
+	 */
+	size_t get_reg(uint8_t* buf, int regname, bool* defined);
+
 	/** Return the current regs of this. */
 	const Registers& regs();
 

--- a/src/test/fxregs.c
+++ b/src/test/fxregs.c
@@ -1,0 +1,55 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 8; indent-tabs-mode: t; -*- */
+
+#include "rrutil.h"
+
+static void breakpoint(void) {
+	int break_here = 1;
+	(void)break_here;
+}
+
+static const double st0 = 1;
+static const double st1 = 2;
+static const double st2 = 3;
+static const double st3 = 4;
+static const double st4 = 5;
+static const double st5 = 6;
+static const double st6 = 7;
+static const double st7 = 8;
+
+static const float xmm0 = 10;
+static const float xmm1 = 11;
+static const float xmm2 = 12;
+static const float xmm3 = 13;
+static const float xmm4 = 14;
+static const float xmm5 = 15;
+static const float xmm6 = 16;
+static const float xmm7 = 17;
+
+int main(int argc, char *argv[]) {
+	__asm__ __volatile__(
+		/* Push the constants in stack order so they look as
+		 * we expect in gdb. */
+		"fldl st7\n\t"
+		"fldl st6\n\t"
+		"fldl st5\n\t"
+		"fldl st4\n\t"
+		"fldl st3\n\t"
+		"fldl st2\n\t"
+		"fldl st1\n\t"
+		"fldl st0\n\t"
+
+		"movss xmm0, %xmm0\n\t"
+		"movss xmm1, %xmm1\n\t"
+		"movss xmm2, %xmm2\n\t"
+		"movss xmm3, %xmm3\n\t"
+		"movss xmm4, %xmm4\n\t"
+		"movss xmm5, %xmm5\n\t"
+		"movss xmm6, %xmm6\n\t"
+		"movss xmm7, %xmm7\n\t"
+	);
+
+	breakpoint();
+
+	atomic_puts("EXIT-SUCCESS");
+	return 0;
+}

--- a/src/test/fxregs.py
+++ b/src/test/fxregs.py
@@ -1,0 +1,19 @@
+from rrutil import *
+
+send_gdb('b breakpoint\n')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c\n')
+expect_gdb('Breakpoint 1, breakpoint')
+
+# See fxregs.c for the list of constants that are loaded into the
+# $st0-$st7 and $xmm0-$xmm7 registers.
+for i in xrange(8):
+    send_gdb('p $st%d\n'% (i))
+    expect_gdb(' = %d'% (i + 1))
+
+for i in xrange(8):
+    send_gdb('p $xmm%d.v4_float[0]\n'% (i))
+    expect_gdb(' = %d'% (i + 10))
+
+ok()

--- a/src/test/fxregs.run
+++ b/src/test/fxregs.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh fxregs "$@"
+debug_test


### PR DESCRIPTION
Resolves #1232.

@rocallahan you might want to skim over this.  The `Task::get_reg()` API isn't my favorite, but I think it's a quick way to get 2.0 out of the door that doesn't send us too far down the wrong path.
