### PR TITLE
fix signed/unsigned comparison warnings in task.cc

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -40,8 +40,8 @@
  * checks that include this fd. */
 static const int REPLAY_DESCHED_EVENT_FD = -123;
 
-static const int NUM_X86_DEBUG_REGS = 8;
-static const int NUM_X86_WATCHPOINTS = 4;
+static const size_t NUM_X86_DEBUG_REGS = 8;
+static const size_t NUM_X86_WATCHPOINTS = 4;
 
 using namespace rr;
 using namespace std;


### PR DESCRIPTION
Otherwise we get warnings on the Travis CI builds.
