### PR TITLE
Assorted fixes for detach code

### DIFF
--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -377,7 +377,7 @@ enum {
 #endif
 
 #ifndef RLIMIT_RTTIME
-#define RLIMIT_RTTIME 16
+#define RLIMIT_RTTIME 15
 #endif
 
 } // namespace rr

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3348,7 +3348,7 @@ static pid_t do_detach_teleport(RecordTask *t)
   // restore that.
   cpu_set_t mask;
   memset(&mask, 0xFF, sizeof(mask));
-  sched_setaffinity(new_t->tid, sizeof(mask), &mask);
+  syscall(SYS_sched_setaffinity, new_t->tid, sizeof(mask), &mask);
   new_t->detach();
   new_t->did_kill();
   delete new_t;


### PR DESCRIPTION
@staticfloat and I spent a bunch of time last week trying to get rr running in our CI environment (again - it's been a long battle), and found a few minor issues in the detach code. One embarrassing typo I made in a prior commit, one kernel issue (https://lkml.org/lkml/2020/12/16/936) for which this at least gives an error message now and one workaround for old libcs. Details in the individual commits.