### PR TITLE
fix ordering issue with recording clone(2)

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2203,19 +2203,19 @@ template <typename Arch> static void rec_process_syscall_arch(Task* t) {
       /* record child id here */
       new_task->record_remote(
           remote_ptr<typename Arch::pid_t>(t->regs().arg3()));
-      new_task->record_remote(
-          remote_ptr<typename Arch::pid_t>(t->regs().arg4()));
 
       if (Arch::clone_tls_type == Arch::UserDescPointer) {
         new_task->record_remote(
-            remote_ptr<typename Arch::user_desc>(new_task->regs().arg5()));
+            remote_ptr<typename Arch::user_desc>(t->regs().arg4()));
+        new_task->record_remote(
+            remote_ptr<typename Arch::user_desc>(new_task->regs().arg4()));
       } else {
         assert(Arch::clone_tls_type == Arch::PthreadStructurePointer);
       }
       new_task->record_remote(
           remote_ptr<typename Arch::pid_t>(new_task->regs().arg3()));
       new_task->record_remote(
-          remote_ptr<typename Arch::pid_t>(new_task->regs().arg4()));
+          remote_ptr<typename Arch::pid_t>(new_task->regs().arg5()));
 
       new_task->pop_syscall();
 

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -350,9 +350,9 @@ static void process_clone(Task* t, TraceFrame* trace, SyscallEntryOrExit state,
   /* FIXME: what if registers are non-null and contain an
    * invalid address? */
   t->set_data_from_trace();
-  t->set_data_from_trace();
 
   if (Arch::clone_tls_type == Arch::UserDescPointer) {
+    t->set_data_from_trace();
     new_task->set_data_from_trace();
   } else {
     assert(Arch::clone_tls_type == Arch::PthreadStructurePointer);


### PR DESCRIPTION
The x86 clone(2) syscall has the prototype:

sys_clone(unsigned long flags, unsigned long newsp,
          int\* parent_tid, int tls_val, int\* child_tid);

Due to a quirk in the recorder, we were inverting the recording of the
tls_val (struct user_desc\* for x86) and child_tid.

(cf. recorder.cc:handle_ptrace_event)

Fixes #1339.
