### PR TITLE
Use strtoull instead of strtoul to make search test succeed at i386.

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -734,7 +734,7 @@ bool GdbConnection::query(char* payload) {
       req.target = query_thread;
       req.mem().addr = strtoul(args, &args, 16);
       parser_assert(';' == *args++);
-      req.mem().len = strtoul(args, &args, 16);
+      req.mem().len = strtoull(args, &args, 16);
       parser_assert(';' == *args++);
       read_binary_data((const uint8_t*)args, inbuf.data() + packetend,
                        req.mem().data);


### PR DESCRIPTION
GDB transmits the length as a 16 byte hex
representation e.g. ffffffffffba6f76.
Unfortunately strtoul at i386 returns 0xffffffff
and silently ignores remaining bytes.
This leads rr to "Assertion `start_ <= end_' failed."

This seems to be because strtoul returns 'unsigned long' which
is at i386 a 32bit type but at x86_64 a 64bit type.

This patch uses strtoull which still gets casted into a 32 bit value,
but len then contains 0xffba6f76 instead of 0xffffffff.


<details><summary>Example GDB session at i386 showing the issue</summary>
<p>

```
benutzer@debian:/home/bernhard/data/entwicklung/2020/rr/2020-11-21/obj_i686$ bin/rr replay -o-n -x /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/test_setup.gdb /tmp/rr-test-search-mrZWyYEwg/latest-trace
GNU gdb (Debian 10.1-1+b1) 10.1
...
Reading symbols from /tmp/rr-test-search-mrZWyYEwg/search-mrZWyYEwg-0/mmap_hardlink_3_search-mrZWyYEwg...
Really redefine built-in command "restart"? (y or n) [answered Y; input not from terminal]
Remote debugging using 127.0.0.1:7460
Reading symbols from /lib/ld-linux.so.2...
Reading symbols from /usr/lib/debug/.build-id/3d/12637936898bf0a0110c35990ebc0617eed9b7.debug...
0xb7fbd0b0 in _start () from /lib/ld-linux.so.2
(rr) b breakpoint
Breakpoint 1 at 0x4563aa: file /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/search.c, line 13.
(rr) c
Continuing.

Breakpoint 1, breakpoint () at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/search.c:13
13      static void breakpoint(void) {}
(rr) find 0,-10L,(char)0,(char)1,(char)2,(char)2,(char)3,(char)0xff,(char)0xfa,(char)0xde,(char)0xbc
0x459080 <buf>
rr: /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h:19: rr::MemoryRange::MemoryRange(rr::remote_ptr<void>, size_t): Assertion `start_ <= end_' failed.
```

```
benutzer@debian:~$ ps aux | grep "bin/rr replay"
benutzer  7460  2.2  0.2  15656  8596 pts/1    S+   09:54   0:00 bin/rr replay -o-n -x /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/test_setup.gdb /tmp/rr-test-search-mrZWyYEwg/latest-trace

benutzer@debian:~$ gdb -q --pid 7460
Attaching to process 7460
...
0xb7ee7559 in __kernel_vsyscall ()
(gdb) b GdbConnection.cc:735
Breakpoint 1 at 0x77c9e8: file /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbConnection.cc, line 735.
(gdb) cont
Continuing.

Breakpoint 1, rr::GdbConnection::query (this=0x2473e50, payload=0x242f862 "Search") at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbConnection.cc:735
735           req.mem().addr = strtoul(args, &args, 16);
(gdb) set print repeats 0
(gdb) print args         
$2 = 0x242f870 "0;fffffffffffffff7;"
(gdb) next
736           parser_assert(';' == *args++);
(gdb) print/x req.mem_.addr
$3 = 0x0
(gdb) next
737           req.mem().len = strtoul(args, &args, 16);
(gdb) print args
$4 = 0x242f872 "fffffffffffffff7;"
(gdb) next
738           parser_assert(';' == *args++);
(gdb) print/x req.mem_.len
$5 = 0xffffffff
(gdb) cont
Continuing.

Breakpoint 1, rr::GdbConnection::query (this=0x2473e50, payload=0x242f862 "Search") at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbConnection.cc:735
735           req.mem().addr = strtoul(args, &args, 16);
(gdb) print args
$6 = 0x242f870 "459081;ffffffffffba6f76;"
(gdb) next
736           parser_assert(';' == *args++);
(gdb) print/x req.mem_.addr
$7 = 0x459081
(gdb) next
737           req.mem().len = strtoul(args, &args, 16);
(gdb) print args
$8 = 0x242f877 "ffffffffffba6f76;"
(gdb) next
738           parser_assert(';' == *args++);
(gdb) print/x req.mem_.len
$9 = 0xffffffff
(gdb) b MemoryRange.h:19
Breakpoint 2 at 0x70b738: file /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h, line 19.
(gdb) cont
Continuing.

Breakpoint 2, rr::MemoryRange::MemoryRange (this=0xbf863850, addr=..., num_bytes=4294967295) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h:19
19          DEBUG_ASSERT(start_ <= end_);
(gdb) print/x start_
$10 = {ptr = 0x459081}
(gdb) print/x end_
$11 = {ptr = 0x459080}
(gdb) cont
Continuing.

Program received signal SIGABRT, Aborted.
0xb7ee7559 in __kernel_vsyscall ()
(gdb) set width 0
(gdb) set pagination off
(gdb) bt
#0  0xb7ee7559 in __kernel_vsyscall ()
#1  0xb78ead12 in __libc_signal_restore_set (set=0xbf8631ec) at ../sysdeps/unix/sysv/linux/internal-signals.h:86
#2  __GI_raise (sig=6) at ../sysdeps/unix/sysv/linux/raise.c:48
#3  0xb78d3306 in __GI_abort () at abort.c:79
#4  0xb78d31d1 in __assert_fail_base (fmt=0xb7a46060 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x9a60ac "start_ <= end_", file=0x9a6064 "/home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h", line=19, function=0x9a6028 "rr::MemoryRange::MemoryRange(rr::remote_ptr<void>, size_t)") at assert.c:92
#5  0xb78e2d39 in __GI___assert_fail (assertion=0x9a60ac "start_ <= end_", file=0x9a6064 "/home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h", line=19, function=0x9a6028 "rr::MemoryRange::MemoryRange(rr::remote_ptr<void>, size_t)") at assert.c:101
#6  0x0070b76e in rr::MemoryRange::MemoryRange (this=0xbf863850, addr=..., num_bytes=4294967295) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/MemoryRange.h:19
#7  0x00791937 in rr::GdbServer::dispatch_debugger_request (this=0xbf865384, session=..., req=..., state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbServer.cc:596
#8  0x00794a1a in rr::GdbServer::process_debugger_requests (this=0xbf865384, state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbServer.cc:1116
#9  0x00795454 in rr::GdbServer::debug_one_step (this=0xbf865384, last_resume_request=...) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbServer.cc:1219
#10 0x007979f1 in rr::GdbServer::serve_replay (this=0xbf865384, flags=...) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/GdbServer.cc:1689
#11 0x0089c09c in rr::replay (trace_dir="/tmp/rr-test-search-mrZWyYEwg/latest-trace", flags=...) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/ReplayCommand.cc:495
#12 0x0089cae7 in rr::ReplayCommand::run (this=0xb4b194 <rr::ReplayCommand::singleton>, args=std::vector of length 0, capacity 8) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/ReplayCommand.cc:616
#13 0x009623f8 in main (argc=6, argv=0xbf865ae4) at /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/main.cc:249
```

```
benutzer@debian:~$ ps aux | grep -i gdb
benutzer  7459  0.2  2.1 180100 65768 pts/1    Sl+  09:54   0:00 gdb -l 10000 -ex set sysroot / -x /proc/7459/fd/4 -n -x /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/test_setup.gdb -ex target extended-remote 127.0.0.1:7460 /tmp/rr-test-search-mrZWyYEwg/search-mrZWyYEwg-0/mmap_hardlink_3_search-mrZWyYEwg
benutzer  7460  0.0  0.1  15656  5944 pts/1    t+   09:54   0:00 bin/rr replay -o-n -x /home/bernhard/data/entwicklung/2020/rr/2020-11-21/rr/src/test/test_setup.gdb /tmp/rr-test-search-mrZWyYEwg/latest-trace

benutzer@debian:~$ gdb -q --pid 7459
Attaching to process 7459
[New LWP 7464]
[New LWP 7465]
[New LWP 7466]
[New LWP 7467]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/i386-linux-gnu/libthread_db.so.1".
0xb7f90559 in __kernel_vsyscall ()
(gdb) set width 0
(gdb) bt
#0  0xb7f90559 in __kernel_vsyscall ()
#1  0xb705365b in __GI___select (timeout=0xbfc9e444, exceptfds=0xbfc9e4cc, writefds=0x0, readfds=0xbfc9e44c, nfds=13) at ../sysdeps/unix/sysv/linux/select.c:41
#2  __GI___select (nfds=13, readfds=0xbfc9e44c, writefds=0x0, exceptfds=0xbfc9e4cc, timeout=0xbfc9e444) at ../sysdeps/unix/sysv/linux/select.c:37
#3  0x006c7798 in gdb_select (n=13, readfds=0xbfc9e44c, writefds=0x0, exceptfds=0xbfc9e4cc, timeout=0xbfc9e444) at ./gdb/posix-hdep.c:31
#4  0x005bfcd8 in interruptible_select (n=13, readfds=0xbfc9e44c, writefds=0x0, exceptfds=0xbfc9e4cc, timeout=0xbfc9e444) at ./gdb/event-top.c:1046
#5  0x0074a285 in ser_base_wait_for (scb=scb@entry=0x151c3c0, timeout=timeout@entry=1) at ./gdb/ser-base.c:239
#6  0x0074a51b in do_ser_base_readchar (scb=0x151c3c0, timeout=9863) at ./gdb/ser-base.c:364
#7  0x0074a8d2 in generic_readchar (scb=0x151c3c0, timeout=10000, do_readchar=0x74a4d0 <do_ser_base_readchar(serial*, int)>) at ./gdb/ser-base.c:443
#8  0x0074a923 in ser_base_readchar (scb=0x151c3c0, timeout=10000) at ./gdb/ser-base.c:470
#9  0x0074d082 in serial_readchar (scb=0x151c3c0, timeout=10000) at ./gdb/serial.c:398
#10 0x00725edc in remote_target::readchar (this=0x15ca470, timeout=10000) at ./gdb/remote.c:9125
#11 0x00727a8e in remote_target::getpkt_or_notif_sane_1 (this=0x15ca470, buf=0x15ca480, forever=0, expecting_notif=0, is_notif=0x0) at ./gdb/remote.c:9683
#12 0x00727db4 in remote_target::getpkt_sane (this=0x15ca470, buf=0x15ca480, forever=0) at ./gdb/remote.c:9790
#13 0x0073674a in remote_target::search_memory (this=0x15ca470, start_addr=4558977, search_space_len=18446744073704992630, pattern=0x147d550 "", pattern_len=9, found_addrp=0xbfc9e858) at ./gdb/remote.c:11228
#14 0x007a4e93 in target_search_memory (start_addr=4558977, search_space_len=18446744073704992630, pattern=0x147d550 "", pattern_len=9, found_addrp=0xbfc9e858) at ./gdb/target.c:2294
#15 0x005cdf8b in find_command (args=0x150eb85 "0,-10L,(char)0,(char)1,(char)2,(char)2,(char)3,(char)0xff,(char)0xfa,(char)0xde,(char)0xbc", from_tty=1) at ./gdb/findcmd.c:241
#16 0x004fc422 in cmd_func (cmd=0x141ad70, args=0x150eb85 "0,-10L,(char)0,(char)1,(char)2,(char)2,(char)3,(char)0xff,(char)0xfa,(char)0xde,(char)0xbc", from_tty=1) at ./gdb/cli/cli-decode.c:2181
#17 0x007c49ae in execute_command (p=<optimized out>, from_tty=1) at ./gdb/top.c:668
#18 0x005bf5a1 in command_handler (command=0x150eb80 "find 0,-10L,(char)0,(char)1,(char)2,(char)2,(char)3,(char)0xff,(char)0xfa,(char)0xde,(char)0xbc") at ./gdb/event-top.c:588
#19 0x005bf9cc in command_line_handler (rl=...) at ./gdb/event-top.c:773
#20 0x005c0050 in gdb_rl_callback_handler (rl=0x15044b0 "find 0,-10L,(char)0,(char)1,(char)2,(char)2,(char)3,(char)0xff,(char)0xfa,(char)0xde,(char)0xbc") at /usr/include/c++/10/bits/unique_ptr.h:172
#21 0xb7f5d9e2 in rl_callback_read_char () from /lib/i386-linux-gnu/libreadline.so.8
#22 0x005be9fa in gdb_rl_callback_read_char_wrapper_noexcept () at ./gdb/event-top.c:177
#23 0x005bfef9 in gdb_rl_callback_read_char_wrapper (client_data=0x13952e0) at ./gdb/event-top.c:193
#24 0x005be6f5 in stdin_event_handler (error=0, client_data=0x13952e0) at ./gdb/event-top.c:516
#25 0x008c188a in handle_file_event (file_ptr=0x1837880, ready_mask=<optimized out>) at ./gdbsupport/event-loop.cc:548
#26 0x008c1e7c in gdb_wait_for_event (block=block@entry=1) at ./gdbsupport/event-loop.cc:673
#27 0x008c2191 in gdb_wait_for_event (block=1) at ./gdbsupport/event-loop.cc:569
#28 gdb_do_one_event () at ./gdbsupport/event-loop.cc:215
#29 0x006738a7 in start_event_loop () at ./gdb/main.c:356
#30 captured_command_loop () at ./gdb/main.c:416
#31 0x00677ad5 in captured_main (data=0xbfc9ecb0) at ./gdb/main.c:1253
#32 gdb_main (args=0xbfc9ecb0) at ./gdb/main.c:1268
#33 0x00466306 in main (argc=13, argv=0xbfc9ed84) at ./gdb/gdb.c:32
(gdb) up
...
(gdb) up
#14 0x007a4e93 in target_search_memory (start_addr=4558977, search_space_len=18446744073704992630, pattern=0x147d550 "", pattern_len=9, found_addrp=0xbfc9e858) at ./gdb/target.c:2294
2294    ./gdb/target.c: Datei oder Verzeichnis nicht gefunden.
(gdb) info local
No locals.
(gdb) print/x search_space_len
$2 = 0xffffffffffba6f76
(gdb) print/x start_addr
$3 = 0x459081
```

</p>
</details>