### PR TITLE
Reset CPU affinity state after detaching from rr

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -685,14 +685,6 @@ static void exec_child(vector<string>& args) {
   // Never returns!
 }
 
-static void reset_cpu_affinity() {
-  cpu_set_t mask;
-  memset(&mask, 0xFF, sizeof(mask));
-  sched_setaffinity(0, sizeof(mask), &mask);
-  // Best effort - if we fail, that's not yet fatal (though
-  // we might be running a bit slower)
-}
-
 static void reset_uid_sudo() {
   // Let's change our uids now. We do keep capabilities though, since that's
   // the point of the exercise. The first exec will reset both the keepcaps,
@@ -744,7 +736,6 @@ int RecordCommand::run(vector<string>& args) {
       if (running_under_rr(false)) {
         FATAL() << "Detaching from parent rr did not work";
       }
-      reset_cpu_affinity();
       // Fall through
     } else {
       fprintf(stderr, "rr: cannot run rr recording under rr. Exiting.\n"

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3343,6 +3343,12 @@ static pid_t do_detach_teleport(RecordTask *t)
     AutoRemoteSyscalls remote(new_t, AutoRemoteSyscalls::DISABLE_MEMORY_PARAMS);
     remote.syscall(syscall_number_for_close(new_t->arch()), tracee_fd_number);
   }
+  // Try to reset the scheduler affinity that we enforced upon the task.
+  // XXX: It would be nice to track what affinity the tracee requested and
+  // restore that.
+  cpu_set_t mask;
+  memset(&mask, 0xFF, sizeof(mask));
+  sched_setaffinity(new_t->tid, sizeof(mask), &mask);
   new_t->detach();
   new_t->did_kill();
   delete new_t;


### PR DESCRIPTION
Previously we did this manually in the child rr process, but if we
want to detach things that are not rr, don't make them repeat it.