### PR TITLE
flushregs on RRCmds because they can invalidate the GDB caches

### DIFF
--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -94,6 +94,7 @@ class RRCmd(gdb.Command):
         for arg in args:
             argStr += ":" + gdb_escape(arg)
         rv = gdb.execute(cmd_prefix + argStr, to_string=True);
+        gdb.execute("flushregs");
         rv_match = re.search('received: "(.*)"', rv, re.MULTILINE);
         if not rv_match:
             gdb.write("Response error: " + rv)

--- a/src/test/history.py
+++ b/src/test/history.py
@@ -1,4 +1,10 @@
 from rrutil import *
+import re
+
+def get_rip():
+    send_gdb('print $rip')
+    expect_gdb(re.compile(r'(.*) \(void \(\*\)\(\)\) (0[xX][0-9a-fA-F]+) (.*)'))
+    return eval(last_match().group(2));
 
 send_gdb('b breakpointA')
 expect_gdb('Breakpoint 1')
@@ -39,7 +45,25 @@ expect_gdb("Can't go forward. No more history entries.")
 send_gdb('back')
 expect_gdb('i=0')
 
-send_gdb('d 1')
-expect_gdb('c')
+# si/back should restore the current state
+old_rip = get_rip()
+send_gdb('si')
+send_gdb('back')
+new_rip = get_rip()
+if old_rip != new_rip:
+    failed('ERROR back did not restore IP')
 
+# TODO Support 'back' after the program has terminated
+# Run to end of the program and restore the state
+# User story: Miss a breakpoint and accidentaly terminate the program
+# send_gdb('delete 1')
+# send_gdb('continue')
+# expect_gdb('EXIT-SUCCESS')
+# send_gdb('back')
+# if old_rip != new_rip:
+#     failed('ERROR back did not restore IP')
+
+# Finish execution
+send_gdb('continue')
+expect_gdb('EXIT-SUCCESS')
 ok()


### PR DESCRIPTION
What do you think about this fix?

https://sourceware.org/gdb/onlinedocs/gdb/Maintenance-Commands.html

We might get hit later by another cache but so far this seems to work ok.

I wrote a testcase to make sure we do the right thing when hitting the end of the program and we don't. I've added it as a todo for now.
