### PR TITLE
Add systemd service to automatically run `zen_workaround.py`

### DIFF
--- a/scripts/zen_workaround.service
+++ b/scripts/zen_workaround.service
@@ -1,0 +1,28 @@
+# systemd service for AMD Zen `rr` workaround
+# See https://github.com/rr-debugger/rr/wiki/Zen for more details
+# To install:
+#   - Save this file as `/etc/systemd/system/zen_workaround.service`
+#   - run `sudo systemctl enable zen_workaround` to enable on startup
+#   - run `sudo systemctl start zen_workaround` to manually start it immediately
+#   - run `systemctl status zen_workaround` to ensure that it completed successfully on your hardware
+#
+# This script will auto-download the `zen_workaround.py` script if it doesn't already exist,
+# and stores the script in `/tmp/zen_workaround` by default.  Feel free to modify this script
+# to look in a different, more persistent folder if you don't want the auto-downloading.
+[Unit]
+Description           = Startup script for rr zen workaround
+
+[Service]
+Environment           =DIR='/tmp/zen_workaround' URL='https://github.com/rr-debugger/rr/raw/master/scripts/zen_workaround.py'
+# Step to download `zen_workaround.py` if it doesn't already exist
+ExecStartPre          =-/bin/sh -c "mkdir -p ${DIR}; [ ! -f ${DIR}/zen_workaround.py ] && curl -L ${URL} -o ${DIR}/zen_workaround.py && chmod +x ${DIR}/zen_workaround.py"
+
+# Step to actually run `zen_workaround.py`.
+ExecStart             =+/bin/sh -c "${DIR}/zen_workaround.py"
+
+# Only run this once, report it as "(active)" even after we've exited.
+Type                  = oneshot
+RemainAfterExit       = yes
+
+[Install]
+WantedBy             = default.target

--- a/scripts/zen_workaround.service
+++ b/scripts/zen_workaround.service
@@ -2,23 +2,21 @@
 # See https://github.com/rr-debugger/rr/wiki/Zen for more details
 # To install:
 #   - Save this file as `/etc/systemd/system/zen_workaround.service`
+#   - Download the `zen_workaround.py` script to a secure location, example:
+#     - sudo mkdir -p /usr/share/zen_workaround
+#     - cd /usr/share/zen_workaround
+#     - curl -L https://github.com/rr-debugger/rr/raw/master/scripts/zen_workaround.py | sudo tee -a zen_workaround.py >/dev/null
+#     - chmod +x ./zen_workaround.py
 #   - run `sudo systemctl enable zen_workaround` to enable on startup
 #   - run `sudo systemctl start zen_workaround` to manually start it immediately
 #   - run `systemctl status zen_workaround` to ensure that it completed successfully on your hardware
-#
-# This script will auto-download the `zen_workaround.py` script if it doesn't already exist,
-# and stores the script in `/tmp/zen_workaround` by default.  Feel free to modify this script
-# to look in a different, more persistent folder if you don't want the auto-downloading.
+
 [Unit]
 Description           = Startup script for rr zen workaround
 
 [Service]
-Environment           =DIR='/tmp/zen_workaround' URL='https://github.com/rr-debugger/rr/raw/master/scripts/zen_workaround.py'
-# Step to download `zen_workaround.py` if it doesn't already exist
-ExecStartPre          =-/bin/sh -c "mkdir -p ${DIR}; [ ! -f ${DIR}/zen_workaround.py ] && curl -L ${URL} -o ${DIR}/zen_workaround.py && chmod +x ${DIR}/zen_workaround.py"
-
 # Step to actually run `zen_workaround.py`.
-ExecStart             =+/bin/sh -c "${DIR}/zen_workaround.py"
+ExecStart             =+/usr/share/zen_workaround/zen_workaround.py
 
 # Only run this once, report it as "(active)" even after we've exited.
 Type                  = oneshot


### PR DESCRIPTION
For users that want to ensure that `zen_workaround.py` is run on startup, this script will automatically do so, downloading the `zen_workaround.py` script if it does not already exist.  Users are encouraged to modify the script to their needs, but the default configuration should provide a good experience for most use cases.