### PR TITLE
Architecture aware events

### DIFF
--- a/src/Event.cc
+++ b/src/Event.cc
@@ -44,13 +44,13 @@ Event::Event(EncodedEvent e) {
     case EV_UNSTABLE_EXIT:
     case EV_INTERRUPTED_SYSCALL_NOT_RESTARTED:
     case EV_EXIT_SIGHANDLER:
-      new (&Base()) BaseEvent(e.has_exec_info);
+      new (&Base()) BaseEvent(e.has_exec_info, e.arch());
       // No auxiliary data.
       assert(0 == e.data);
       return;
 
     case EV_DESCHED:
-      new (&Desched()) DeschedEvent(nullptr);
+      new (&Desched()) DeschedEvent(nullptr, e.arch());
       Desched().state = DeschedState(e.data);
       return;
 
@@ -58,11 +58,12 @@ Event::Event(EncodedEvent e) {
     case EV_SIGNAL_DELIVERY:
     case EV_SIGNAL_HANDLER:
       new (&Signal())
-          SignalEvent(~DET_SIGNAL_BIT & e.data, DET_SIGNAL_BIT & e.data);
+          SignalEvent(~DET_SIGNAL_BIT & e.data,
+                      DET_SIGNAL_BIT & e.data, e.arch());
       return;
 
     case EV_SYSCALL:
-      new (&Syscall()) SyscallEvent(e.data);
+      new (&Syscall()) SyscallEvent(e.data, e.arch());
       Syscall().state =
           SYSCALL_ENTRY == e.state ? ENTERING_SYSCALL : EXITING_SYSCALL;
       return;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2198,7 +2198,7 @@ template <typename Arch> static void rec_process_syscall_arch(Task* t) {
       if (new_tid < 0)
         break;
 
-      new_task->push_event(SyscallEvent(syscallno));
+      new_task->push_event(SyscallEvent(syscallno, t->arch()));
 
       /* record child id here */
       new_task->record_remote(

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -166,7 +166,8 @@ static void handle_ptrace_event(Task** tp) {
        * space, so we can unblock signals. */
       can_deliver_signals = 1;
 
-      t->push_event(SyscallEvent(syscall_number_for_execve(t->arch())));
+      t->push_event(SyscallEvent(syscall_number_for_execve(t->arch()),
+                                 t->arch()));
       t->ev().Syscall().state = ENTERING_SYSCALL;
       t->record_current_event();
       t->pop_syscall();
@@ -187,7 +188,7 @@ static void handle_ptrace_event(Task** tp) {
       }
 
       EventType ev = t->unstable ? EV_UNSTABLE_EXIT : EV_EXIT;
-      t->record_event(Event(ev, NO_EXEC_INFO));
+      t->record_event(Event(ev, NO_EXEC_INFO, t->arch()));
 
       rec_sched_deregister_thread(tp);
       t = *tp;
@@ -327,7 +328,8 @@ static void desched_state_changed(Task* t) {
        * recorded that syscall.  The following event sets
        * the abort-commit bit. */
       t->syscallbuf_hdr->abort_commit = 1;
-      t->record_event(Event(EV_SYSCALLBUF_ABORT_COMMIT, NO_EXEC_INFO));
+      t->record_event(Event(EV_SYSCALLBUF_ABORT_COMMIT,
+                            NO_EXEC_INFO, t->arch()));
 
       t->ev().Desched().state = DISARMING_DESCHED_EVENT;
     /* fall through */
@@ -345,7 +347,8 @@ static void desched_state_changed(Task* t) {
       t->syscallbuf_hdr->num_rec_bytes = 0;
       t->delay_syscallbuf_reset = false;
       t->delay_syscallbuf_flush = false;
-      t->record_event(Event(EV_SYSCALLBUF_RESET, NO_EXEC_INFO));
+      t->record_event(Event(EV_SYSCALLBUF_RESET, NO_EXEC_INFO,
+                            t->arch()));
       // We were just descheduled for potentially a long
       // time, and may have just had a signal become
       // pending.  Ensure we get another chance to run.
@@ -365,7 +368,8 @@ static void syscall_not_restarted(Task* t) {
 #endif
   t->pop_syscall_interruption();
 
-  t->record_event(Event(EV_INTERRUPTED_SYSCALL_NOT_RESTARTED, NO_EXEC_INFO));
+  t->record_event(Event(EV_INTERRUPTED_SYSCALL_NOT_RESTARTED,
+                        NO_EXEC_INFO, t->arch()));
 }
 
 /**
@@ -484,7 +488,7 @@ static void syscall_state_changed(Task* t, bool by_waitpid) {
 
         // We've finished processing this signal now.
         t->pop_signal_handler();
-        t->record_event(Event(EV_EXIT_SIGHANDLER, NO_EXEC_INFO));
+        t->record_event(Event(EV_EXIT_SIGHANDLER, NO_EXEC_INFO, t->arch()));
 
         maybe_discard_syscall_interruption(t, retval);
         // XXX probably not necessary to make the
@@ -577,7 +581,7 @@ static void syscall_state_changed(Task* t, bool by_waitpid) {
  */
 static void maybe_reset_syscallbuf(Task* t) {
   if (t->flushed_syscallbuf && !t->delay_syscallbuf_reset) {
-    t->record_event(Event(EV_SYSCALLBUF_RESET, NO_EXEC_INFO));
+    t->record_event(Event(EV_SYSCALLBUF_RESET, NO_EXEC_INFO, t->arch()));
   }
   /* Any code that sets |delay_syscallbuf_reset| is responsible
    * for recording its own SYSCALLBUF_RESET event at a
@@ -800,7 +804,7 @@ static void runnable_state_changed(Task* t) {
     case EV_SYSCALL_INTERRUPTION:
       // We just entered a syscall.
       if (!maybe_restart_syscall(t)) {
-        t->push_event(SyscallEvent(t->regs().original_syscallno()));
+        t->push_event(SyscallEvent(t->regs().original_syscallno(), t->arch()));
         rec_before_record_syscall_entry(t, t->ev().Syscall().number);
       }
       ASSERT(t, EV_SYSCALL == t->ev().type());
@@ -1010,7 +1014,7 @@ void terminate_recording(Task* t, int status) {
 
   TraceFrame frame(
       session->trace_writer().time(), t ? t->tid : 0,
-      Event(EV_TRACE_TERMINATION, BaseEvent(NO_EXEC_INFO)).encode());
+      Event(EV_TRACE_TERMINATION, NO_EXEC_INFO, RR_NATIVE_ARCH).encode());
   session->trace_writer().write_frame(frame);
   session->trace_writer().close();
 

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1245,7 +1245,7 @@ static void rep_process_syscall_arch(Task* t, struct rep_trace_step* step) {
       // that's semantically correct, and because
       // we'll only know how to pop one interruption
       // event later.
-      t->push_event(Event(interrupted, SyscallEvent(syscall)));
+      t->push_event(Event(interrupted, SyscallEvent(syscall, t->arch())));
       t->ev().Syscall().regs = t->regs();
     }
     step->action = TSTEP_RETIRE;

--- a/src/replayer.cc
+++ b/src/replayer.cc
@@ -974,9 +974,9 @@ static void guard_unexpected_signal(Task* t) {
     return;
   }
   if (t->child_sig) {
-    ev = SignalEvent(t->child_sig, NONDETERMINISTIC_SIG);
+    ev = SignalEvent(t->child_sig, NONDETERMINISTIC_SIG, t->arch());
   } else {
-    ev = SyscallEvent(max(0L, (long)t->regs().original_syscallno()));
+    ev = SyscallEvent(max(0L, (long)t->regs().original_syscallno()), t->arch());
   }
   ASSERT(t, child_sig_is_zero_or_sigtrap) << "Replay got unrecorded event "
                                           << ev << " while awaiting signal";
@@ -1296,12 +1296,12 @@ static Completion emulate_signal_delivery(struct dbg_context* dbg,
   bool restored_sighandler_frame = 0 < t->set_data_from_trace();
   if (restored_sighandler_frame) {
     LOG(debug) << "--> restoring sighandler frame for " << signalname(sig);
-    t->push_event(SignalEvent(sig, sigtype));
+    t->push_event(SignalEvent(sig, sigtype, t->arch()));
     t->ev().transform(EV_SIGNAL_DELIVERY);
     t->ev().transform(EV_SIGNAL_HANDLER);
   } else if (possibly_destabilizing_signal(
                  t, sig, Event(trace->event()).Signal().deterministic)) {
-    t->push_event(SignalEvent(sig, sigtype));
+    t->push_event(SignalEvent(sig, sigtype, t->arch()));
     t->ev().transform(EV_SIGNAL_DELIVERY);
 
     t->destabilize_task_group();

--- a/src/task.cc
+++ b/src/task.cc
@@ -216,7 +216,7 @@ Task::Task(Session& session, pid_t _tid, pid_t _rec_tid, int _priority)
       seen_ptrace_exit_event(false) {
   session_record = session.as_record();
   session_replay = session.as_replay();
-  push_event(Event(EV_SENTINEL, NO_EXEC_INFO));
+  push_event(Event(EV_SENTINEL, NO_EXEC_INFO, RR_NATIVE_ARCH));
 }
 
 Task::~Task() {
@@ -1771,7 +1771,7 @@ void Task::maybe_flush_syscallbuf() {
   }
   // Write the entire buffer in one shot without parsing it,
   // because replay will take care of that.
-  push_event(Event(EV_SYSCALLBUF_FLUSH, NO_EXEC_INFO));
+  push_event(Event(EV_SYSCALLBUF_FLUSH, NO_EXEC_INFO, arch()));
   record_local(syscallbuf_child,
                // Record the header for consistency checking.
                syscallbuf_hdr->num_rec_bytes + sizeof(*syscallbuf_hdr),


### PR DESCRIPTION
This is a straightforward go at fixing #1331.  But I'm not confident that 6c13bcb is correct; we do get a few test failures by keeping `regs()` in `arch()`, so that's the reason the commit is there.
