### PR TITLE
Explicitly set offsets in rr_page linker script

### DIFF
--- a/src/preload/rr_page.ld
+++ b/src/preload/rr_page.ld
@@ -21,9 +21,9 @@ SECTIONS
   .gnu.version    : { *(.gnu.version) } :header
   .gnu.version_d  : { *(.gnu.version_d) } :header
   .gnu.version_r  : { *(.gnu.version_r) } :header
-  . = CONSTANT (MAXPAGESIZE);
+  . = 0x1000;
   .text : { *(.text) } :text
-  . = 2*CONSTANT (MAXPAGESIZE);
+  . = 0x2000;
   .replay.text : { *(.replay.text) } :replay
   /DISCARD/ : { *(.debug_* ) }
 }


### PR DESCRIPTION
Apparently the binutils on Ubuntu 18.04 has a very large value of
MAXPAGESIZE. Just hardcode a 4k page instead. This might break on
aarch64, but we're not using the syscallbuf there yet anyway, so
let's revisit that when we get there.

@khuey See if this fixes things for you. Seems to work locally with 18.04.