### PR TITLE
Fix struct size for copying rlimits at i386.

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3602,7 +3602,7 @@ void Task::dup_from(Task *other) {
     }
 
     // Copy rlimits
-    struct rlimit limit;
+    struct rlimit64 limit;
     for (size_t i = 0; i < (sizeof(all_rlimits)/sizeof(all_rlimits[0])); ++i) {
       int err = syscall(SYS_prlimit64, (uintptr_t)other->tid,
         (uintptr_t)all_rlimits[i], (uintptr_t)NULL, (uintptr_t)&limit);


### PR DESCRIPTION
I found some detach tests started to fail since c512416f2.
At i386 struct rlimit is just 8 bytes while struct rlimit64 is 16 bytes, while at x86_64 both are the same size.
Therefore memory followed by the variable limit got overwritten causing a crash later.

```
(gdb) print sizeof(limit)
$3 = 8
(gdb) x/32xb &limit
0xbfffd4dc:     0x68    0xbe    0x76    0x00    0x14    0xd5    0xff    0xbf
0xbfffd4e4:     0x78    0xd3    0xff    0xbf    0x6e    0x1e    0xca    0xb7
0xbfffd4ec:     0xe0    0x58    0xb0    0x00    0xe2    0x58    0xb0    0x00
0xbfffd4f4:     0xe2    0x58    0xb0    0x00    0x70    0x1e    0xca    0xb7
(gdb) next
3599            (uintptr_t)all_rlimits[i], (uintptr_t)NULL, (uintptr_t)&limit);
1: &(((rr::AutoRestoreMem * const) 0xbfffd4e4).remote)
 = (rr::AutoRemoteSyscalls *) 0xbfffd378
(gdb) x/32xb &limit
0xbfffd4dc:     0x68    0xbe    0x76    0x00    0x14    0xd5    0xff    0xbf
0xbfffd4e4:     0x78    0xd3    0xff    0xbf    0x6e    0x1e    0xca    0xb7
0xbfffd4ec:     0xe0    0x58    0xb0    0x00    0xe2    0x58    0xb0    0x00
0xbfffd4f4:     0xe2    0x58    0xb0    0x00    0x70    0x1e    0xca    0xb7
(gdb) next
3598          int err = syscall(SYS_prlimit64, (uintptr_t)other->tid,
1: &(((rr::AutoRestoreMem * const) 0xbfffd4e4).remote)
 = (rr::AutoRemoteSyscalls *) 0xbfffd378
(gdb) 
3600          ASSERT(other, err == 0);
1: &(((rr::AutoRestoreMem * const) 0xbfffd4e4).remote)
 = (rr::AutoRemoteSyscalls *) 0xffffffff
(gdb) x/32xb &limit
0xbfffd4dc:     0xff    0xff    0xff    0xff    0xff    0xff    0xff    0xff
0xbfffd4e4:     0xff    0xff    0xff    0xff    0xff    0xff    0xff    0xff
0xbfffd4ec:     0xe0    0x58    0xb0    0x00    0xe2    0x58    0xb0    0x00
0xbfffd4f4:     0xe2    0x58    0xb0    0x00    0x70    0x1e    0xca    0xb7
(gdb) bt  
#0  rr::Task::dup_from (this=0xb04510, other=0xafec10) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/Task.cc:3600
#1  0x007c5092 in rr::do_detach_teleport (t=0xafec10) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/record_syscall.cc:3332
#2  0x007d04c1 in rr::rec_prepare_syscall_arch<rr::X86Arch> (t=0xafec10, syscall_state=..., regs=...) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/record_syscall.cc:4747
#3  0x007c539f in operator() (__closure=0xbfffed58, regs=...) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/record_syscall.cc:4863
#4  0x007db357 in rr::with_converted_registers<rr::Switchable, rr::rec_prepare_syscall_internal(rr::RecordTask*, rr::TaskSyscallState&)::<lambda(const rr::Registers&)> >(const rr::Registers &, rr::SupportedArch, struct {...}) (regs=..., arch=rr::x86, f=...) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/Registers.h:604
#5  0x007c545c in rr::rec_prepare_syscall_internal (t=0xafec10, syscall_state=...) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/record_syscall.cc:4861
#6  0x007c54ad in rr::rec_prepare_syscall (t=0xafec10) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/record_syscall.cc:4872
#7  0x007abe88 in rr::RecordSession::syscall_state_changed (this=0xaf4970, t=0xafec10, step_state=0xbffff34c) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/RecordSession.cc:1054
#8  0x007b20fb in rr::RecordSession::record_step (this=0xaf4970) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/RecordSession.cc:2344
#9  0x007a5e40 in rr::record (args=std::vector of length 1, capacity 2 = {...}, flags=...) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/RecordCommand.cc:642
#10 0x007a6aab in rr::RecordCommand::run (this=0xaeb100 <rr::RecordCommand::singleton>, args=std::vector of length 1, capacity 2 = {...}) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/RecordCommand.cc:777
#11 0x00902c48 in main (argc=3, argv=0xbffff664) at /home/bernhard/data/entwicklung/2020/rr/2020-12-23/rr/src/main.cc:249

(gdb) print sizeof(struct rlimit)
$1 = 8
(gdb) print sizeof(struct rlimit64)
$2 = 16
```