### PR TITLE
Propagate SIGTRAP to client during diversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,6 +1185,7 @@ set(TESTS_WITH_PROGRAM
   daemon_read
   dconf_mock
   dev_tty
+  diversion_sigtrap
   diversion_syscall
   dlopen
   early_error

--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -154,6 +154,10 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
   if (t->stop_sig()) {
     LOG(debug) << "Pending signal: " << t->get_siginfo();
     result.break_status = diagnose_debugger_trap(t, command);
+    if (!result.break_status.breakpoint_hit && result.break_status.watchpoints_hit.empty() && !result.break_status.singlestep_complete && (t->stop_sig() == SIGTRAP)) {
+      result.break_status.signal = unique_ptr<siginfo_t>(new siginfo_t(t->get_siginfo()));
+      result.break_status.signal->si_signo = t->stop_sig();
+    }
     LOG(debug) << "Diversion break at ip=" << (void*)t->ip().register_value()
                << "; break=" << result.break_status.breakpoint_hit
                << ", watch=" << !result.break_status.watchpoints_hit.empty()

--- a/src/test/diversion_sigtrap.c
+++ b/src/test/diversion_sigtrap.c
@@ -1,0 +1,18 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static __attribute__((noinline)) void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+static __attribute__((noinline)) int hardware_breakpoint(void) {
+  asm("int3;");
+  return 10;
+}
+
+int main(void) {
+  breakpoint();
+  hardware_breakpoint();
+}

--- a/src/test/diversion_sigtrap.py
+++ b/src/test/diversion_sigtrap.py
@@ -1,0 +1,11 @@
+from util import *
+import re, sys
+
+send_gdb('b breakpoint')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+send_gdb('p hardware_breakpoint()')
+expect_gdb('Program received signal SIGTRAP')

--- a/src/test/diversion_sigtrap.run
+++ b/src/test/diversion_sigtrap.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record $TESTNAME
+debug_test


### PR DESCRIPTION
Changes DiversionSession to propagate a SIGTRAP received by the target
process to the client, as a signal, when it was not produced by a
debugger breakpoint, a singlestep operation or a watchpoint.