### PR TITLE
fix replaying zero-length reads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ set(BASIC_TESTS
   unjoined_thread
   wait
   write_race
+  zero_length_read
 )
 
 # A "test with program" consists of a foo.c source file and a foo.run driver

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2736,10 +2736,12 @@ template <typename Arch> static void rec_process_syscall_arch(Task* t) {
     case Arch::read: {
       AutoRestoreScratch restore_scratch(t, ALLOW_SLACK);
       remote_ptr<void> buf;
+      bool restore_buf = false;
 
       ssize_t nread = t->regs().syscall_result_signed();
       if (has_saved_arg_ptrs(t)) {
         buf = pop_arg_ptr<void>(t);
+        restore_buf = true;
       } else {
         buf = t->regs().arg2();
       }
@@ -2754,7 +2756,7 @@ template <typename Arch> static void rec_process_syscall_arch(Task* t) {
         record_noop_data(t);
       }
 
-      if (restore_scratch.scratch_used()) {
+      if (restore_buf) {
         Registers r = t->regs();
         r.set_arg2(buf);
         t->set_regs(r);

--- a/src/test/zero_length_read.c
+++ b/src/test/zero_length_read.c
@@ -1,0 +1,11 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char* argv[]) {
+  char buf[1024];
+  ssize_t count = read(STDIN_FILENO, &buf[0], 0);
+  test_assert(count == 0);
+  atomic_printf("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
The problem here is that AutoRestoreScratch assumes that:

```
  data.resize(num_bytes/*=0*/);
  iter = data.data();
```

results in a non-nullptr |iter|.  Since `scratch_used()` assumes the nullptr-ness of `iter` determines whether we have used scratch memory, we didn't properly restore the original buffer pointer for zero-length reads, leading to replay failures.

Theoretically, 0-length `recv` as implemented by `socketcall` suffers from the same problem.  But I couldn't figure out how to write a test that would exercise this, since we're always allocating scratch space for the `socketcall` argument buffer, and therefore the `scratch_used()` check always returns true.  `recvfrom` seems to not suffer from this bug.
