### PR TITLE
RFC: Pretend to the tracee that librrpage is the vdso

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,9 @@ set_target_properties(rrpage PROPERTIES LINK_DEPENDS ${CMAKE_SOURCE_DIR}/src/pre
 # CMake seems to have trouble generating the link line without this
 set_target_properties(rrpage PROPERTIES LINKER_LANGUAGE C)
 
+add_custom_command(TARGET rrpage POST_BUILD
+                   COMMAND ${CMAKE_SOURCE_DIR}/src/preload/tweak_librrpage.py $<TARGET_FILE:rrpage>)
+
 # Order matters here! syscall_hook.S must be immediately before syscallbuf.c,
 # raw_syscall.S must be before overrides.c, which must be last.
 set(PRELOAD_FILES
@@ -686,6 +689,10 @@ if(rr_32BIT AND rr_64BIT)
   set_target_properties(rrpage_32 PROPERTIES LINK_FLAGS "-m32 -Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -nostartfiles -nostdlib ${LINKER_FLAGS}")
   set_target_properties(rrpage_32 PROPERTIES LINK_DEPENDS ${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld)
   set_target_properties(rrpage_32 PROPERTIES LINKER_LANGUAGE C)
+
+  add_custom_command(TARGET rrpage_32 POST_BUILD
+                    COMMAND ${CMAKE_SOURCE_DIR}/src/preload/tweak_librrpage.py $<TARGET_FILE:rrpage_32>)
+
 
   add_library(rrpreload_32)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ set(RR_PAGE_FILES
 set(RR_PAGE_SOURCE_FILES
   ${RR_PAGE_FILES}
   rr_page_instructions.S
+  rr_vdso.S
   rr_page.ld
 )
 add_library(rrpage)
@@ -595,8 +596,6 @@ endif()
 
 target_link_libraries(rrpreload
   ${CMAKE_DL_LIBS}
-  -Wl,-no-as-needed
-  rrpage
 )
 
 add_executable(rr_exec_stub src/exec_stub.c)
@@ -706,8 +705,6 @@ if(rr_32BIT AND rr_64BIT)
   set_target_properties(rrpreload_32 PROPERTIES INSTALL_RPATH "\$ORIGIN")
   target_link_libraries(rrpreload_32
     ${CMAKE_DL_LIBS}
-    -Wl,-no-as-needed
-    rrpage_32
   )
 
   add_library(rraudit_32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,7 +342,7 @@ foreach(file ${RR_PAGE_FILES})
   set_source_files_properties("${CMAKE_SOURCE_DIR}/src/preload/${file}"
                               PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
 endforeach(file)
-set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -nostartfiles -nostdlib ${LINKER_FLAGS}")
+set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -nostartfiles -nostdlib -Wl,-z,max-page-size=0x1000 ${LINKER_FLAGS}")
 set_target_properties(rrpage PROPERTIES LINK_DEPENDS ${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld)
 # CMake seems to have trouble generating the link line without this
 set_target_properties(rrpage PROPERTIES LINKER_LANGUAGE C)

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -305,7 +305,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
     FATAL() << "Failed to locate " << fname;
   }
   path += fname;
-  size_t offset_pages = t->session().is_recording() ? 2 : 3;
+  size_t offset_pages = t->session().is_recording() ? 3 : 4;
 
   {
     ScopedFd page(path.c_str(), O_RDONLY);
@@ -313,7 +313,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
     long child_fd = remote.send_fd(page.get());
     ASSERT(t, child_fd >= 0);
     if (t->session().is_recording()) {
-      remote.infallible_mmap_syscall(rr_page_start() - 2*rr_page_size(), 2*rr_page_size(), prot, flags,
+      remote.infallible_mmap_syscall(rr_page_start() - 3*rr_page_size(), 3*rr_page_size(), prot, flags,
                                     child_fd, 0);
     }
     remote.infallible_mmap_syscall(rr_page_start(), rr_page_size(), prot, flags,
@@ -329,7 +329,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
         fstat.st_dev, fstat.st_ino);
     mapping_flags_of(rr_page_start()) = Mapping::IS_RR_PAGE;
     if (t->session().is_recording()) {
-      map(t, rr_page_start() - 2*rr_page_size(), 2*rr_page_size(), prot, flags,
+      map(t, rr_page_start() - 3*rr_page_size(), 3*rr_page_size(), prot, flags,
           0, file_name,
           fstat.st_dev, fstat.st_ino);
     }

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -826,6 +826,12 @@ public:
   int stopping_breakpoint_table_entry_size() { return stopping_breakpoint_table_entry_size_; }
 
   // Also sets brk_ptr.
+  enum {
+    RRVDSO_PAGE_OFFSET = 2,
+    RRPAGE_RECORD_PAGE_OFFSET = 3,
+    RRPAGE_REPLAY_PAGE_OFFSET = 4
+  };
+
   void map_rr_page(AutoRemoteSyscalls& remote);
   void unmap_all_but_rr_page(AutoRemoteSyscalls& remote);
 

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1834,12 +1834,33 @@ static ScopedFd generate_fake_proc_maps(Task* t) {
   }
   FILE* f = fdopen(fd, "w");
 
+
   int addr_min_width = word_size(t->arch()) == 8 ? 10 : 8;
-  for (auto& m : t->vm()->maps()) {
+  for (AddressSpace::Maps::iterator it = t->vm()->maps().begin();
+       it != t->vm()->maps().end(); ++it) {
+    // If this is the mapping just before the rr page and it's still librrpage,
+    // merge this mapping with the subsequent one. We'd like gdb to treat
+    // librrpage as the vdso, but it'll only do so if the entire vdso is one
+    // mapping.
+    auto m = *it;
+    uintptr_t map_end = (long long)m.recorded_map.end().as_int();
+    if (m.recorded_map.end() == t->vm()->rr_page_start()) {
+      auto it2 = it;
+      if (++it2 != t->vm()->maps().end()) {
+        auto m2 = *it2;
+        if (m2.flags & AddressSpace::Mapping::IS_RR_PAGE) {
+          // Extend this mapping
+          map_end += t->vm()->rr_page_size();
+          // Skip the rr page
+          ++it;
+        }
+      }
+    }
+
     int len =
         fprintf(f, "%0*llx-%0*llx %s%s%s%s %08llx %02x:%02x %lld",
                 addr_min_width, (long long)m.recorded_map.start().as_int(),
-                addr_min_width, (long long)m.recorded_map.end().as_int(),
+                addr_min_width, (long long)map_end,
                 (m.recorded_map.prot() & PROT_READ) ? "r" : "-",
                 (m.recorded_map.prot() & PROT_WRITE) ? "w" : "-",
                 (m.recorded_map.prot() & PROT_EXEC) ? "x" : "-",

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -628,7 +628,7 @@ void patch_after_exec_arch<X86Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 2*RR_PAGE_SIZE);
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
     patch_auxv_vdso(t, X86Arch::RR_AT_SYSINFO, RR_PAGE_ADDR - 1*RR_PAGE_SIZE);
   }
 }
@@ -665,7 +665,7 @@ void patch_after_exec_arch<X64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 2*RR_PAGE_SIZE);
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
   }
 }
 
@@ -684,7 +684,7 @@ void patch_after_exec_arch<ARM64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR + RR_PAGE_SIZE);
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
   }
 }
 

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -628,8 +628,10 @@ void patch_after_exec_arch<X86Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
-    patch_auxv_vdso(t, X86Arch::RR_AT_SYSINFO, RR_PAGE_ADDR - 1*RR_PAGE_SIZE);
+    size_t librrpage_base = RR_PAGE_ADDR - AddressSpace::RRPAGE_RECORD_PAGE_OFFSET*RR_PAGE_SIZE;
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, librrpage_base);
+    patch_auxv_vdso(t, X86Arch::RR_AT_SYSINFO, librrpage_base +
+      AddressSpace::RRVDSO_PAGE_OFFSET*RR_PAGE_SIZE);
   }
 }
 
