### PR TITLE
Wait to let the child process settle before force_close_record_session.

### DIFF
--- a/src/test-monitor/test-monitor.cc
+++ b/src/test-monitor/test-monitor.cc
@@ -279,6 +279,7 @@ static void dump_state_and_kill(pid_t child, const char* out_file_name) {
         fclose(gdb_cmd);
       }
     } else {
+      sleep(10);
       force_trace_closure(rr_pid, out);
     }
   }


### PR DESCRIPTION
Found a test failing since 3aaf7920 at i386 because
of "Failed to locate librrpage_32.so".
This got fixed in e0dce08a, with this test still failing,
but now it hangs until test-monitor timeout is reached.

With this additional wait between backtrace and forced close
this test can fail without hitting the timeout.

These gdb calls are done with a three second time between,
this patch increases the time between them:
/usr/bin/gdb -p 12310 -ex set confirm off -ex set height 0 -ex thread apply all bt -ex q
/usr/bin/gdb -p 12310 -ex set confirm off -ex set height 0 -ex p rr::force_close_record_session() -ex q

Without this patch the second gdb command then hangs showing this process tree:
```
  PID  VIRT   RES   SHR S   TIME+  Command
12289 67088 15928 12064 S  0:00.13 │  │           └─ ctest -j1 --verbose --tests-regex ^record_replay-no-syscallbuf$
12290  4152  3016  2696 S  0:00.00 │  │              └─ /bin/bash source_dir/src/test/record_replay.run record_replay -n bin_dir 120
12309  5624  2788  2592 S  0:00.01 │  │                 └─ test-monitor 120 record.err rr --suppress-environment-warnings --check-cached-mmaps --fatal-errors --resource-path=...
12333  2564  1696  1628 S  0:00.00 │  │                    ├─ sh -c gdb -p 12310 -ex 'set confirm off' -ex 'set height 0' -ex 'p rr::force_close_record_session()' -ex q </dev/null 2>&1
12334  196M 95588 34952 S  0:01.94 │  │                    │  └─ /usr/bin/gdb.real -p 12310 -ex set confirm off -ex set height 0 -ex p rr::force_close_record_session() -ex q
12310 63928 18252  7160 S  1:53.35 │  │                    └─ rr --suppress-environment-warnings --check-cached-mmaps --fatal-errors --resource-path=...
12318     0     0     0 Z  0:06.77 │  │                       └─ rr
```