### PR TITLE
Make librrpreload lib harmless after detach

### DIFF
--- a/src/preload/rr_page.S
+++ b/src/preload/rr_page.S
@@ -57,6 +57,10 @@
 
 .section .text
 .align 0x1000
+
+.global rr_page_start
+rr_page_start:
+
 #define STARTPROC(name) #name:; .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
 #include "rr_page_instructions.S"

--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -18,6 +18,7 @@ stopped_locations = {
              '(0x[0-9a-f]+ in )?_traced_raw_syscall',
              '0x[0-9a-f]+ in \?\?',
              '(0x[0-9a-f]+ in )?syscall_traced',
+             '(0x[0-9a-f]+ in )?rr_page_start',
              '(0x[0-9a-f]+ in )?__lll_lock_wait',
              '(0x[0-9a-f]+ in )?pthread_barrier_wait',
              '(0x[0-9a-f]+ in )?futex_wait'],
@@ -25,7 +26,8 @@ stopped_locations = {
                     '(0x[0-9a-f]+ in )?pthread_barrier_wait',
                     '(0x[0-9a-f]+ in )?futex_wait',
                     '0x0*70000002 in \?\?',
-                    '(0x[0-9a-f]+ in )?syscall_traced'],
+                    '(0x[0-9a-f]+ in )?syscall_traced',
+                    '(0x[0-9a-f]+ in )?rr_page_start'],
     'aarch64': ['(0x[0-9a-f]+ in )?futex_wait']
 }
 

--- a/src/test/step_thread.py
+++ b/src/test/step_thread.py
@@ -59,6 +59,7 @@ stopped_locations = {
     'i386': ['(0x[0-9a-f]+ in )?__kernel_vsyscall',
              '(0x[0-9a-f]+ in )?_traced_raw_syscall',
               '0x[0-9a-f]+ in \?\?',
+             '(0x[0-9a-f]+ in )?rr_page_start',
              '(0x[0-9a-f]+ in )?syscall_traced',
              '(0x[0-9a-f]+ in )?__lll_lock_wait',
              '(0x[0-9a-f]+ in )?pthread_barrier_wait',
@@ -67,7 +68,8 @@ stopped_locations = {
                     '(0x[0-9a-f]+ in )?pthread_barrier_wait',
                     '(0x[0-9a-f]+ in )?futex_wait',
                     '0x0*70000002 in \?\?',
-                    '(0x[0-9a-f]+ in )?syscall_traced'
+                    '(0x[0-9a-f]+ in )?syscall_traced',
+                    '(0x[0-9a-f]+ in )?rr_page_start'
                     ],
     'aarch64': ['(0x[0-9a-f]+ in )?futex_wait'],
 }


### PR DESCRIPTION
After detaching, librrpreload is still in LD_PRELOAD. However,
librrpreload does not like being loaded when rr is not listening
and will crash attempting to execute a system call from the rr
page. Of course it is possible to sanitize LD_PRELOAD, but that
seems a bit heavy handed to require every possible user of detach
to do. Instead, this makes librrpreload a bit more careful about
checking for the presence of rr. In the happy path, where the
load address of librrpage matches RR_PAGE_START, this only
introduces an extra pointer comparison to avoid jumping to
an unmapped address. Otherwise, we fall back to a syscall to
determine if the rr page was mapped. Of course, there is still
the case where librrpage was accidentally mapped at the correct
address, but rr isn't actually listening. To distinguish that
case, we check for the presence of the thread locals page.