### PR TITLE
fix __syscall_slong_t errors in CI builds

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1178,7 +1178,7 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     struct timespec st_atim;
     struct timespec st_mtim;
     struct timespec st_ctim;
-    __syscall_slong_t __unused[3];
+    syscall_slong_t __unused[3];
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::stat, struct stat);
 
@@ -1197,7 +1197,7 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     struct timespec st_atim;
     struct timespec st_mtim;
     struct timespec st_ctim;
-    __syscall_slong_t __unused[3];
+    syscall_slong_t __unused[3];
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::stat64, struct stat64);
 };


### PR DESCRIPTION
Don't know if this will turn the build green, but it at least fixes one error.
