### PR TITLE
WIP: Add support to run tests with 32-bit rr below 64-bit kernel (prctl_mm_map)

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -495,7 +495,7 @@ void AddressSpace::save_ld_path(Task* t, remote_ptr<void> interpreter_base) {
   saved_ld_path_ = read_ld_path(t, interpreter_base);
 }
 
-void AddressSpace::read_mm_map(Task* t, struct prctl_mm_map* map) {
+void AddressSpace::read_mm_map(Task* t, NativeArch::prctl_mm_map* map) {
   char buf[PATH_MAX+1024];
   {
     string proc_stat = t->proc_stat_path();
@@ -512,7 +512,7 @@ void AddressSpace::read_mm_map(Task* t, struct prctl_mm_map* map) {
   // We don't change /proc/pid/exe, since we're unlikely to have CAP_SYS_ADMIN
   map->exe_fd = -1;
   // auxv is restored separately
-  map->auxv = NULL;
+  map->auxv.val = 0;
   map->auxv_size = 0;
   // All of these fields of /proc/pid/stat, we don't use (currently)
   char state;

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -29,8 +29,6 @@
 #include "remote_code_ptr.h"
 #include "util.h"
 
-struct prctl_mm_map;
-
 namespace rr {
 
 class AutoRemoteSyscalls;
@@ -759,7 +757,7 @@ public:
   std::string saved_ld_path() { return saved_ld_path_;}
   void save_ld_path(Task* t, remote_ptr<void>);
 
-  void read_mm_map(Task* t, struct prctl_mm_map* map);
+  void read_mm_map(Task* t, NativeArch::prctl_mm_map* map);
 
   /**
    * Reads the /proc/<pid>/maps entry for a specific address. Does no caching.

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -5,7 +5,6 @@
 #include "ReplaySession.h"
 
 #include <linux/futex.h>
-#include <sys/prctl.h>
 #include <syscall.h>
 
 #include <algorithm>

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -4,7 +4,6 @@
 
 #include <linux/limits.h>
 #include <linux/unistd.h>
-#include <sys/prctl.h>
 #include <syscall.h>
 #include <sys/wait.h>
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/personality.h>
-#include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -3448,7 +3447,7 @@ static void create_mapping(Task *t, AutoRemoteSyscalls &remote, const KernelMapp
                real_file_name, device, inode, nullptr, &km);
 }
 
-static void apply_mm_map(AutoRemoteSyscalls& remote, const struct prctl_mm_map& map)
+static void apply_mm_map(AutoRemoteSyscalls& remote, const NativeArch::prctl_mm_map& map)
 {
   AutoRestoreMem remote_mm_map(remote, (const uint8_t*)&map, sizeof(map));
   int result = remote.syscall(syscall_number_for_prctl(remote.task()->arch()), PR_SET_MM,
@@ -3619,8 +3618,8 @@ void Task::dup_from(Task *other) {
       ASSERT(this, err == 0);
     }
 
-    struct prctl_mm_map map;
-    memset(&map, 0, sizeof(prctl_mm_map));
+    NativeArch::prctl_mm_map map;
+    memset(&map, 0, sizeof(map));
 
     other->vm()->read_mm_map(other, &map);
     apply_mm_map(remote_this, map);

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
+#include <sys/prctl.h>
 #include <sys/quota.h>
 #include <sys/resource.h>
 #include <sys/socket.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1667,6 +1667,24 @@ struct BaseArch : public wordsize,
     ptr<link_map> r_map;
     // More fields we don't need (and are potentially libc specific)
   };
+
+  struct prctl_mm_map {
+    __u64 start_code;
+    __u64 end_code;
+    __u64 start_data;
+    __u64 end_data;
+    __u64 start_brk;
+    __u64 brk;
+    __u64 start_stack;
+    __u64 arg_start;
+    __u64 arg_end;
+    __u64 env_start;
+    __u64 env_end;
+    ptr<__u64> auxv;
+    __u32 auxv_size;
+    __u32 exe_fd;
+  };
+  RR_VERIFY_TYPE(prctl_mm_map);
 };
 
 struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4332,6 +4332,19 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           break;
         }
 
+        case PR_SET_MM:{
+          switch ((unsigned long)regs.arg2()) {
+            case PR_SET_MM_MAP_SIZE:
+              syscall_state.reg_parameter(3, sizeof(unsigned int));
+              break;
+
+            default:
+              syscall_state.expect_errno = EINVAL;
+              break;
+          }
+        }
+        break;
+
         default:
           syscall_state.expect_errno = EINVAL;
           break;

--- a/src/test/prctl.c
+++ b/src/test/prctl.c
@@ -58,6 +58,10 @@ int main(void) {
   test_assert(0 == prctl(PR_GET_CHILD_SUBREAPER, &reaper));
   test_assert(reaper == 1);
 
+  unsigned int size = 0;
+  test_assert(0 == prctl(PR_SET_MM, PR_SET_MM_MAP_SIZE, &size, 0, 0));
+  test_assert(size != 0);
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }


### PR DESCRIPTION
This helps tests detach_state, nested_detach and nested_detach_wait
to succeed with a 32-bit rr running under a 64-bit kernel.

This iteration of the series has moved the structure definition to kernel_abi.h and replaced all uses of sys/prctl.h's definition like @khuey asked for.

Also I hope this should make my use of fflush in the commit message in the last iteration more clear.
Is it known what this fflush changes to make the prctl not to fail with EPERM?