### PR TITLE
Save interpreter_base and ld_path at AddressSpace construction.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1215,6 +1215,7 @@ set(TESTS_WITH_PROGRAM
   x86/int3_ok
   interrupt
   intr_ptrace_decline
+  invalid_interpreter
   invalid_jump
   jit_proc_mem
   link

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -752,6 +752,12 @@ public:
   const std::vector<uint8_t>& saved_auxv() { return saved_auxv_; }
   void save_auxv(Task* t);
 
+  remote_ptr<void> saved_interpreter_base() { return saved_interpreter_base_; }
+  void save_interpreter_base(Task* t, std::vector<uint8_t> auxv);
+
+  std::string saved_ld_path() { return saved_ld_path_;}
+  void save_ld_path(Task* t, remote_ptr<void>);
+
   void read_mm_map(Task* t, struct prctl_mm_map* map);
 
   /**
@@ -1123,6 +1129,8 @@ private:
   int stopping_breakpoint_table_entry_size_;
 
   std::vector<uint8_t> saved_auxv_;
+  remote_ptr<void> saved_interpreter_base_;
+  std::string saved_ld_path_;
 
   /**
    * The time of the first event that ran code for a task in this address space.

--- a/src/test/invalid_interpreter.c
+++ b/src/test/invalid_interpreter.c
@@ -1,0 +1,26 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+size_t page_size;
+
+static void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+void callback(__attribute__((unused)) uint64_t env, char* name, map_properties_t* props) {
+  if (strstr(name, "/ld-") != 0) {
+    test_assert(0 == munmap((void*)(uintptr_t)props->start, page_size));
+    void* p = (void*)mmap((void*)(uintptr_t)props->start, page_size, PROT_NONE, MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS, -1, 0);
+    test_assert(p != MAP_FAILED);
+  }
+}
+
+int main(void) {
+  page_size = sysconf(_SC_PAGESIZE);
+  FILE* maps_file = fopen("/proc/self/maps", "r");
+  iterate_maps(0, callback, maps_file);
+  breakpoint();
+  return 0;
+}

--- a/src/test/invalid_interpreter.py
+++ b/src/test/invalid_interpreter.py
@@ -1,0 +1,12 @@
+from util import *
+
+send_gdb('break breakpoint')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+send_gdb('checkpoint')
+expect_gdb('Checkpoint 1 at')
+send_gdb('restart 1')
+expect_gdb('stopped')
+
+ok()

--- a/src/test/invalid_interpreter.run
+++ b/src/test/invalid_interpreter.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record invalid_interpreter$bitness
+debug invalid_interpreter

--- a/src/util.h
+++ b/src/util.h
@@ -52,6 +52,16 @@ enum Completion { COMPLETE, INCOMPLETE };
 std::vector<uint8_t> read_auxv(Task* t);
 
 /**
+ * Returns the base address where the interpreter is mapped.
+ */
+remote_ptr<void> read_interpreter_base(std::vector<uint8_t> auxv);
+
+/**
+ * Returns a string containing the file name of the interpreter.
+ */
+std::string read_ld_path(Task* t, remote_ptr<void> interpreter_base);
+
+/**
  * Returns a vector containing the environment strings.
  */
 std::vector<std::string> read_env(Task* t);


### PR DESCRIPTION
This aids compatibility with GDB 10.1.
Related issue #2740.