### PR TITLE
More meaningful message when ~/.rr doesn't exist.

### DIFF
--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -51,9 +51,16 @@ static TraceStream::Substream operator++(TraceStream::Substream& s) {
   return s;
 }
 
+static bool file_exists(const string& file) {
+  struct stat dummy;
+  return !file.empty() && stat(file.c_str(), &dummy) == 0
+      && S_ISREG(dummy.st_mode);
+}
+
 static bool dir_exists(const string& dir) {
   struct stat dummy;
-  return !dir.empty() && stat(dir.c_str(), &dummy) == 0;
+  return !dir.empty() && stat(dir.c_str(), &dummy) == 0
+      && S_ISDIR(dummy.st_mode);
 }
 
 static string default_rr_trace_dir() {
@@ -592,6 +599,14 @@ TraceReader::TraceReader(const string& dir)
   }
 
   string path = version_path();
+  if (!file_exists(path)) {
+    fprintf(
+        stderr,
+        "rr: warning: No traces have been recorded so far.\n"
+        "\n");
+    exit(EX_DATAERR);
+  }
+
   fstream vfile(path.c_str(), fstream::in);
   if (!vfile.good()) {
     fprintf(


### PR DESCRIPTION
Fixes #1583 
