### PR TITLE
Detach: Unpatch syscalls before detaching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,7 @@ set(BASIC_TESTS
   daemon
   desched_blocking_poll
   detach_state
+  detach_threads
   deterministic_sigsys
   direct
   dup

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -98,7 +98,10 @@ templates = {
         RawBytes(0xe9),                               # jmp $trampoline_relative_addr
         Field('trampoline_relative_addr', 4)
     ),
-
+    'X86SyscallStubRestore': AssemblyTemplate(
+        RawBytes(0xe9),                               # jmp $trampoline_relative_addr
+        Field('trampoline_relative_addr', 4)
+    ),
     'X64CallMonkeypatch': AssemblyTemplate(
         RawBytes(0xe8),         # call $relative_addr
         Field('relative_addr', 4),
@@ -126,6 +129,10 @@ templates = {
         Field('return_addr_hi', 4),
         RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00),       # jmp *0(%rip)
         Field('jump_target', 8),
+    ),
+    'X64SyscallStubRestore': AssemblyTemplate(
+        RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00),       # jmp *0(%rip)
+        Field('return_addr', 8),
     ),
     'X64DLRuntimeResolve': AssemblyTemplate(
         RawBytes(0x53),                   # push %rbx

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3326,6 +3326,7 @@ static pid_t do_detach_teleport(RecordTask *t)
     AutoRemoteSyscalls remote(new_t, AutoRemoteSyscalls::DISABLE_MEMORY_PARAMS);
     remote.syscall(syscall_number_for_close(new_t->arch()), tracee_fd_number);
   }
+  t->vm()->monkeypatcher().unpatch_syscalls_in(new_t);
   // Try to reset the scheduler affinity that we enforced upon the task.
   // XXX: It would be nice to track what affinity the tracee requested and
   // restore that.

--- a/src/test/detach_threads.c
+++ b/src/test/detach_threads.c
@@ -1,0 +1,53 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+#include "util_internal.h"
+
+#define NUM_THREADS 20
+
+static pid_t my_gettid(void) {
+	pid_t pid = syscall(SYS_gettid);
+	test_assert(pid > 0);
+	return pid;
+}
+
+static void* run_thread(__attribute__((unused)) void* p) {
+	pid_t tid = my_gettid();
+	for (int i = 0; i < 10000; ++i) {
+		test_assert(tid == my_gettid());
+		if (i % 500 == 0) {
+			sched_yield();
+		}
+	}
+  return NULL;
+}
+
+static pid_t my_tid;
+
+int main(__attribute__((unused)) int argc,
+         __attribute__((unused)) const char** argv) {
+	if (fork() == 0) {
+		pthread_t threads[NUM_THREADS];
+		// Make sure this is patched before the detach
+		my_tid = my_gettid();
+
+		if (running_under_rr()) {
+			rr_detach_teleport();
+			test_assert(my_gettid() != my_tid);
+		}
+
+		for (int i = 0; i < NUM_THREADS; ++i) {
+			pthread_create(&threads[i], NULL, run_thread, NULL);
+		}
+		for (int i = 0; i < NUM_THREADS; ++i) {
+			pthread_join(threads[i], NULL);
+		}
+		return 0;
+	}
+
+  int status;
+  wait(&status);
+  test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
When detaching we leave the preload library in the former tracee.
We do lock the syscallbuf, so the tracee shouldn't really make use
of it, but I neglected to consider that the tracee might launch
additional threads, which, if they used a previously patched syscall,
would then share the syscallbuf stack. I considered simply setting
the stack nesting level to 1, which would force the syscallbuf
back onto the original stack, but this doesn't work because we
still use the preload thread locals for thread space and only
one thread may use these at a time. Additionally, it the tracee
may not expect to have its stack used in this way, which is why
we're switching stacks in the first place. This instead tries to
prevent the tracee from using the preload library entirely by
unpatching the syscalls. I considered trying to unpatch the
syscalls themselves, but I was worried that the tracee may
have modified said memory (e.g. because it was JITTed, or
because the tracee wants to set its own breakpoints, etc),
and detecting such conditions seemed very complex. Instead,
this unpatches the extended jump pages, which the tracee
should never really touch. Additionally, on x86, we need
to unpatch the vsyscall. The same JIT concerns don't really
apply here, so I'm just unpatching it directly. However,
I'm also expecting to just get rid of this patching in #2772,
so this code path is probably not particularly long-lived.

Ref https://github.com/JuliaLang/julia/issues/39068