@@ -665,7 +667,8 @@ void patch_after_exec_arch<X64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
+    size_t librrpage_base = RR_PAGE_ADDR - AddressSpace::RRPAGE_RECORD_PAGE_OFFSET*RR_PAGE_SIZE;
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, librrpage_base);
   }
 }
 
@@ -684,7 +687,8 @@ void patch_after_exec_arch<ARM64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   if (!t->vm()->has_vdso()) {
     patch_auxv_vdso(t, AT_SYSINFO_EHDR, AT_IGNORE);
   } else {
-    patch_auxv_vdso(t, AT_SYSINFO_EHDR, RR_PAGE_ADDR - 3*RR_PAGE_SIZE);
+    size_t librrpage_base = RR_PAGE_ADDR - AddressSpace::RRPAGE_RECORD_PAGE_OFFSET*RR_PAGE_SIZE;
+    patch_auxv_vdso(t, AT_SYSINFO_EHDR, librrpage_base);
   }
 }
 

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -107,12 +107,6 @@ public:
   bool is_jump_stub_instruction(remote_code_ptr p);
 
   /**
-   * Syscalls in the VDSO that we patched to be direct syscalls. These can
-   * always be safely patched to jump to the syscallbuf.
-   */
-  std::unordered_set<remote_code_ptr> patched_vdso_syscalls;
-
-  /**
    * Addresses/lengths of syscallbuf stubs.
    */
   std::map<remote_ptr<uint8_t>, size_t> syscallbuf_stubs;

