### PR TITLE
ensure RegisterArguments mmaps have offsets translated to pages

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2458,7 +2458,7 @@ template <typename Arch> static void rec_process_syscall_arch(Task* t) {
           process_mmap(
               t, syscallno, (size_t)t->regs().arg2(),
               (int)t->regs().arg3_signed(), (int)t->regs().arg4_signed(),
-              (int)t->regs().arg5_signed(), (off_t)t->regs().arg6_signed());
+              (int)t->regs().arg5_signed(), ((off_t)t->regs().arg6_signed()) / 4096);
           break;
       }
       break;


### PR DESCRIPTION
Kind of an embarrassing bug, but it's nice to have embarrassing bugs as we get down to the wire with x86-64 bugs left to be fixed!
