### PR TITLE
Skip some tests if run with 32-bit rr under a 64-bit kernel

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2064,6 +2064,12 @@ void Task::did_waitpid(WaitStatus status) {
         // cs segment register and checking if that segment is a long mode segment
         // (Linux always uses GDT entries for this, which are globally the same).
         SupportedArch a = is_long_mode_segment(registers.cs()) ? x86_64 : x86;
+
+        if (a == x86_64 && NativeArch::arch() == x86) {
+          FATAL() << "Sorry, tracee " << tid << " is executing in x86-64 mode"
+                  << " and that's not supported with a 32-bit rr.";
+        }
+
         if (a != registers.arch()) {
           registers.set_arch(a);
           registers.set_from_ptrace(ptrace_regs);

--- a/src/test/64bit_child.c
+++ b/src/test/64bit_child.c
@@ -2,7 +2,40 @@
 
 #include "util.h"
 
+void callback(uint64_t env, char *name, __attribute__((unused)) map_properties_t* props) {
+  const char search[] = "librrpage.so";
+  if (strlen(name) > strlen(search)) {
+    if (sizeof(void*) == 4 &&
+        strcmp(name + strlen(name) - strlen(search), search) == 0)
+    {
+      int* rr_is_32bit = (int*)(uintptr_t)env;
+      *rr_is_32bit = 1;
+    }
+  }
+}
+
+static void skip_if_rr_32_bit_under_kernel_64_bit(void) {
+  FILE* maps_file = fopen("/proc/self/maps", "r");
+  int rr_is_32bit = 0;
+  iterate_maps((uintptr_t)&rr_is_32bit, callback, maps_file);
+
+  struct utsname buf;
+  if (uname(&buf) != 0)
+    return;
+
+  if (rr_is_32bit && // we are inside a 32bit rr process
+      strcmp(buf.machine, "x86_64") == 0) // running at a 64bit kernel
+  {
+    atomic_puts("NOTE: Skipping 32-bit test because of 32-bit rr with 64-bit kernel.");
+    atomic_puts("EXIT-SUCCESS");
+    exit(0);
+  }
+}
+
 int main(void) {
+
+  skip_if_rr_32_bit_under_kernel_64_bit();
+
   /* Fork-and-exec 'echo'.
      The exec may fail if 'bash' is 64-bit and rr doesn't support
      64-bit processes. That's fine; the test should still pass. We're

--- a/src/test/simple_script.run
+++ b/src/test/simple_script.run
@@ -1,5 +1,7 @@
 source `dirname $0`/util.sh
 
+skip_if_rr_32_bit_with_shell_64_bit
+
 just_record $TESTDIR/simple_script.sh
 replay
 check EXIT-SUCCESS

--- a/src/test/simple_script_debug.run
+++ b/src/test/simple_script_debug.run
@@ -1,4 +1,6 @@
 source `dirname $0`/util.sh
 
+skip_if_rr_32_bit_with_shell_64_bit
+
 just_record $TESTDIR/simple_script.sh
 debug simple_script_debug "--onprocess simple_script.sh"

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -210,9 +210,16 @@ function skip_if_no_syscall_buf {
     fi
 }
 
-function skip_if_32_bit {
-    if [[ "_32" == $bitness ]] || [[ "$(uname -m)" =~ i[3-6]86 ]]; then
-        echo NOTE: Skipping 32-bit "'$TESTNAME'"
+function skip_if_test_32_bit {
+    if [[ "_32" == $bitness ]]; then
+        echo NOTE: Skipping "'$TESTNAME'" because 32-bit test
+        exit 0
+    fi
+}
+
+function skip_if_rr_32_bit {
+    if [[ "$(file $RESOURCE_PATH/lib/rr/librrpage.so | grep 32-bit -c)" == "1" ]]; then
+        echo NOTE: Skipping "'$TESTNAME'" because 32-bit rr
         exit 0
     fi
 }

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -224,6 +224,15 @@ function skip_if_rr_32_bit {
     fi
 }
 
+function skip_if_rr_32_bit_with_shell_64_bit {
+    if [[ "$(file $RESOURCE_PATH/lib/rr/librrpage.so | grep 32-bit -c)" == "1" ]] &&
+       [[ "$(file -L $(which sh) | grep 64-bit -c)" == "1" ]];
+    then
+        echo NOTE: Skipping "'$TESTNAME'" because 32-bit rr with 64-bit shell
+        exit 0
+    fi
+}
+
 # If the test is causing an unrealistic failure when the syscallbuf is
 # enabled, skip it.  This better be a temporary situation!
 function skip_if_syscall_buf {

--- a/src/test/vdso_clock_gettime_stack.run
+++ b/src/test/vdso_clock_gettime_stack.run
@@ -7,7 +7,7 @@ skip_if_no_syscall_buf
 # Ubuntu 5.8.0-25-generic, at least, doesn't produce usable stacks inside certain VDSO syscalls
 # with gdb and we can't under rr either due to the VDSO functions being too short for a single
 # patch without call-outs.
-skip_if_32_bit
+skip_if_test_32_bit
 
 # Use 4K syscallbuf size to force frequent overflows
 RECORD_ARGS=--syscall-buffer-size=4

--- a/src/test/vdso_gettimeofday_stack.run
+++ b/src/test/vdso_gettimeofday_stack.run
@@ -7,7 +7,8 @@ skip_if_no_syscall_buf
 # Ubuntu 5.8.0-25-generic, at least, doesn't produce usable stacks inside certain VDSO syscalls
 # with gdb and we can't under rr either due to the VDSO functions being too short for a single
 # patch without call-outs.
-skip_if_32_bit
+skip_if_test_32_bit
+skip_if_rr_32_bit
 
 # Use 4K syscallbuf size to force frequent overflows
 RECORD_ARGS=--syscall-buffer-size=4

--- a/src/test/vdso_time_stack.run
+++ b/src/test/vdso_time_stack.run
@@ -7,7 +7,8 @@ skip_if_no_syscall_buf
 # Ubuntu 5.8.0-25-generic, at least, doesn't produce usable stacks inside certain VDSO syscalls
 # with gdb and we can't under rr either due to the VDSO functions being too short for a single
 # patch without call-outs.
-skip_if_32_bit
+skip_if_test_32_bit
+skip_if_rr_32_bit
 
 # Use 4K syscallbuf size to force frequent overflows
 RECORD_ARGS=--syscall-buffer-size=4

--- a/src/test/vsyscall_singlestep.run
+++ b/src/test/vsyscall_singlestep.run
@@ -1,4 +1,4 @@
 source `dirname $0`/util.sh
-skip_if_32_bit
+skip_if_test_32_bit
 record vsyscall$bitness
 _RR_TRACE_DIR="$workdir" rr rerun -s 300 --singlestep=rip > /dev/null || failed "Singlestepping through vsyscall failed"


### PR DESCRIPTION
This is mostly done by detecting bitness or the name of librrpage.so.
Can we take a `which` and `file` in the environment as given?
In 64bit_child.c the following comment makes me wonder if it is still true:
```cpp
  /* Fork-and-exec 'echo'.
     The exec may fail if 'bash' is 64-bit and rr doesn't support
     64-bit processes. That's fine; the test should still pass. We're
     testing that rr doesn't abort.
   */
```
In my tests a 32-bit rr with a 64-bit shell under a 64-bit kernel, if not skipped, does abort like this:
```
$ bin/rr record bin/64bit_child
rr: Saving execution to trace directory `/home/bernhard/.local/share/rr/64bit_child-0'.
rr: /home/bernhard/data/entwicklung/2020/rr/2021-01-03/rr/src/Registers.cc:550: void rr::Registers::set_from_ptrace(const rr::X86Arch::user_regs_struct&): Assertion `arch() == x86 && NativeArch::arch() == x86_64' failed.
Aborted (core dumped)
```
Therefore should this comment be removed too?

Related to #2782