### PR TITLE
Use the correct (raw) names for hardware-interrupt perf events.

### DIFF
--- a/src/trace.cc
+++ b/src/trace.cc
@@ -106,7 +106,7 @@ trace_frame::dump(FILE* out, bool raw_dump)
 	if (raw_dump) {
 		fprintf(out, " %lld %lld %lld %lld",
 #ifdef HPC_ENABLE_EXTRA_PERF_COUNTERS
-			hw_interrupts, page_faults, rbc, insts,
+			hw_interrupts, page_faults, rbc, insts
 #else
 			// Don't force tools to detect our config.
 			-1LL, -1LL, rbc, -1LL

--- a/src/trace.h
+++ b/src/trace.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "event.h"
+#include "hpc.h"
 #include "registers.h"
 #include "types.h"
 


### PR DESCRIPTION
Part of #610.

Something in the libpfm stack stopped understanding the HW_INTERRUPTS event, but that's OK: in meantime, it's grown support for parsing raw perf-event names.  That's fabulous, because it allows us to be 100% sure we're using the same events that are mentioned in the [deterministic counters bible](http://web.eece.maine.edu/~vweaver/projects/deterministic/deterministic_counters.pdf).
