### PR TITLE
RFC: Add a mechanism to avoid including unnecessary files in the trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,11 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
 include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++17" SUPPORTS_CXX17)
 CHECK_CXX_COMPILER_FLAG("-std=c++14" SUPPORTS_CXX14)
-if (SUPPORTS_CXX14)
+if (SUPPORTS_CXX17)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++17")
+elseif(SUPPORTS_CXX14)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++11")

--- a/src/CompressedReader.h
+++ b/src/CompressedReader.h
@@ -63,7 +63,7 @@ public:
   }
 
   CompressedReader& operator>>(std::string& value) {
-    value.empty();
+    value.clear();
     while (true) {
       char ch;
       read(&ch, 1);


### PR DESCRIPTION
This is more a kick off point for discussion than a serious PR at this point,
but I figure it's always better to discuss with working code than in the abstract.

We're planning to start collecting large numbers of rr traces from failing CI jobs.
However, at the moment, these traces are a bit large for comfort. However, they
don't need to be that large, because a good fraction of their size comes from
binaries that we're already storing on our artifact server, and thus don't need
to store separately in the trace. This PR adds an `--index-dir` option to `rr pack`.
rr will index each such directory, cataloguing all contained files by content hash.
It will then symlink the index directory into the trace, rewrite the mmap entries
to point into this symlink and as usual delete any unreferenced files. The idea is
to send this directory over to the replay machine, rewrite the symlink to a directory
containing the same immutable binaries that were in the index directory and replay
the trace that way.

This works ok, and is probably what we'll do for the short term, but it's not a
satisfying long-term solution, since we don't record any information whatsoever
about what was in the index directory. I'm thinking a better solution would be
to have a custom `external` record type that we could use with a custom packer
to record exactly where on our artifact server the relevant binary can be found
(which is easy, since those binaries are already content-addressed). That said,
the effort to implement that seemed not-insubstantial, so this is the poor man's
version of that.

If the version in this PR is interesting, I'm happy to clean it up and get it in
properly, but as I said, I'd like to personally move away from it in the medium
term, so I don't need it merged.