### PR TITLE
Override pthread_mutex_init() to force PTHREAD_PRIO_NONE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -944,6 +944,7 @@ set(BASIC_TESTS
   pid_ns_reap
   pid_ns_segv
   pidfd
+  pthread_pi_mutex
   pthread_rwlocks
   poll_sig_race
   ppoll

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -143,6 +143,7 @@ static int process_inited;
 RR_HIDDEN struct preload_globals globals;
 RR_HIDDEN char impose_syscall_delay;
 RR_HIDDEN char impose_spurious_desched;
+RR_HIDDEN int (*real_pthread_mutex_init)(void* mutex, const void* attr);
 RR_HIDDEN int (*real_pthread_mutex_lock)(void* mutex);
 RR_HIDDEN int (*real_pthread_mutex_trylock)(void* mutex);
 RR_HIDDEN int (*real_pthread_mutex_timedlock)(void* mutex,
@@ -775,6 +776,7 @@ static void __attribute__((constructor)) init_process(void) {
           "or try using `rr record -n` (slow).");
   }
 
+  real_pthread_mutex_init = dlsym(RTLD_NEXT, "pthread_mutex_init");
   real_pthread_mutex_lock = dlsym(RTLD_NEXT, "pthread_mutex_lock");
   real_pthread_mutex_trylock = dlsym(RTLD_NEXT, "pthread_mutex_trylock");
   real_pthread_mutex_timedlock = dlsym(RTLD_NEXT, "pthread_mutex_timedlock");

--- a/src/preload/syscallbuf.h
+++ b/src/preload/syscallbuf.h
@@ -12,6 +12,7 @@ RR_HIDDEN extern struct preload_globals globals;
 RR_HIDDEN extern char impose_syscall_delay;
 RR_HIDDEN extern char impose_spurious_desched;
 
+RR_HIDDEN extern int (*real_pthread_mutex_init)(void* mutex, const void* attr);
 RR_HIDDEN extern int (*real_pthread_mutex_lock)(void* mutex);
 RR_HIDDEN extern int (*real_pthread_mutex_trylock)(void* mutex);
 RR_HIDDEN extern int (*real_pthread_mutex_timedlock)(void* mutex,

--- a/src/test/pthread_pi_mutex.c
+++ b/src/test/pthread_pi_mutex.c
@@ -1,0 +1,18 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  pthread_mutexattr_t attr;
+  pthread_mutex_t mutex;
+
+  test_assert(pthread_mutexattr_init(&attr) == 0);
+  test_assert(pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0);
+  test_assert(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) == 0);
+  test_assert(pthread_mutex_init(&mutex, &attr) == 0);
+  test_assert(pthread_mutex_destroy(&mutex) == 0);
+  test_assert(pthread_mutexattr_destroy(&attr) == 0);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
When `PTHREAD_PRIO_INHERIT` is set, `pthread_mutex_init()` from glibc performs a test `futex()` call to probe for OS support.  This fails with RR.  Workaround by forcing `PTHREAD_PRIO_NONE`.

Attempts to address #2750