--- a/src/ProcMemMonitor.cc
+++ b/src/ProcMemMonitor.cc
@@ -40,7 +40,7 @@ void ProcMemMonitor::did_write(Task* t, const std::vector<Range>& ranges,
 
   // In prior versions of rr, we recorded this directly into the trace.
   // If so, there's nothing to do here.
-  if (t->session().is_replaying() && t->session().as_replay()->explicit_proc_mem()) {
+  if (t->session().is_replaying() && t->session().as_replay()->has_trace_quirk(TraceReader::ExplicitProcMem)) {
     return;
   }
 

--- a/src/RRPageMonitor.h
+++ b/src/RRPageMonitor.h
@@ -4,6 +4,7 @@
 #define RR_RR_PAGE_MONITOR_H_
 
 #include "FileMonitor.h"
+#include "TraceStream.h"
 
 namespace rr {
 
@@ -18,6 +19,9 @@ public:
 
   virtual Type type() override { return RRPage; }
 };
+
+static_assert(TraceReader::SpecialLibRRpage != 0,
+  "Remember to delete this if support for the quirk is ever dropped");
 
 } // namespace rr
 

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -326,10 +326,9 @@ void RecordSession::handle_seccomp_traced_syscall(RecordTask* t,
 
     // Now that we're in a sane state, ask the Moneypatcher to try and patch
     // that.
-    if (!t->vm()->monkeypatcher().try_patch_vsyscall_caller(t, ret_addr)) {
-      FATAL() << "The tracee issues a vsyscall, but we failed to moneypatch the\n"
-              << "caller. Recording will not succeed. Exiting.";
-    }
+    bool patch_ok = t->vm()->monkeypatcher().try_patch_vsyscall_caller(t, ret_addr);
+    ASSERT(t, patch_ok) << "The tracee issues a vsyscall, but we failed to moneypatch the\n"
+            << "caller. Recording will not succeed. Exiting.";
 
     // Reset to the start of the region and continue
     regs = t->regs();

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -9,6 +9,7 @@
 #include "AddressSpace.h"
 #include "CPUIDBugDetector.h"
 #include "DiversionSession.h"
+#include "TraceStream.h"
 #include "EmuFs.h"
 #include "Session.h"
 #include "Task.h"
@@ -314,7 +315,7 @@ public:
 
   virtual int cpu_binding(TraceStream& trace) const override;
 
-  bool explicit_proc_mem() { return trace_in.explicit_proc_mem(); }
+  bool has_trace_quirk(TraceReader::TraceQuirks quirk) { return trace_in.quirks() & quirk; }
 
 private:
   ReplaySession(const std::string& dir, const Flags& flags);

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -429,8 +429,15 @@ public:
 
   SupportedArch arch() const { return arch_; }
 
-  // Whether the /proc/<pid>/mem calls were explicitly recorded in this trace
-  bool explicit_proc_mem() const { return explicit_proc_mem_; }
+  enum TraceQuirks {
+    // Whether the /proc/<pid>/mem calls were explicitly recorded in this trace
+    ExplicitProcMem = 0x1,
+    // Whether this trace requires the special librrpage replay behavior
+    // added in 3aaf792 and later removed.
+    SpecialLibRRpage = 0x2
+  };
+
+  int quirks() const { return quirks_; }
 
 private:
   CompressedReader& reader(Substream s) { return *readers[s]; }
@@ -448,7 +455,7 @@ private:
   bool clear_fip_fdp_;
   int rrcall_base_;
   SupportedArch arch_;
-  bool explicit_proc_mem_;
+  int quirks_;
 };
 
 extern std::string trace_save_dir();

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -80,52 +80,9 @@ class AssemblyTemplate(object):
         return bytes
 
 templates = {
-    'X86SysenterVsyscallImplementation': AssemblyTemplate(
-        RawBytes(0x51),         # push %ecx
-        RawBytes(0x52),         # push %edx
-        RawBytes(0x55),         # push %ebp
-        RawBytes(0x89, 0xe5),   # mov %esp,%ebp
-        RawBytes(0x0f, 0x34),   # sysenter
-    ),
-    'X86SysenterVsyscallImplementationAMD': AssemblyTemplate(
-        RawBytes(0x51),         # push %ecx
-        RawBytes(0x52),         # push %edx
-        RawBytes(0x55),         # push %ebp
-        RawBytes(0x89, 0xcd),   # mov %ecx,%ebp
-        RawBytes(0x0f, 0x05),   # syscall
-        RawBytes(0xcd, 0x80),   # int $0x80
-    ),
-    'X86SysenterVsyscallUseInt80': AssemblyTemplate(
-        RawBytes(0xcd, 0x80),   # int $0x80
-        RawBytes(0xc3),         # ret
-    ),
     'X86SysenterVsyscallSyscallHook': AssemblyTemplate(
         RawBytes(0xe9),         # jmp $syscall_hook_trampoline
         Field('syscall_hook_trampoline', 4),
-    ),
-    'X86VsyscallMonkeypatch': AssemblyTemplate(
-        RawBytes(0xb8),         # mov $syscall_number,%eax
-        Field('syscall_number', 4),
-        RawBytes(0xe8),         # call $X86VsyscallMonkeypatchShared
-        Field('vsyscall_monkeypatch_shared', 4),
-        RawBytes(0xc3),
-    ),
-    'X86VsyscallMonkeypatchShared': AssemblyTemplate(
-        # __vdso functions use the C calling convention, so
-        # we have to set up the syscall parameters here.
-        # No x86-32 __vdso functions take more than two parameters.
-        RawBytes(0x53),         # push %ebx
-        RawBytes(0x8b, 0x5c, 0x24, 0x0c), # mov 12(%esp),%ebx
-        RawBytes(0x8b, 0x4c, 0x24, 0x10), # mov 16(%esp),%ecx
-        RawBytes(0xcd, 0x80),   # int $0x80
-        # pad with NOPs to make room to dynamically patch the syscall
-        # with a call to the preload library, once syscall buffering
-        # has been initialized.
-        RawBytes(0x90),         # nop
-        RawBytes(0x90),         # nop
-        RawBytes(0x90),         # nop
-        RawBytes(0x5b),         # pop %ebx
-        RawBytes(0xc3),         # ret
     ),
     'X86SyscallStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
@@ -149,18 +106,6 @@ templates = {
     'X64JumpMonkeypatch': AssemblyTemplate(
         RawBytes(0xe9),         # jmp $relative_addr
         Field('relative_addr', 4),
-    ),
-    'X64VsyscallMonkeypatch': AssemblyTemplate(
-        RawBytes(0xb8),         # mov $syscall_number,%eax
-        Field('syscall_number', 4),
-        RawBytes(0x0f, 0x05),   # syscall
-        # pad with NOPs to make room to dynamically patch the syscall
-        # with a call to the preload library, once syscall buffering
-        # has been initialized.
-        RawBytes(0x90),         # nop
-        RawBytes(0x90),         # nop
-        RawBytes(0x90),         # nop
-        RawBytes(0xc3),         # ret
     ),
     'X64SyscallStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
@@ -219,13 +164,6 @@ templates = {
         RawBytes(0x48, 0xc7, 0xc0), # movq $[syscallno], %rax
         Field('syscallno', 4),
         RawBytes(0x0f, 0x05) # syscall
-    ),
-    'ARM64VdsoMonkeypatch': AssemblyTemplate(
-        ShiftField(
-            RawBytes(0x08, 0x00, 0x80, 0xd2),   # movz x8, #0
-            5, 'syscall_number', 2),
-        RawBytes(0x01, 0x00, 0x00, 0xd4),   # svc #0
-        RawBytes(0xc0, 0x03, 0x5f, 0xd6),   # ret
     ),
 }
 

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1902,6 +1902,7 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
   // PTRACE_ARCH_PRCTL does not exist on x86
   static const int PTRACE_SYSEMU = Arch64::PTRACE_SYSEMU;
   static const int PTRACE_SYSEMU_SINGLESTEP = Arch64::PTRACE_SYSEMU_SINGLESTEP;
+  static const int RR_AT_SYSINFO = 32;
 
   struct user_regs_struct {
     int32_t ebx;

--- a/src/preload/rr_page.S
+++ b/src/preload/rr_page.S
@@ -55,13 +55,19 @@
     ret
 #endif
 
-.section .text
+.section .vdso.text, "a", @progbits
+.align 0x1000
+
+#include "rr_vdso.S"
+
+.section .record.text, "a", @progbits
 .align 0x1000
 
 .global rr_page_start
 rr_page_start:
 
 #define STARTPROC(name) #name:; .cfi_startproc
+#define STARTPROC_GLOBAL(name) .global #name; #name:; .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
 #include "rr_page_instructions.S"
 

--- a/src/preload/rr_page.S
+++ b/src/preload/rr_page.S
@@ -4,21 +4,21 @@
 // contains syscall instructions at known ip values. These values must be fixed
 // for all processes in a given rr session, since rr cannot adjust the seccomp
 // filter that makes use of these values once it has been set. `librrpage.so`
-// contains this page, and rr will attmept to have the dynamic linker map it
-// such that the dynamic-linker-loaded copy of the rr page will be at the same
-// address as the copy unconditionally loaded by rr such that debuggers and
-// internal unwinders don't get confused by the presence of a random code page.
-// Should the mapping not succeed for whatever reason, rr will still use its
-// internal copy of the rr page.
+// contains this page, and rr will map it in place at process start and inform
+// the process about it by passing it as the address of the vdso. This way
+// the tracee's unwinders, as well as GDB will load the librrpage.so symbols and
+// unwind info and function correctly if execution is stopped in these locations.
 //
-// The `librrpage.so` file is made up of three pages:
-// 1: The ELF header, symbol/string table, and eh_frame sections
-// 2: The rr page to be used during recording
-// 3: The rr page to be used during replay
+// The `librrpage.so` file is made up of five pages:
+// 1: The ELF header, dynamic symbol/string table, and eh_frame sections
+// 2: The ELF section, symbol string tables (moved here in a post-processing step)
+// 3: A fake vdso that rr will ask the kernel to treat as the real vdso
+// 4: The rr page to be used during recording
+// 5: The rr page to be used during replay
 //
-// librrpage.so itself is set up to request the dynamic linker to only map the
-// first two pages. During replay, rr will map the third page in place of the
-// second. Note however, that we only have one copy of the eh_frame and symbol
+// During record, rr will map the first four pages of librrpage.so only.
+// During replay, rr will replace the record page by the replay page.
+// Note however, that we only have one copy of the eh_frame and symbol
 // information - we expect all offsets and unwind instructions to match between
 // the record and replay versions (anything else would likely result in
 // divergences anyway)
@@ -54,6 +54,10 @@
     brk #0; \
     ret
 #endif
+
+.section .sh_placeholder, "a"
+.align 0x1000
+.fill 0x1000, 1, 0xff
 
 .section .vdso.text, "a", @progbits
 .align 0x1000

--- a/src/preload/rr_page.ld
+++ b/src/preload/rr_page.ld
@@ -9,7 +9,7 @@ PHDRS
 }
 SECTIONS
 {
-  . = SIZEOF_HEADERS;
+  . = 0x6fffe000 + SIZEOF_HEADERS;
   .eh_frame_hdr   : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } :header :eh_frame
   .eh_frame       : { KEEP (*(.eh_frame)) *(.eh_frame.*) } :header :eh_frame
   .note.gnu.build-id  : { *(.note.gnu.build-id) } :header :note
@@ -21,9 +21,10 @@ SECTIONS
   .gnu.version    : { *(.gnu.version) } :header
   .gnu.version_d  : { *(.gnu.version_d) } :header
   .gnu.version_r  : { *(.gnu.version_r) } :header
-  . = 0x1000;
-  .text : { *(.text) } :text
-  . = 0x2000;
+  .vdso.text : { *(.vdso.text) } : text
+  . = 0x70000000;
+  .record.text : { *(.record.text) } :text
+  . = 0x70001000;
   .replay.text : { *(.replay.text) } :replay
   /DISCARD/ : { *(.debug_* ) }
 }

--- a/src/preload/rr_page.ld
+++ b/src/preload/rr_page.ld
@@ -9,7 +9,7 @@ PHDRS
 }
 SECTIONS
 {
-  . = 0x6fffe000 + SIZEOF_HEADERS;
+  . = 0x70000000 - 0x3000 + SIZEOF_HEADERS;
   .eh_frame_hdr   : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } :header :eh_frame
   .eh_frame       : { KEEP (*(.eh_frame)) *(.eh_frame.*) } :header :eh_frame
   .note.gnu.build-id  : { *(.note.gnu.build-id) } :header :note
