### PR TITLE
[WIP] Compatibility with LLDB

### DIFF
--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -355,6 +355,11 @@ public:
     bool reverse_execution;
   };
 
+  struct GdbFeatures {
+    GdbFeatures() : multiprocess(false) {}
+    bool multiprocess;
+  };
+
   /**
    * Call this when the target of |req| is needed to fulfill the
    * request, but the target is dead.  This situation is a symptom of a
@@ -681,6 +686,7 @@ private:
   size_t packetend;            /* index of '#' character */
   std::vector<uint8_t> outbuf; /* buffered output for gdb */
   Features features_;
+  GdbFeatures gdb_features_;
   bool connection_alive_;
 };
 


### PR DESCRIPTION
This teaches rr to respect the client debuggers's advertised support of
the GDB multiprocess protocol. We parse the state of the client's
multiprocess support from its qSupported message and use this to
determine whether we produce old-style thread IDs or the
multiprocess-style pPID.TID format.

This fixes #2078.