### PR TITLE
don't assume the length of a syscall insn in Task::is_entering_traced_syscall

### DIFF
--- a/src/task.cc
+++ b/src/task.cc
@@ -486,6 +486,16 @@ bool Task::is_disarm_desched_event_syscall() {
           PERF_EVENT_IOC_DISABLE == regs().arg2());
 }
 
+template <typename Arch>
+static bool is_entering_traced_syscall_arch(Task* t) {
+  remote_ptr<uint8_t> next_ip = t->ip() + sizeof(Arch::syscall_insn);
+  return next_ip == t->traced_syscall_ip;
+}
+
+bool Task::is_entering_traced_syscall() {
+  RR_ARCH_FUNCTION(is_entering_traced_syscall_arch, arch(), this);
+}
+
 bool Task::is_probably_replaying_syscall() {
   assert(session().is_replaying());
   // If the tracee is at our syscall entry points, we know for

--- a/src/task.h
+++ b/src/task.h
@@ -399,12 +399,7 @@ public:
    * code.  Callers may assume |is_in_syscallbuf()| is implied
    * by this.
    */
-  bool is_entering_traced_syscall() {
-    // |int $0x80| is |5d 80|, so |2| comes from
-    // |sizeof(int $0x80)|.
-    remote_ptr<uint8_t> next_ip = ip() + 2;
-    return next_ip == traced_syscall_ip;
-  }
+  bool is_entering_traced_syscall();
 
   /**
    * Return true if this is within the syscallbuf library.  This


### PR DESCRIPTION
By happy circumstance, the bare '+ 2' here works for supported architectures, but we have better ways to describe the length of a syscall insn now.

The first time I tested this change on my VM, I saw a few `checkpoint_` failures, but subsequent runs showed no failures.  The `gdb_rr.log` files from those failures looked truncated, though, so it's possible there was some pyexpect problem or similar.
