### PR TITLE
fix 64-bit-only signed/unsigned comparison warning

### DIFF
--- a/src/vm.cc
+++ b/src/vm.cc
@@ -535,7 +535,7 @@ static bool is_adjacent_mapping(const MappingResourcePair& left,
 		return false;
 	}
 	if (rleft.id.is_real_device()
-	    && mleft.offset + mleft.num_bytes() != mright.offset) {
+	    && mleft.offset + off64_t(mleft.num_bytes()) != mright.offset) {
 		LOG(debug) <<"    ("<< mleft.offset <<" + "
 			   << mleft.num_bytes() <<" != "<< mright.offset
 			   <<": offsets into real device aren't adjacent)";


### PR DESCRIPTION
GCC complains when compiling rr for 64-bit:

/home/froydnj/src/rr/src/vm.cc: In function ‘bool is_adjacent_mapping(const MappingResourcePair&, const MappingResourcePair&)’:
/home/froydnj/src/rr/src/vm.cc:538:52: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
      && mleft.offset + mleft.num_bytes() != mright.offset) {

.offset is an off64_t, and .num_bytes() returns a size_t.  On a 32-bit
platform, everything is fine, because .num_bytes() is promoted to a
larger signed type, and the comparison is done purely in signed
arithmetic.  But on a 64-bit platform, where off64_t and size_t are the
same size, the promotion happens to .offset instead, to an unsigned
type, and then we have the signedness comparison mismatch.  Just ensure
that we do everything in signed arithmetic regardless.
