### PR TITLE
Only use PTRACE_O_TRACESECCOMP if seccomp is in fact enabled.

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -2090,7 +2090,12 @@ static void perform_remote_clone(Task* parent, AutoRemoteSyscalls& remote,
   intptr_t options =
       PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK |
       PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXEC | PTRACE_O_TRACEVFORKDONE |
-      PTRACE_O_TRACEEXIT | PTRACE_O_TRACESECCOMP | PTRACE_O_EXITKILL;
+      PTRACE_O_TRACEEXIT | PTRACE_O_EXITKILL;
+
+  if (Flags::get().use_syscall_buffer) {
+    options |= PTRACE_O_TRACESECCOMP;
+  }
+
   long ret = t->fallible_ptrace(PTRACE_SEIZE, nullptr, (void*)options);
   if (ret < 0 && errno == EINVAL) {
     // PTRACE_O_EXITKILL was added in kernel 3.8, and we only need


### PR DESCRIPTION
Using this flag on a 3.4 kernel causes ptrace() to fail with EIO.
