### PR TITLE
prevent step_thread test from infinite looping

### DIFF
--- a/src/test/step_thread.py
+++ b/src/test/step_thread.py
@@ -21,6 +21,7 @@ hit_bps = { 'A': 0, 'B': 0, 'C': 0 }
 
 events = [ re.compile(r'Breakpoint 1, hit_barrier'),
            re.compile(r'Breakpoint \d, ([ABC])'),
+           re.compile(r'Remote connection closed'),
            re.compile(r'\(gdb\)') ]
 while 1:
     send_gdb('s\n')
@@ -28,6 +29,8 @@ while 1:
     if 0 == i:
         break
     if 2 == i:
+        assert False, 'Program stopped unexpectedly, review gdb_rr.log'
+    if 3 == i:
         continue
 
     bp = last_match().group(1)


### PR DESCRIPTION
If an internal rr error occurs during the step_thread test, the
gdb_rr.log file will start to fill up with:

(gdb) s
s
[ERROR /home/froydnj/src/rr/src/Registers.cc:289:maybe_print_reg_mismatch() errno: 0 'Success']
 -> r11 0x306 != 0x206 (replaying vs. recorded)
Remote connection closed
(gdb) s
s
The program is not being run.
(gdb) s
s
The program is not being run.
(gdb) s

...and so forth.  Short-circuit this by checking to see whether gdb died
when we issued a step command.
