### PR TITLE
Fix small typo in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 rr is a lightweight tool for recording and replaying execution of applications (trees of processes and threads).  More information about the project, including instructions on how to install, run, and build rr, is at [http://rr-project.org](http://rr-project.org).
 
-Or go directly to the [installation and building instructions](https://github.com/mozilla/rr/wiki/Installation).
+Or go directly to the [installation and building instructions](https://github.com/mozilla/rr/wiki/Building-And-Installing).
 
 Please contribute!  Make sure to review the [pull request checklist](/CONTRIBUTING.md) before submitting a pull request.


### PR DESCRIPTION
URL was pointing to a blank page.
