### PR TITLE
Uncomment `d_type` in struct `dirent`

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1393,7 +1393,7 @@ struct BaseArch : public wordsize,
     ino_t d_ino;
     off_t d_off;
     uint16_t d_reclen;
-    //    uint8_t d_type;
+    uint8_t d_type;
     uint8_t d_name[256];
   };
   RR_VERIFY_TYPE(dirent);


### PR DESCRIPTION
For some reason `d_type` member variable is commented out in struct `dirent`. Perhaps it was by mistake? Or is there a reason?

This commit simply uncomments this