### PR TITLE
account for trailing exponent in test call_function's regexp

### DIFF
--- a/src/test/call_function.py
+++ b/src/test/call_function.py
@@ -19,7 +19,7 @@ send_gdb('call make_unhandled_syscall()\n')
 expect_gdb('return from kill: -1')
 
 send_gdb('call print_time()\n')
-expect_gdb(r'now is \d+(\.\d+)? sec')
+expect_gdb(r'now is \d+(\.\d+(e\+\d\d)?)? sec')
 
 send_gdb('c\n')
 expect_rr('var is -42')


### PR DESCRIPTION
`call_function` started failing on my machine for no apparent reason.  I think this is because the `%g` format used by its `print_time` function is allowed to print an exponent, but the regular expression in `call_function.py` failed to account for that.  _Why_ it started printing the exponent is unclear, but I did adjust the system time on my VM, so maybe that accounts for it...
