### PR TITLE
Enable rr to be built on RHEL7 again.

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -506,9 +506,11 @@ static void handle_seccomp_trap(RecordTask* t,
     case x86_64:
       si.native_api._sifields._sigsys._arch = AUDIT_ARCH_X86_64;
       break;
+    #ifdef AUDIT_ARCH_AARCH64
     case aarch64:
       si.native_api._sifields._sigsys._arch = AUDIT_ARCH_AARCH64;
       break;
+    #endif
     default:
       DEBUG_ASSERT(0 && "Unknown architecture");
       break;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3452,7 +3452,9 @@ void Task::dup_from(Task *other) {
       remote_this.syscall(syscall_number_for_fchdir(this->arch()), child_fd);
       remote_this.syscall(syscall_number_for_close(this->arch()), child_fd);
     }
-    struct prctl_mm_map map = {};
+    struct prctl_mm_map map;
+    memset(&map, 0, sizeof(prctl_mm_map));
+
     other->vm()->read_mm_map(other, &map);
     apply_mm_map(remote_this, map);
   }

--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -213,9 +213,15 @@ static void ethtool(int sockfd, struct ifreq* req) {
   ALLOCATE_GUARD(et_drvinfo, 'c');
   GENERIC_ETHTOOL_REQUEST_BY_NAME(et_drvinfo, ETHTOOL_GDRVINFO);
   if (-1 != ret) {
+    #ifdef ETHTOOL_EROMVERS_LEN
     atomic_printf("driver:%s version:%s fw_version:%s bus_info:%s erom_version:%s\n",
                   et_drvinfo->driver, et_drvinfo->version, et_drvinfo->fw_version,
                   et_drvinfo->bus_info, et_drvinfo->erom_version);
+    #else
+    atomic_printf("driver:%s version:%s fw_version:%s bus_info:%s\n",
+                  et_drvinfo->driver, et_drvinfo->version, et_drvinfo->fw_version,
+                  et_drvinfo->bus_info);
+    #endif
   }
 
   ALLOCATE_GUARD(et_wolinfo, 'd');

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -125,6 +125,10 @@ typedef unsigned char uint8_t;
 
 #define ALEN(_a) (sizeof(_a) / sizeof(_a[0]))
 
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+
 /**
  * Allocate new memory of |size| in bytes. The pointer returned is never NULL.
  * This calls aborts the program if the host runs out of memory.

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,10 @@
  * so we can't use it. */
 #define SYSCALLBUF_DEFAULT_DESCHED_SIGNAL SIGPWR
 
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+
 namespace rr {
 
 /*


### PR DESCRIPTION
This patch allows `rr` to be built on RHEL7. 

The build issues are stemming from older kernel versions (missing macros) and the base compiler (warnings due to zero initialization).