### PR TITLE
Improve compatibility to GDB 10.1

### DIFF
--- a/src/test/util.py
+++ b/src/test/util.py
@@ -89,9 +89,9 @@ def expect(prog, what):
 
 def get_exe_arch():
     send_gdb('show architecture')
-    expect_gdb('The target architecture is set automatically \\(currently ([0-9a-z:-]+)\\)')
+    expect_gdb(r'The target architecture is set (automatically|to "auto") \(currently "?([0-9a-z:-]+)"?\)\.?')
     global gdb_rr
-    return gdb_rr.match.group(1)
+    return gdb_rr.match.group(2)
 
 def get_rr_cmd():
     '''Return the command that should be used to invoke rr, as the tuple

--- a/src/test/x86/fxregs.py
+++ b/src/test/x86/fxregs.py
@@ -18,7 +18,7 @@ for i in range(8):
     expect_gdb(' = %d'%(i + 10))
 
 send_gdb('show architecture')
-have_64 = 0 == expect_list([re.compile('i386:x86-64\)'), re.compile('i386\)')])
+have_64 = 0 == expect_list([re.compile('i386:x86-64"?\)'), re.compile('i386"?\)')])
 
 if have_64:
     for i in range(8,16):


### PR DESCRIPTION
gdb_9.2-1_amd64.deb
(rr) show architecture
The target architecture is set automatically (currently i386:x86-64)

gdb_10.1-1_amd64.deb
(rr) show architecture
The target architecture is set to "auto" (currently "i386:x86-64").

Related issue #2740