### PR TITLE
Blacklist possibly-bad syscalls during diversions, instead of whitelisti...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,6 @@ set(BASIC_TESTS
   barrier
   big_buffers
   block
-  call_function
   chew_cpu
   clock
   clone
@@ -200,6 +199,7 @@ set(TESTS_WITH_PROGRAM
   block_intr_sigchld
   breakpoint
   breakpoint_overlap
+  call_function
   condvar_stress
   crash
   exit_group

--- a/src/debugger_gdb.cc
+++ b/src/debugger_gdb.cc
@@ -704,9 +704,7 @@ static void read_reg_value(char** strp, DbgRegister* reg)
 	}
 
 	reg->defined = true;
-	// TODO: mixed-arch support
-	reg->size = sizeof(void*);
-	assert(2 * reg->size == strlen(str));
+	reg->size = strlen(str) / 2;
 	for (size_t i = 0; i < reg->size; ++i) {
 		char tmp = str[2];
 		str[2] = '\0';

--- a/src/registers.cc
+++ b/src/registers.cc
@@ -303,7 +303,7 @@ Registers::write_register(unsigned reg_name,
 
 	// TODO remainder of register set
 	default:
-		FATAL() <<"Unhandled register name "<< reg_name;
+		LOG(warn) <<"Unhandled register name "<< reg_name;
 	}
 }
 

--- a/src/test/call_function.c
+++ b/src/test/call_function.c
@@ -35,12 +35,12 @@ static void alloc_and_print(void) {
 }
 
 static void make_unhandled_syscall(void) {
-	ssize_t ret = splice(-1, NULL, -1, NULL, 0, 0);
+	ssize_t ret = kill(getpid(), SIGKILL);
 	/* XXX the error return is somewhat arbitrary here, but as
 	 * long as |splice()| remains unimplemented in experiment
 	 * mode, it's reasonable to assume that the libc wrapper will
 	 * return -1 back to us. */
-	atomic_printf("return from splice: %d\n", ret);
+	atomic_printf("return from kill: %d\n", ret);
 }
 
 static void print_time(void) {

--- a/src/test/call_function.py
+++ b/src/test/call_function.py
@@ -16,12 +16,10 @@ send_gdb('call alloc_and_print()\n')
 expect_gdb('Hello 22')
 
 send_gdb('call make_unhandled_syscall()\n')
-expect_gdb('return from splice: -1')
+expect_gdb('return from kill: -1')
 
 send_gdb('call print_time()\n')
-# TODO: settle on a reasonable semantics for
-# clock_gettime() during experiments
-expect_gdb('now is 0 sec')
+expect_gdb(r'now is \d+ sec')
 
 send_gdb('c\n')
 expect_rr('var is -42')

--- a/src/test/call_function.run
+++ b/src/test/call_function.run
@@ -1,2 +1,2 @@
-source `dirname $0`/util.sh call_function "$@"
+source `dirname $0`/util.sh
 debug_test


### PR DESCRIPTION
...ng known-to-be OK ones.

This turned out to be particularly irritating because it turned out that the call_function test wasn't actually running.  (Luckily it hadn't regressed.)  And then for some reason, with nonzero return from clock_gettime to the call_function test, gdb all of a sudden started trying to write xsave registers.  That's stubbed out for now because we're about to add that support for real.
