### PR TITLE
Fix build bustage on gcc 4.6, which is apparently not smart enough to do...

### DIFF
--- a/src/CompressedReader.cc
+++ b/src/CompressedReader.cc
@@ -20,7 +20,7 @@
 CompressedReader::CompressedReader(const std::string& filename)
     : fd(new ScopedFd(filename.c_str(), O_CLOEXEC | O_RDONLY | O_LARGEFILE)) {
   fd_offset = 0;
-  error = fd < 0;
+  error = (int)fd < 0;
   eof = false;
   buffer_read_pos = 0;
   have_saved_state = false;


### PR DESCRIPTION
... this conversion implicitly.

Travis is broken because of this too.  I still have a test failure in deliver_async_signal_during_syscalls after this.
