### PR TITLE
Handle the mmap "length" argument consistently.

### DIFF
--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -15,6 +15,7 @@
 #include "task.h"
 
 using namespace rr;
+using namespace std;
 
 struct RegisterValue {
   // The name of this register.
@@ -541,4 +542,12 @@ struct user_regs_struct Registers::get_ptrace() {
   convert_x86<from_x86_narrow, from_x86_same>(
       u.x86regs, *reinterpret_cast<X64Arch::user_regs_struct*>(&result));
   return result;
+}
+
+ostream& operator<<(ostream& stream, const Registers& r) {
+  stream << "{ args:("<< HEX(r.arg1()) << "," << HEX(r.arg2()) << ","
+         << HEX(r.arg3()) << "," << HEX(r.arg4()) << ","
+         << HEX(r.arg5()) << "," << r.arg6()
+         << ") orig_syscall:" << r.original_syscallno() << " }";
+  return stream;
 }

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -326,4 +326,6 @@ private:
   SupportedArch arch_;
 };
 
+std::ostream& operator<<(std::ostream& stream, const Registers& r);
+
 #endif /* RR_REGISTERS_H_ */

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1331,8 +1331,8 @@ void ReplaySession::setup_replay_one_trace_frame(Task* t) {
              << state_name(trace_frame.event().state);
   if (t->syscallbuf_hdr) {
     LOG(debug) << "    (syscllbufsz:" << t->syscallbuf_hdr->num_rec_bytes
-               << ", abrtcmt:" << t->syscallbuf_hdr->abort_commit
-               << ", locked:" << t->syscallbuf_hdr->locked << ")";
+               << ", abrtcmt:" << bool(t->syscallbuf_hdr->abort_commit)
+               << ", locked:" << bool(t->syscallbuf_hdr->locked) << ")";
   }
 
   if (t->child_sig != 0) {

--- a/src/test/mmap_shared.c
+++ b/src/test/mmap_shared.c
@@ -38,7 +38,7 @@ static void run_test(void) {
   args.flags = MAP_SHARED;
   args.fd = fd;
   args.offset = 0;
-  rpage = (int*)syscall(SYS_mmap, &args);
+  rpage = (int*)syscall(SYS_mmap, &args, -1, -1, -1, -1, -1);
 #elif defined(__x86_64__)
   rpage = (int*)syscall(SYS_mmap, 0, num_bytes, PROT_READ, MAP_SHARED, fd,
                         (off_t)0);


### PR DESCRIPTION
Resolves #1402.

Really nasty bug ... still not entirely sure how it was passing by accident before.  But anyway.

I'd recommend someone look over this to make sure I'm using the new `Arch` toys correctly.
