### PR TITLE
32bit fixes related to 3aaf7920e11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,6 +706,8 @@ if(rr_32BIT AND rr_64BIT)
   set_target_properties(rrpreload_32 PROPERTIES INSTALL_RPATH "\$ORIGIN")
   target_link_libraries(rrpreload_32
     ${CMAKE_DL_LIBS}
+    -Wl,-no-as-needed
+    rrpage_32
   )
 
   add_library(rraudit_32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1591,6 +1591,14 @@ if(BUILD_TESTS)
                                   PROPERTIES COMPILE_FLAGS "-m32 ${RR_TEST_FLAGS}")
     endforeach(test)
 
+    foreach(test ${BASIC_CPP_TESTS})
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/${test}.cc"
+                     "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.cc"
+                     COPYONLY)
+      set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/${test}.cc"
+                                  PROPERTIES COMPILE_FLAGS "-m32 ${RR_TEST_FLAGS}")
+    endforeach(test)
+
     foreach(file x86/cpuid_loop.S x86/util.h)
       configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/${file}"
                      "${CMAKE_CURRENT_BINARY_DIR}/32/${file}"
@@ -1599,9 +1607,13 @@ if(BUILD_TESTS)
                                   PROPERTIES COMPILE_FLAGS "-m32 ${RR_TEST_FLAGS}")
     endforeach(file)
 
-    foreach(test ${BASIC_TESTS} ${TESTS_WITH_PROGRAM})
+    foreach(test ${BASIC_TESTS} ${BASIC_CPP_TESTS} ${TESTS_WITH_PROGRAM})
       get_filename_component(testname ${test} NAME)
-      add_executable(${testname}_32 "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.c")
+      if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.c")
+        add_executable(${testname}_32 "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.c")
+      else()
+        add_executable(${testname}_32 "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.cc")
+      endif()
       target_include_directories(${testname}_32 PRIVATE src/preload)
       post_build_executable(${testname}_32)
       add_dependencies(${testname}_32 Generated)
@@ -1636,7 +1648,7 @@ if(BUILD_TESTS)
               DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr/testsuite/obj/bin)
     endif(INSTALL_TESTSUITE)
 
-    foreach(test ${BASIC_TESTS} ${OTHER_TESTS})
+    foreach(test ${BASIC_TESTS} ${BASIC_CPP_TESTS} ${OTHER_TESTS})
       get_filename_component(testname ${test} NAME)
       add_test(${test}-32
         bash source_dir/src/test/basic_test.run ${testname}_32 "" bin_dir)

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -292,7 +292,11 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
       fname = RRPAGE_LIB_FILENAME;
       break;
     case x86:
+#if defined(__x86_64__)
       fname = RRPAGE_LIB_FILENAME_32;
+#else
+      fname = RRPAGE_LIB_FILENAME;
+#endif
       break;
   }
 

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -649,7 +649,8 @@ inline static int is_proc_stat_file(const char* filename) {
 }
 
 inline static int is_rr_page_lib(const char* filename) {
-  return streq(extract_file_name(filename), "librrpage.so");
+  return streq(extract_file_name(filename), "librrpage.so") ||
+         streq(extract_file_name(filename), "librrpage_32.so");
 }
 
 /**


### PR DESCRIPTION
Hello, tried to run the tests on plain i386 and found most tests did fail.
With the libname in map_rr_page fixed just two tests were then failing,
therefore I wondered if the tests do not run at amd64 as _32 and tried
to change this.
Please note that the change to is_rr_page_lib got not triggered
by any issue, just finding me there just one of the libname.

The test record_replay still fails by hanging infinitely at i386,
but not sure if this is related to rrpage or not.

cc: @Keno