### PR TITLE
Retry pthread_create on failure

### DIFF
--- a/src/CompressedWriter.cc
+++ b/src/CompressedWriter.cc
@@ -61,7 +61,16 @@ CompressedWriter::CompressedWriter(const string& filename, size_t block_size,
   // until we've finished initializing it.
   pthread_mutex_lock(&mutex);
   for (uint32_t i = 0; i < num_threads; ++i) {
-    pthread_create(&threads[i], nullptr, compression_thread_callback, this);
+    while (true) {
+      int err = pthread_create(&threads[i], nullptr, compression_thread_callback, this);
+      if (err == EAGAIN) {
+        sched_yield(); // Give other processes a chance to exit.
+        continue;
+      } else if (err != 0) {
+        SAFE_FATAL(err, "Failed to create compression threads!");
+      }
+      break;
+    }
     size_t last_slash = filename.rfind('/');
     string thread_name =
         string("compress ") + (last_slash == string::npos

--- a/src/kernel_metadata.cc
+++ b/src/kernel_metadata.cc
@@ -175,7 +175,7 @@ bool is_sigreturn(int syscallno, SupportedArch arch) {
          is_rt_sigreturn_syscall(syscallno, arch);
 }
 
-string errno_name(int err) {
+const char *errno_name_cstr(int err) {
   switch (err) {
     case 0:
       return "SUCCESS";
@@ -310,12 +310,18 @@ string errno_name(int err) {
       CASE(ENOTRECOVERABLE);
       CASE(ERFKILL);
       CASE(EHWPOISON);
-    default: {
-      char buf[100];
-      snprintf(buf, sizeof(buf), "errno(%d)", err);
-      return string(buf);
-    }
+    default: return NULL;
   }
+}
+
+string errno_name(int err) {
+  const char *name = errno_name_cstr(err);
+  if (name == NULL) {
+    char buf[100];
+    snprintf(buf, sizeof(buf), "errno(%d)", err);
+    return string(buf);
+  }
+  return string(name);
 }
 
 string sicode_name(int code, int sig) {

--- a/src/kernel_metadata.h
+++ b/src/kernel_metadata.h
@@ -52,6 +52,10 @@ bool is_sigreturn(int syscall, SupportedArch arch);
  */
 std::string errno_name(int err);
 
+/* Same as errno_name, but returns a pointer to static memory or NULL if
+allocation would be required. Suitable for use in volatile contexts */
+const char *errno_name_cstr(int err);
+
 /**
  * Return the symbolic name (e.g. "SI_USER") for an si_code.
  */

--- a/src/util.h
+++ b/src/util.h
@@ -529,6 +529,10 @@ static inline struct timeval to_timeval(double t) {
 /* Slow but simple pop-count implementation. */
 int pop_count(uint64_t v);
 
+/* A version of fatal that uses no allocation/thread resource and is thus
+  safe to use in volatile contexts */
+void SAFE_FATAL(int err, const char *msg);
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
On older libcs, we're observing about a 0.1% crash (SIGSEGV) rate
when starting an rr process under load. With #2780, the printed
stack trace reveals that the crash is in pthread_join.
My suspicion is that the pthread_create failed and never actually
created the thread that pthread_join then tries and fails to
join. I am not sure why newer libcs would not show the same
behavior but maybe glibc gained some sort of internal retry.