@@ -21,7 +21,15 @@ SECTIONS
   .gnu.version    : { *(.gnu.version) } :header
   .gnu.version_d  : { *(.gnu.version_d) } :header
   .gnu.version_r  : { *(.gnu.version_r) } :header
-  .vdso.text : { *(.vdso.text) } : text
+  . = 0x70000000 - 0x2000;
+  /* This space in .sh_placeholder is reserved for the section table
+     symtab/strtab, which ordinarily go after the text sections,
+     but we need to have before the rr page.
+     We move it there in a post-processing step, since linker
+     scripts can't specify these locations for legacy reasons */
+  .sh_placeholder : { *(.sh_placeholder) } :header
+  . = 0x70000000 - 0x1000;
+  .vdso.text : { *(.vdso.text) } :text
   . = 0x70000000;
   .record.text : { *(.record.text) } :text
   . = 0x70001000;

--- a/src/preload/rr_vdso.S
+++ b/src/preload/rr_vdso.S
@@ -1,0 +1,83 @@
+#define STARTPROC_GLOBAL(name) .global #name; .type #name, @function; \
+ #name:; .cfi_startproc
+#define CFI_ENDPROC .cfi_endproc
+
+#if defined(__x86_64__)
+
+#define SYSCALL(which) \
+    movq $which, %rax;  \
+    syscall; \
+    nop; \
+    nop; \
+    nop; \
+    retq
+
+STARTPROC_GLOBAL(__vdso_clock_getres)
+SYSCALL(229)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_getcpu)
+SYSCALL(309)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_time)
+SYSCALL(201)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_clock_gettime)
+SYSCALL(228)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_gettimeofday)
+SYSCALL(96)
+CFI_ENDPROC
+
+#elif defined(__i386__)
+
+// __vdso functions use the C calling convention, so
+// we have to set up the syscall parameters here.
+// No x86-32 __vdso functions take more than two parameters.
+#define SYSCALL(which) \
+    push %ebx; \
+    .cfi_adjust_cfa_offset 4; \
+    .cfi_rel_offset %ebx, 0; \
+    mov 8(%esp),%ebx; \
+    mov 12(%esp),%ecx; \
+    mov $which, %eax;  \
+    int $0x80; \
+    nop; \
+    nop; \
+    nop; \
+    pop %ebx; \
+    .cfi_adjust_cfa_offset -4; \
+    .cfi_restore %ebx; \
+    ret
+
+// N.B.: We depend on this being the first symbol in the vdso page.
+STARTPROC_GLOBAL(__kernel_vsyscall)
+int $0x80
+nop
+nop
+nop
+ret
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_clock_getres)
+SYSCALL(266)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_time)
+SYSCALL(13)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_clock_gettime)
+SYSCALL(265)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_clock_gettime64)
+SYSCALL(403)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__vdso_gettimeofday)
+SYSCALL(78)
+CFI_ENDPROC
+
+#else
+
+#error "VDSO Hooks not defined for this platform"
+
+#endif
+
+#undef STARTPROC_GLOBAL
+#undef CFI_ENDPROC

