### PR TITLE
Implement more of the linux signal-related syscalls.

### DIFF
--- a/src/syscall_defs.h
+++ b/src/syscall_defs.h
@@ -1184,9 +1184,42 @@ SYSCALL_DEF1(rt_sigaction, EMU, struct kernel_sigaction, arg3)
 SYSCALL_DEF1(rt_sigprocmask, EMU, sigset_t, arg3)
 
 SYSCALLNO_X86_64(127)
-SYSCALL_DEF_UNSUPPORTED(rt_sigpending)
-SYSCALL_DEF_UNSUPPORTED(rt_sigtimedwait)
-SYSCALL_DEF_UNSUPPORTED(rt_sigqueueinfo)
+
+/**
+ *  int sigpending(sigset_t *set);
+ *
+ * sigpending() returns the set of signals that are pending for
+ * delivery to the calling thread (i.e., the signals which have been
+ * raised while blocked).  The mask of pending signals is returned in
+ * set.
+ */
+SYSCALL_DEF1_DYNSIZE(rt_sigpending, EMU, t->regs().arg2(), arg1)
+
+/**
+ *  int sigtimedwait(const sigset_t *set, siginfo_t *info,
+ *                   const struct timespec *timeout);
+ *
+ * sigwaitinfo() suspends execution of the calling thread until one of
+ * the signals in set is pending (If one of the signals in set is
+ * already pending for the calling thread, sigwaitinfo() will return
+ * immedi ately.)
+ *
+ * sigtimedwait() operates in exactly the same way as sigwaitinfo()
+ * except that it has an additional argument, timeout, which specifies
+ * a minimum interval for which the thread is suspended waiting for a
+ * signal.
+ */
+SYSCALL_DEF_IRREG(rt_sigtimedwait, EMU)
+
+/**
+ *  int sigpending(sigset_t *set);
+ *
+ * sigpending() returns the set of signals that are pending for
+ * delivery to the calling thread (i.e., the signals which have been
+ * raised while blocked).  The mask of pending signals is returned in
+ * set.
+ */
+SYSCALL_DEF1_DYNSIZE(rt_sigqueueinfo, EMU, t->regs().arg2(), arg1)
 
 /**
  *  int sigsuspend(const sigset_t *mask);

--- a/src/task.cc
+++ b/src/task.cc
@@ -105,7 +105,7 @@ struct Sighandlers {
 	}
 
 	void init_from_current_process() {
-		for (int i = 0; i < ssize_t(ALEN(handlers)); ++i) {
+		for (int i = 1; i < ssize_t(ALEN(handlers)); ++i) {
 			Sighandler& h = handlers[i];
 			struct sigaction act;
 			if (-1 == sigaction(i, NULL, &act)) {

--- a/src/test/sigqueueinfo.c
+++ b/src/test/sigqueueinfo.c
@@ -2,34 +2,49 @@
 
 #include "rrutil.h"
 
-static int invoked_sighandler;
-
-static void* thread(void* unused) {
+static void queue_siginfo(int sig, int val) {
 	siginfo_t si = { 0 };
 
 	si.si_code = SI_QUEUE;
 	si.si_pid = getpid();
 	si.si_uid = geteuid();
-	si.si_value.sival_int = -42;
-	syscall(SYS_rt_tgsigqueueinfo, getpid(), getpid(), SIGUSR1, &si);
+	si.si_value.sival_int = val;
+	syscall(SYS_rt_tgsigqueueinfo, getpid(), getpid(), sig, &si);
+}
 
+static void* thread(void* unused) {
+	queue_siginfo(SIGUSR1, -42);
+	sleep(1);
+	queue_siginfo(SIGUSR2, 12345);
 	return NULL;
 }
 
+static int usr1_val;
+static int usr2_val;
+
 static void handle_signal(int sig, siginfo_t* si, void* ctx) {
-	test_assert(-42 == si->si_value.sival_int);
-	invoked_sighandler = 1;
+	int val = si->si_value.sival_int;
+	if (SIGUSR1 == sig) {
+		usr1_val = val;
+	} else if (SIGUSR2 == sig) {
+		usr2_val = val;
+	} else {
+		assert("Unexpected signal" && 0);
+	}
 }
 
 int main(int argc, char *argv[]) {
 	struct sigaction sa = {{ 0 }};
 	pthread_t t;
-	sigset_t mask;
+	sigset_t mask, pending;
 	int err;
+	struct timespec ts;
+	siginfo_t si = { 0 };
 
 	sa.sa_sigaction = handle_signal;
 	sa.sa_flags |= SA_SIGINFO;
 	sigaction(SIGUSR1, &sa, NULL);
+	sigaction(SIGUSR2, &sa, NULL);
 
 	pthread_create(&t, NULL, thread, NULL);
 
@@ -37,7 +52,22 @@ int main(int argc, char *argv[]) {
 	sigsuspend(&mask);
 	err = errno;
 	test_assert(EINTR == err);
-	test_assert(invoked_sighandler);
+	test_assert(-42 == usr1_val);
+
+	sigpending(&pending);
+	atomic_printf("USR1 pending? %s; USR2 pending? %s\n",
+		      sigismember(&pending, SIGUSR1) ? "yes" : "no",
+		      sigismember(&pending, SIGUSR2) ? "yes" : "no");
+
+	sigemptyset(&pending);
+	sigaddset(&pending, SIGUSR1);
+	sigaddset(&pending, SIGUSR2);
+	ts.tv_sec = 5;
+	ts.tv_nsec = 0;
+	err = sigtimedwait(&pending, &si, &ts);
+	atomic_printf("Signal %d became pending\n", err);
+	assert(SIGUSR2 == err);
+	assert(12345 == si.si_value.sival_int);
 
 	atomic_puts("EXIT-SUCCESS");
 	return 0;


### PR DESCRIPTION
#16.  We hit these syscalls when running under valgrind, presumably in the post-fork valgrind stub.

The task.cc change is the first rr fix that came from a valgrind warning :).
