### PR TITLE
Install a SEGV handler that prints a stacktrace

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -518,11 +518,25 @@ static void handle_SIGTERM(__attribute__((unused)) int sig) {
   }
 }
 
+/**
+ * Something segfaulted - this is probably a bug in rr. Try to at least
+ * give a stacktrace.
+ */
+static void handle_SIGSEGV(__attribute__((unused)) int sig) {
+  static const char msg[] =
+    "rr itself crashed (SIGSEGV). This shouldn't happen!\n";
+  write_all(STDERR_FILENO, msg, sizeof(msg) - 1);
+  notifying_abort();
+}
+
 static void install_signal_handlers(void) {
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = handle_SIGTERM;
   sigaction(SIGTERM, &sa, nullptr);
+
+  sa.sa_handler = handle_SIGSEGV;
+  sigaction(SIGSEGV, &sa, nullptr);
 
   sa.sa_handler = SIG_IGN;
   sigaction(SIGHUP, &sa, nullptr);


### PR DESCRIPTION
On our CI, we are seeing recording rr tracers segfault
every couple of days (which isn't terrible we run probably
around 40 rr processes continuously 24/7). We are also
using the detach feature quite heavily, so this could
be related to #2777. However, at the moment when rr
crashes, it doesn't print any useful information
whatsoever. To help diagnose, this PR makes it at
least print a backtrace on SIGSEGV, which I think
would be generally useful. If that doesn't work,
we'll have to move on to rr-recording our rr-recordings ;).