--- a/src/preload/rr_vdso.S
+++ b/src/preload/rr_vdso.S
@@ -2,6 +2,10 @@
  #name:; .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
 
+// Older libs don't use the __vdso symbols, but try to look for the syscall
+// names directly. Follow the kernel vdso and make them weak aliases
+#define WEAK_ALIAS(sym, target) .weak sym; .set sym, target
+
 #if defined(__x86_64__)
 
 #define SYSCALL(which) \
@@ -27,6 +31,12 @@ CFI_ENDPROC
 STARTPROC_GLOBAL(__vdso_gettimeofday)
 SYSCALL(96)
 CFI_ENDPROC
+
+WEAK_ALIAS(clock_getres, __vdso_clock_getres)
+WEAK_ALIAS(getcpu, __vdso_getcpu)
+WEAK_ALIAS(time, __vdso_time)
+WEAK_ALIAS(clock_gettime, __vdso_clock_gettime)
+WEAK_ALIAS(gettimeofday,__vdso_gettimeofday)
 
 #elif defined(__i386__)
 
@@ -72,6 +82,12 @@ CFI_ENDPROC
 STARTPROC_GLOBAL(__vdso_gettimeofday)
 SYSCALL(78)
 CFI_ENDPROC
+
+WEAK_ALIAS(clock_getres, __vdso_clock_getres)
+WEAK_ALIAS(time, __vdso_time)
+WEAK_ALIAS(clock_gettime, __vdso_clock_gettime)
+WEAK_ALIAS(clock_gettime64, __vdso_clock_gettime64)
+WEAK_ALIAS(gettimeofday,__vdso_gettimeofday)
 
 #else
 

