### PR TITLE
Fix interaction of desched sig and vsyscall patching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1138,6 +1138,7 @@ set(BASIC_TESTS
   video_capture
   vm_readv_writev
   vsyscall
+  vsyscall_timeslice
   x86/x87env
   wait
   wait_sigstop

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -797,6 +797,13 @@ void RecordSession::task_continue(const StepState& step_state) {
       }
     }
 
+    // Override requested by the tracee for testing purposes
+    if (t->tick_request_override != (TicksRequest)0) {
+      ASSERT(t, !t->next_pmc_interrupt_is_for_user);
+      ticks_request = t->tick_request_override;
+      t->tick_request_override = (TicksRequest)0;
+    }
+
     bool singlestep = is_ptrace_any_singlestep(t->arch(),
       t->emulated_ptrace_cont_command);
     if (singlestep && is_at_syscall_instruction(t, t->ip())) {

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -197,7 +197,8 @@ RecordTask::RecordTask(RecordSession& session, pid_t _tid, uint32_t serial,
       waiting_for_reap(false),
       waiting_for_zombie(false),
       waiting_for_ptrace_exit(false),
-      retry_syscall_patching(false) {
+      retry_syscall_patching(false),
+      tick_request_override((TicksRequest)0) {
   push_event(Event::sentinel());
   if (session.tasks().empty()) {
     // Initial tracee. It inherited its state from this process, so set it up.

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -754,6 +754,10 @@ public:
 
   // When exiting a syscall, we should call MonkeyPatcher::try_patch_syscall again.
   bool retry_syscall_patching;
+
+  // Set if the tracee requested an override of the ticks request.
+  // Used for testing.
+  TicksRequest tick_request_override;
 };
 
 } // namespace rr

--- a/src/preload/rrcalls.h
+++ b/src/preload/rrcalls.h
@@ -78,3 +78,9 @@
  * process tree, such that it may run without seccomp.
  */
 #define SYS_rrcall_detach_teleport (RR_CALL_BASE + 9)
+/**
+ * Requests that rr reset the time slice signal to the
+ * requested period. Used for testing interaction corner
+ * cases between the time slice signal and other rr behavior.
+ */
+#define SYS_rrcall_arm_time_slice (RR_CALL_BASE + 10)

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4782,6 +4782,29 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       return ALLOW_SWITCH;
     }
 
+    case SYS_rrcall_arm_time_slice: {
+      Registers r = t->regs();
+      bool arguments_are_zero = true;
+      for (int i = 2; i <= 6; ++i) {
+        arguments_are_zero &= r.arg(i) == 0;
+      }
+      // Ticks request of zero is invalid for the moment
+      // for purposes of this syscall. In the future we
+      // want to have it mean to simulate a timeslice expiry
+      // at the end of this syscall, but we have no use for
+      // that at the moment.
+      if (r.arg(1) == 0 || r.arg(1) > (uintptr_t)MAX_TICKS_REQUEST ||
+          !arguments_are_zero) {
+        syscall_state.emulate_result((uintptr_t)-EINVAL);
+        syscall_state.expect_errno = ENOSYS;
+        return PREVENT_SWITCH;
+      }
+      t->tick_request_override = (TicksRequest)r.arg(1);
+      syscall_state.emulate_result(0);
+      syscall_state.expect_errno = ENOSYS;
+      return PREVENT_SWITCH;
+    }
+
     case Arch::brk:
     case Arch::munmap:
     case Arch::process_vm_readv:

--- a/src/test/vsyscall_timeslice.c
+++ b/src/test/vsyscall_timeslice.c
@@ -1,0 +1,89 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+#include "util_internal.h"
+
+#ifdef __x86_64__
+void __attribute__((naked)) generate_tick(long generate) {
+  __asm__ __volatile("test %%rdi, %%rdi\n\t"
+  "jnz 1f\n\t"
+  "ud2\n\t"
+  "1: retq\n\t" :: "D"(generate));
+  (void)generate;
+}
+
+static void test_vsyscall_timeslice_sig(void)
+{
+  intptr_t ret;
+  uintptr_t syscall = SYS_rrcall_arm_time_slice;
+  uintptr_t request = 1;
+  register long r10 __asm__("r10") = 0;
+  register long r8 __asm__("r8") = 0;
+  register long r9 __asm__("r9") = 0;
+  __asm__ __volatile(
+    "syscall\n\t"
+    "test %%rax, %%rax\n\t"
+    "jnz .Ldone\n\t"
+    // Create a pipeline stall - the CPU will speculate through
+    // these, but because of the dependency from %rax (the result of the
+    // division) to the %rdi argument of generate_tick will not be able to
+    // retire the conditional branches therein, thus skidding our time
+    // slice signal into the vsyscall.
+    "movq $1, %%rax\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    "div %%rdi\n\t"
+    // Two taken conditional branches here will trigger the
+    // time slice expiration. We expect this to skid into
+    // the subsequent vsyscall, triggering the condition we
+    // want to test
+    "movq %%rax, %%rdi\n\t"
+    // N.B.: This only works if the branches contained herein are
+    // predicted taken. Below we train the branch predictor to make
+    // sure this happens.
+    "callq generate_tick\n\t"
+    "callq generate_tick\n\t"
+    "xorq %%rdi, %%rdi\n\t"
+    "movq $0xffffffffff600400, %%rax\n\t" // time(NULL)
+    "callq *%%rax\n\t"
+    ".Ldone:"
+    "nop\n\t"
+        : "=a"(ret)
+        : "a"(syscall), "D"(request), "S"(NULL), "d"(NULL),
+            "r"(r10), "r"(r8), "r"(r9)  : "cc", "memory");
+  test_assert(ret > 0);
+}
+
+void callback(uint64_t env, char *name, __attribute__((unused)) map_properties_t* props) {
+  if (strcmp(name, "[vsyscall]") == 0) {
+    int* has_vsyscall = (int*)(uintptr_t)env;
+    *has_vsyscall = 1;
+  }
+}
+#endif
+
+int main(void) {
+  // x86_64 only
+#ifdef __x86_64__
+  FILE* maps_file = fopen("/proc/self/maps", "r");
+  int has_vsyscall = 0;
+  iterate_maps((uintptr_t)&has_vsyscall, callback, maps_file);
+
+  if (!running_under_rr()) {
+    atomic_puts("WARNING: This test only works under rr.");
+  } else if (has_vsyscall) {
+    for (int i = 0; i < 20000; ++i) {
+      // Train the branch predictor that these branches are taken
+      generate_tick(1);
+    }
+    test_vsyscall_timeslice_sig();
+  }
+#endif
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
In rare cases we can get an inopportune TIME_SLICE_SIGNAL while trying to patch a vsyscall, confusing rr. The fix is easy - the test quite a bit harder, because it only happens if we skid into a vsyscall, but I think I managed to come up with something that reliably triggers this.

Fixes https://github.com/JuliaLang/julia/issues/39206