### PR TITLE
Work around a bad GDB heuristic in unwind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1245,6 +1245,7 @@ set(TESTS_WITH_PROGRAM
   mmap_tmpfs
   mmap_write
   mmap_write_private
+  morestack_unwind
   mprotect_growsdown
   mprotect_syscallbuf_overflow
   mutex_pi_stress

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -456,6 +456,14 @@ CFA_AT_RSP_OFFSET(16)
 RSP_IS_RSP_PLUS_OFFSET(8)
 RIP_IS_DEREF_RSP(0)
 callq _syscall_hook_trampoline
+/* GDB likes to override valid CFI with its own heuristics if the current
+   instruction is a retq. This becomes a problem here, because GDB will set
+   a breakpoint at the next instruction after the callq when continuing out of
+   `_syscall_hook_trampoline`. This `nop` makes said instruction not a retq,
+   thus preventing that GDB heuristic from kicking in and letting GDB realize
+   that it did in fact manage to step out of the `_syscall_hook_trampoline`
+   frame. */
+nop
 retq
 .cfi_endproc
 .size __morestack, .-__morestack

--- a/src/test/morestack_unwind.c
+++ b/src/test/morestack_unwind.c
@@ -1,0 +1,14 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+int main(void) {
+  atomic_puts("EXIT-SUCCESS");
+  breakpoint();
+  return 0;
+}

--- a/src/test/morestack_unwind.py
+++ b/src/test/morestack_unwind.py
@@ -1,0 +1,25 @@
+from util import *
+
+send_gdb('break main')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+send_gdb('break _syscall_hook_trampoline')
+expect_gdb('Breakpoint 2')
+send_gdb('c')
+expect_gdb('Breakpoint 2')
+
+send_gdb('fin')
+send_gdb('fin')
+send_gdb('fin')
+
+# Verify we didn't run too far
+
+send_gdb('b breakpoint')
+expect_gdb('Breakpoint 3')
+
+send_gdb('c')
+expect_gdb('Breakpoint 3')
+
+ok()

--- a/src/test/morestack_unwind.run
+++ b/src/test/morestack_unwind.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+skip_if_no_syscall_buf
+debug_test


### PR DESCRIPTION
GDB has a heuristic [1] that overrides unwind info if
the current instruction is a literal `retq`. Unfortunately
this interferes with our __morestack hack because it changes
the CFA, which in response to a `fin` command, causes GDB
to believe that it did not in fact manage to step out of
the frame, but rather ended up stepping into the same function
again. This causes #2682. To work around this, we could set
the producer to "GCC 4.5" or greater, which disables the
heuristic. However, creating this information in assembly
is quite tedious because there is no native support for it,
so it would have to be entered using raw directives. Instead,
simply put a `nop` at the return of the `_syscall_hook_trampoline`.
This prevents the heuristic from kicking in, so GDB doesn't miss
the frame. GDB will still unwind incorrectly at the `retq` that
follows, but we generally won't stop there. Long term
this isn't perfect of course and we're playing a bit of a
game of whack-a-mole with GDB heuristics here when our unwind
information is actually 100% valid. I have written to the
lsb-discuss mailing list to see if we can get an unwind
augmentation that would signal to the debugger to just trust
our unwind info and disable all heuristics. For the moment
though, this fixes #2682.

[1] https://github.com/bminor/binutils-gdb/blob/master/gdb/dwarf2/read.c#L10083-L10084