--- a/src/preload/tweak_librrpage.py
+++ b/src/preload/tweak_librrpage.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# This script adjusts librrpage.so to have the final layout that we want
+# See rr_page.S for a description of the expected final layout of librrpage
+
+import struct
+import os
+import sys
+
+# How much space (and where) we reserved in the middle of the file for
+# the section header
+new_table_offset = 0x1000
+reserved_size = 0x1000
+
+# Force this alignment for any sections
+sect_align = 0x10
+
+# some constants
+ELFCLASS32 = 1
+ELFCLASS64 = 2
+
+def read_byte(f):
+	return struct.unpack('b', f.read(1))[0]
+
+def read_uint64(f):
+	return struct.unpack('Q', f.read(8))[0]
+
+def write_uint64(f, v):
+	return f.write(struct.pack('Q', v))
+
+def read_uint32(f):
+	return struct.unpack('I', f.read(4))[0]
+
+def write_uint32(f, v):
+	return f.write(struct.pack('I', v))
+
+def read_uint16(f):
+	return struct.unpack('H', f.read(2))[0]
+
+def seek_nth_section_sh_offset(f, shtable, e_shentsize, n, offset):
+	f.seek(shtable + n*e_shentsize + offset)
+
+def read_uptr(is64, f):
+	if is64:
+		return read_uint64(f)
+	else:
+		return read_uint32(f)
+
+def write_uptr(is64, f, v):
+	if is64:
+		return write_uint64(f, v)
+	else:
+		return write_uint32(f, v)
+
+with open(sys.argv[1], 'rb+') as f:
+	assert f.read(4) == b'\x7fELF'
+	elfclass = read_byte(f)
+	assert (elfclass == ELFCLASS32) or (elfclass == ELFCLASS64)
+	is64 = elfclass == ELFCLASS64
+
+	# Hardcoded offsets for fields of the ELF header - a more sophisticated
+	# tweaker would parse the structure, but we only need to make some very
+	# small tweaks
+	if is64:
+		e_shoff_offset = 0x28
+		e_shentsize_offset = 0x3a
+		e_shnum_offset = 0x3c
+		# offset of sh_offset  the section header
+		sh_offset_offset = 0x18
+	else:
+		e_shoff_offset = 0x20
+		e_shentsize_offset = 0x2e
+		e_shnum_offset = 0x30
+		sh_offset_offset = 0x10
+
+	f.seek(e_shoff_offset)
+	e_shoff = read_uptr(is64, f)
+
+	f.seek(e_shentsize_offset)
+	e_shentsize = read_uint16(f)
+
+	f.seek(e_shnum_offset)
+	e_shnum = read_uint16(f)
+
+	old_offset = e_shoff
+	size = e_shentsize * e_shnum
+
+	assert size <= reserved_size
+	assert old_offset + size == os.stat(sys.argv[1]).st_size
+
+	f.seek(old_offset)
+	data = f.read(size)
+
+	f.seek(new_table_offset)
+	f.write(data)
+
+	f.seek(e_shoff_offset)
+	write_uptr(is64, f, new_table_offset)
+
+	alloc_offset = new_table_offset + size
+	for n in range(12, 15):
+		seek_nth_section_sh_offset(f, new_table_offset, e_shentsize, n, sh_offset_offset)
+		sh_offs = read_uptr(is64, f)
+		sh_size = read_uptr(is64, f)
+
+		f.seek(sh_offs)
+		sh_data = f.read(sh_size)
+
+		new_section_offset = (alloc_offset + sect_align - 1) & ~(sect_align-1)
+		f.seek(new_section_offset)
+
+		f.write(sh_data)
+
+		seek_nth_section_sh_offset(f, new_table_offset, e_shentsize, n, sh_offset_offset)
+		write_uptr(is64, f, new_section_offset)
+
+		alloc_offset = new_section_offset + sh_size
+		assert (alloc_offset - new_section_offset) <= reserved_size

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -694,21 +694,6 @@ static void process_mmap(ReplayTask* t, const TraceFrame& trace_frame,
         TraceReader::VALIDATE, TraceReader::CURRENT_TIME_ONLY, &extra_fds,
         &skip_monitoring_mapped_fd);
 
