### PR TITLE
In detach, don't try to copy MAP_SHARED pages

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3557,8 +3557,9 @@ void Task::dup_from(Task *other) {
       LOG(debug) << "Creating mapping " << km << " for " << tid;
       create_mapping(this, remote_this, km);
       LOG(debug) << "Copying mapping into " << tid;
-      // XXX: If this maps a file, recreate it as such
-      copy_mem_mapping(other, this, km);
+      if (!(km.flags() & MAP_SHARED)) {
+        copy_mem_mapping(other, this, km);
+      }
     }
     AutoRemoteSyscalls remote_other(other);
     std::vector<int> all_fds = read_all_proc_fds(other->tid);


### PR DESCRIPTION
Any updates that were made to the page will already be visible,
so there's no need to copy. Of course, applications that use
MAP_SHARED are quite likely to break anyway, but we might
as well let it continue here. There are some libraries that
like to map global caches MAP_SHARED, even if they generally
aren't written without manual update, which is usually fine.