### PR TITLE
Assert that AutoRemoteSyscall advances ip by one syscall_insn.

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -80,6 +80,9 @@ long AutoRemoteSyscalls::syscall_helper(SyscallWaiting wait, int syscallno,
 
   advance_syscall(t);
 
+  ASSERT(t, t->regs().ip() - callregs.ip() == sizeof(X86Arch::syscall_insn))
+      << "Should have advanced ip by one syscall_insn";
+
   ASSERT(t, t->regs().original_syscallno() == syscallno)
       << "Should be entering " << t->syscallname(syscallno)
       << ", but instead at " << t->syscallname(t->regs().original_syscallno());


### PR DESCRIPTION
This was useful for me debugging, so I thought we might want it in the tree.