-      FileMonitor *fd_monitor = t->fd_table()->get_monitor(fd);
-      if (fd_monitor && fd_monitor->type() == FileMonitor::RRPage) {
-        if (offset_pages == 0 && !(flags & MAP_FIXED) &&
-            length <= 2*page_size() && addr == (RR_PAGE_ADDR - page_size())) {
-          // We only mapped the first page during record. Do the same here
-          length = page_size();
-        }
-        if (offset_pages == 1 && length == page_size() &&
-            addr == RR_PAGE_ADDR && t->vm()->has_rr_page()) {
-          // We skipped this during recording. Setting length to zero here
-          // will have the same effect.
-          length = 0;
-        }
-      }
-
       if (data.source == TraceReader::SOURCE_FILE &&
           data.file_size_bytes > data.data_offset_bytes) {
         struct stat real_file;

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -90,9 +90,17 @@ struct Header {
     # rr sets FIP/FDP to zero at each recorded event.
     clearFipFdp @14 :Bool = false;
   }
-  # Whether the version of rr that recorded this, explicitly recorded
-  # modifications made through /proc/<pid>/<mem>
-  explicitProcMem @11 :Bool = true;
+  # These flags guard rr behavior differences that ensure old rr traces can
+  # be sucessfully replayed on newer replayers
+  quirks :group {
+    # Whether the version of rr that recorded this, explicitly recorded
+    # modifications made through /proc/<pid>/<mem>
+    explicitProcMem @11 :Bool = true;
+
+    # Whether the version of rr that recorded this (may have) had special
+    # record behavior for librrpage.so
+    specialLibrrpage @15 :Bool = true;
+  }
 }
 
 # A file descriptor belonging to a task

