### PR TITLE
Handle being at PTRACE_EVENT_SECCOMP in AutoRemoteSyscalls

### DIFF
--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -275,6 +275,7 @@ private:
   Registers initial_regs;
   remote_code_ptr initial_ip;
   remote_ptr<void> initial_sp;
+  bool initial_at_seccomp;
   remote_ptr<void> fixed_sp;
   std::vector<uint8_t> replaced_bytes;
   WaitStatus restore_wait_status;


### PR DESCRIPTION
This is an attempt to fix the issue reported in JuliaLang/julia#39145.
Essentially, the gist is as follows: During execve, we try to unmap
some buffers in the parent address space by picking an arbitrary
stopped task in the parent address space and comandeering it to
do the unmapping for us. Usually this is not a problem, because
this task will likely sit at a syscall exit event or signal event,
both of which AutoRemoteSyscalls supports fine. However, in rare
circumstances, it is possible for us to instead be sitting at a
PTRACE_EVENT_SECCOMP. The sequence of events that leads to this
is approximately as follows:

1. We resume using RESUME_SYSCALL (by itself fairly unusual if
the seccomp filter is running, since we usually prefer to save the
extra trap and go straight to the EVENT_SECCOMP trap - however,
we do use RESUME_SYSCALL to enter any restarted syscall).
2. We process the syscall at entry and if the syscall is blocking,
   we switch away from the task and let it run.
3. The task we switch to does an execve.
4. The task we resumed finally gets scheduled again and reaches its
   SECCOMP trap.
5. We try to use the task that got resumed for our bidding.

I think this solution of allowing AutoRemoteSyscalls from a
PTRACE_EVENT_SECCOMP will work fine, but I do find it a bit
unsatisfying. I tried for a few hours to just enforce the
invariant that if we switch away from a task while it's running,
the next stop will always be an exit stop or a signal stop, but
unfortunately this just descended into endless complexity, since
we essentially assume that the two stop types (entry/seccomp) are
interchangable. Another option would be to simply exclude tasks in
SECCOMP stop from consideration for comandeering, which wouldn't
be aweful since it's just a memory leak (and this case is very rare),
but I think there are other situations in which we want to comandeer
tasks where this may not be possible. Unfortunately, I was also
unable to come up with a testcase that reliably triggers this
interaction, so unless anybody has any clever ideas, I think the
only way to see if this works is for me to deploy it and see if
the issue goes away.