### PR TITLE
Set deb package architecture appropriately. Fixes #1336

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,13 @@ set(CPACK_PACKAGE_VENDOR "Mozilla Foundation")
 
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Mozilla Foundation")
 set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "i.86")
+  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm.*")
+  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm")
+endif()
 
 # XXX Cmake 2.8.7 doesn't know how to avoid specifiying /usr,
 # /usr/bin, etc, as files to be installed, but distros are finicky


### PR DESCRIPTION
This works locally, but I haven't actually tested an x86 or arm build:

```
$ dpkg-deb -I dist/rr-2.0.0-Linux-x86_64.deb
 new debian package, version 2.0.
 size 474450 bytes: control archive=423 bytes.
     251 bytes,     9 lines      control              
     168 bytes,     3 lines      md5sums              
 Package: rr
 Version: 2.0.0
 Section: devel
 Priority: optional
 Architecture: amd64
 Installed-Size: 1493
 Maintainer: Mozilla Foundation
 Description: Lightweight tool for recording and replaying execution of applications (trees of processes and threads)

$ sudo dpkg -i dist/rr-2.0.0-Linux-x86_64.deb 
[sudo] password for luser: 
dpkg: warning: parsing file '/var/lib/dpkg/available' near line 29140 package 'rr':
 missing architecture
Selecting previously unselected package rr.
(Reading database ... 416151 files and directories currently installed.)
Preparing to unpack dist/rr-2.0.0-Linux-x86_64.deb ...
Unpacking rr (2.0.0) ...
Setting up rr (2.0.0) ...
```