--- a/src/test/mmap_replace_most_mappings.c
+++ b/src/test/mmap_replace_most_mappings.c
@@ -20,7 +20,8 @@ void callback(uint64_t env, char* name, map_properties_t* props) {
   if (contains_symbol(props, &main) ||
       /* env is on the stack - this prevents it from being unmapped if
          the kernel gets confused by syscallbuf's stack switching */
-      contains_symbol(props, &env) || props->start == RR_PAGE_ADDR ||
+      contains_symbol(props, &env) ||
+      (props->start <= RR_PAGE_ADDR && RR_PAGE_ADDR < props->end) ||
       strcmp(name, "[stack]") == 0) {
     return;
   }

--- a/src/test/ptrace_remote_unmap.c
+++ b/src/test/ptrace_remote_unmap.c
@@ -83,7 +83,8 @@ void munmap_remote(pid_t child, uintptr_t start, size_t size) {
 static void remote_unmap_callback(uint64_t child, char* name,
                                   map_properties_t* props) {
   if ((props->start <= child_syscall_addr && child_syscall_addr < props->end) ||
-      props->start == RR_PAGE_ADDR || strcmp(name, "[vsyscall]") == 0) {
+      (props->start <= RR_PAGE_ADDR && props->end > RR_PAGE_ADDR) ||
+      strcmp(name, "[vsyscall]") == 0) {
     return;
   }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -126,14 +126,14 @@ std::string read_ld_path(Task* t, remote_ptr<void> interpreter_base) {
   return t->vm()->mapping_of(interpreter_base).map.fsname();
 }
 
-template <typename Arch> void patch_auxv_vdso_arch(RecordTask* t) {
+template <typename Arch> void patch_auxv_vdso_arch(RecordTask* t, uintptr_t search, uintptr_t new_entry_native) {
   auto stack_ptr = auxv_ptr<Arch>(t);
   std::vector<uint8_t> v = read_auxv_arch<Arch>(t, stack_ptr);
   size_t wsize = sizeof(typename Arch::unsigned_word);
   for (int i = 0; (i + 1)*wsize*2 <= v.size(); ++i) {
-    if (*((typename Arch::unsigned_word*)(v.data() + i*2*wsize)) == AT_SYSINFO_EHDR) {
-      auto entry_ptr = stack_ptr + i*2;
-      typename Arch::unsigned_word new_entry = AT_IGNORE;
+    if (*((typename Arch::unsigned_word*)(v.data() + i*2*wsize)) == search) {
+      auto entry_ptr = stack_ptr + i*2 + 1;
+      typename Arch::unsigned_word new_entry = new_entry_native;
       t->write_mem(entry_ptr, new_entry);
       t->record_local(entry_ptr, &new_entry);
       return;
@@ -142,8 +142,8 @@ template <typename Arch> void patch_auxv_vdso_arch(RecordTask* t) {
   return;
 }
 
-void patch_auxv_vdso(RecordTask* t) {
-  RR_ARCH_FUNCTION(patch_auxv_vdso_arch, t->arch(), t);
+void patch_auxv_vdso(RecordTask* t, uintptr_t search, uintptr_t new_entry) {
+  RR_ARCH_FUNCTION(patch_auxv_vdso_arch, t->arch(), t, search, new_entry);
 }
 
 template <typename Arch> static vector<string> read_env_arch(Task* t) {

--- a/src/util.h
+++ b/src/util.h
@@ -66,7 +66,7 @@ std::string read_ld_path(Task* t, remote_ptr<void> interpreter_base);
  */
 std::vector<std::string> read_env(Task* t);
 
-void patch_auxv_vdso(RecordTask* t);
+void patch_auxv_vdso(RecordTask* t, uintptr_t search, uintptr_t new_entry);
 
 /**
  * Create a file named |filename| and dump |buf_len| words in |buf| to


### PR DESCRIPTION
We were running into another #2721 like situation, except this time
due the vdso patch (for which we deliberately destroy the unwind info
to avoid confusing the unwinder - unfortunately, we'd not only like it
to not be confused, we'd also like it to work). To solve this, I
propose to stop patching the vdso alltogether and instead implement
a VDSO-compatible ABI in librrpage that can then a-priori do
whatever we need it to while simultaneously having correct unwind
information. As a bonus, this also lets us rip out the heuristic for
mapping librrpage, since the dynamic linker is happy to take what
it thinks of as the VDSO as a pre-relocated object in memory.

This seems to work fairly well and results in a bunch of nice simplification
of the Monkeypatcher code. There are two test failures because GDB
seems to have some special ideas about how to unwind the vdso (because
of course it does), so I need to look into how to convince GDB to
do the right thing, but before I do that, I wanted to check on
the direction here. I quite like it, but I'm wondering if it's a bit
too cute. Any concerns?