### PR TITLE
Move syscall_insn constants to a single place.

### DIFF
--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -187,9 +187,7 @@ private:
   Registers initial_regs;
   remote_ptr<uint8_t> initial_ip;
   int pending_syscallno;
-  static const uint8_t x86_syscall_insn[2];
-  static const uint8_t x64_syscall_insn[2];
-  uint8_t code_buffer[sizeof(x86_syscall_insn)];
+  uint8_t code_buffer[sizeof(rr::X86Arch::syscall_insn)];
 
   AutoRemoteSyscalls& operator=(const AutoRemoteSyscalls&) = delete;
   AutoRemoteSyscalls(const AutoRemoteSyscalls&) = delete;

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -288,10 +288,11 @@ static void validate_args(int syscallno, SyscallEntryOrExit state, Task* t) {
 /** Return true when |t|'s $ip points at a syscall instruction. */
 static bool entering_syscall_insn(Task* t) {
   static const uint8_t sysenter[] = { 0x0f, 0x34 };
+  auto& syscall_insn =
 #if defined(__x86_64__)
-  static const uint8_t syscall_insn[] = { 0x0f, 0x05 };
+                       X64Arch::syscall_insn;
 #elif defined(__i386__)
-  static const uint8_t syscall_insn[] = { 0xcd, 0x80 };
+                       X86Arch::syscall_insn;
 #else
 #error unknown architecture
 #endif

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -819,6 +819,8 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
   static const SelectCallingSemantics select_semantics = SelectStructArguments;
   static const UserAndGroupIDSizesSupported uid_gid_sizes = Mixed16And32Bit;
 
+  static const uint8_t syscall_insn[2];
+
 #include "SyscallEnumsX86.generated"
 
   struct user_regs_struct {
@@ -887,6 +889,8 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
   static const SelectCallingSemantics select_semantics =
       SelectRegisterArguments;
   static const UserAndGroupIDSizesSupported uid_gid_sizes = Only32Bit;
+
+  static const uint8_t syscall_insn[2];
 
 #include "SyscallEnumsX64.generated"
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -47,6 +47,9 @@
 using namespace std;
 using namespace rr;
 
+const uint8_t X86Arch::syscall_insn[2] = { 0xcd, 0x80 };
+const uint8_t X64Arch::syscall_insn[2] = { 0x0f, 0x05 };
+
 // FIXME this function assumes that there's only one address space.
 // Should instead only look at the address space of the task in
 // question.
@@ -832,10 +835,13 @@ void destroy_buffers(Task* t) {
 // the vdso in the future, this code can be eliminated in
 // favor of a *much* simpler vsyscall SYS_exit hook in the
 // preload lib.
+  auto& syscall_insn =
 #if defined(__i386__)
-  static const uint8_t syscall_insn[] = { 0xcd, 0x80 };
+                       X86Arch::syscall_insn;
 #elif defined(__x86_64__)
-  static const uint8_t syscall_insn[] = { 0x0f, 0x05 };
+                       X64Arch::syscall_insn;
+#else
+#error unknown architecture
 #endif
 
   Registers exit_regs = t->regs();


### PR DESCRIPTION
Not sure if util.cc is the best place for the actual initializers ... happy to move them somewhere else.  I thought about creating a kernel_abi.cc but it seemed like overkill.
