### PR TITLE
Ignore SIGWINCH during replay.

### DIFF
--- a/src/replayer.h
+++ b/src/replayer.h
@@ -30,6 +30,17 @@ void dispatch_debugger_request(ReplaySession& session, struct dbg_context* dbg,
 			       Task* t, const struct dbg_request& req);
 
 /**
+ * Return true if |sig| is a signal that may be generated during
+ * replay but should be ignored.  For example, SIGCHLD can be
+ * delivered at almost point during replay when tasks exit, but it's
+ * not part of the recording and shouldn't be delivered.
+ *
+ * TODO: can we do some clever sigprocmask'ing to avoid pending
+ * signals altogether?
+ */
+bool is_ignored_replay_signal(int sig);
+
+/**
  * Open a temporary debugging connection for |t| and service requests
  * until the user quits or requests execution to resume.
  *

--- a/src/util.cc
+++ b/src/util.cc
@@ -1209,7 +1209,8 @@ static void advance_syscall(Task* t)
 {
 	do {
 		t->cont_syscall();
-	} while (t->is_ptrace_seccomp_event() || SIGCHLD == t->pending_sig());
+	} while (t->is_ptrace_seccomp_event()
+		 || is_ignored_replay_signal(t->pending_sig()));
 	assert(t->ptrace_event() == 0);
 }
 


### PR DESCRIPTION
Resolves #1245.
