### PR TITLE
Account for a program break that may not be contiguous with the other ex...

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -354,6 +354,7 @@ static void iterate_memory_map(Task* t, memory_map_iterator_t it,
 static void print_process_mmap_iterator(void* unused, Task* t,
                                         const struct map_iterator_data* data) {
   fputs(data->raw_map_line, stderr);
+  fputc('\n', stderr);
 }
 
 /**
@@ -871,7 +872,7 @@ void VerifyAddressSpace::assert_segments_match(Task* t) {
     LOG(error) << "/proc/" << t->tid << "/mmaps:";
     print_process_mmap(t);
 
-    ASSERT(t, same_mapping) << "\nCached mapping " << m << "should be " << km;
+    ASSERT(t, same_mapping) << "\nCached mapping " << m << " should be " << km;
   }
 }
 
@@ -1162,11 +1163,15 @@ void AddressSpace::map_and_coalesce(const Mapping& m,
   }
 
   bool is_dynamic_heap = "[heap]" == info.name;
-  // This segment is adjacent to our previous guess at the start
-  // of the dynamic heap, but it's still not an explicit heap
-  // segment.  Update the guess.
-  if (as->heap.end == info.start_addr && !(info.prot & PROT_EXEC)) {
-    assert(as->heap.start == as->heap.end);
+  // This segment is adjacent to our previous guess at the start of
+  // the dynamic heap, but it's still not an explicit heap segment.
+  // Or, in corner cases, the segment is the final mapping of the data
+  // segment of the exe image, but is not adjacent to the prior mapped
+  // segment of the exe.  (This is seen with x86-64 bash on Fedora
+  // Core 20.)  Update the guess.
+  if (!(info.prot & PROT_EXEC)
+      && (as->heap.end == info.start_addr || as->exe == info.name)) {
+    assert(as->heap.start == as->heap.end || as->exe == info.name);
     as->update_heap(info.end_addr, info.end_addr);
     LOG(debug) << "  updating start-of-heap guess to " << as->heap.start
                << " (end of mapped-data segment)";


### PR DESCRIPTION
...ecutable image mappings.

Resolves #1384.

The problem is that just after an exec we see an address space laid out like

```
00400000-004dd000 r-xp 00000000 fd:01 1314442                            /usr/bin/bash
006dc000-006dd000 r--p 000dc000 fd:01 1314442                            /usr/bin/bash
006dd000-006e6000 rw-p 000dd000 fd:01 1314442                            /usr/bin/bash
006e6000-006ec000 rw-p 00000000 00:00 0 
008e5000-008ee000 rw-p 000e5000 fd:01 1314442                            /usr/bin/bash
```

The logic before this patch infers the program break as being at 0x006ec000, however the break is actually at 0x008ee000 as the immediately-following `brk` call shows:

```
008ee000-0090f000 rw-p 00000000 00:00 0                                  [heap]
```

So this patch updates the logic to look for the contiguous end-of-mappings as before, _or_ the last mapped page from the executable image.  This all still feels pretty fragile, but I still don't have a better solution :/.

Would be a good idea for someone to look this over so that the bus factor on this delicate code is >1.
