### PR TITLE
Propagate SIGTERM to detached tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1378,6 +1378,7 @@ set(TESTS_WITHOUT_PROGRAM
   hbreak
   mprotect_step
   nested_detach
+  nested_detach_kill
   parent_no_break_child_bkpt
   parent_no_stop_child_crash
   post_exec_fpu_regs

--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -577,7 +577,7 @@ static RecordSession* static_session;
 // later.
 void force_close_record_session() {
   if (static_session) {
-    static_session->terminate_recording();
+    static_session->terminate_recording(false);
   }
 }
 
@@ -660,7 +660,7 @@ static WaitStatus record(const vector<string>& args, const RecordFlags& flags) {
     }
   } while (step_result.status == RecordSession::STEP_CONTINUE && !term_requested);
 
-  session->terminate_recording();
+  session->terminate_recording(term_requested > 0);
   static_session = nullptr;
 
   switch (step_result.status) {

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -122,7 +122,7 @@ public:
    * Flush buffers and write a termination record to the trace. Don't call
    * record_step() after this.
    */
-  void terminate_recording();
+  void terminate_recording(bool do_sigterm_detached);
 
   /**
    * Close trace output without flushing syscall buffers or writing
@@ -193,6 +193,11 @@ public:
    * killed.
    */
   void kill_all_record_tasks();
+
+  /**
+   * Send SIGTERM to all detached tasks and wait for them to finish.
+   */
+  void term_detached_tasks();
 
 private:
   RecordSession(const std::string& exe_path,

--- a/src/test/nested_detach_kill.run
+++ b/src/test/nested_detach_kill.run
@@ -1,0 +1,35 @@
+source `dirname $0`/util.sh
+
+NEST_EXE=nested_detach_wait
+SLEEP_EXE=term_trace_syscall
+SYNC_TOKEN=sleeping
+WAIT_SECS=1
+
+mkdir $workdir/inner
+RECORD_ARGS="--env=_RR_TRACE_DIR=$workdir/inner"
+save_exe "$NEST_EXE"
+save_exe "$SLEEP_EXE"
+touch record.out
+just_record $NEST_EXE-$nonce "$(which rr) record --nested=detach $PWD/$SLEEP_EXE-$nonce" &
+
+echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
+until grep -q $SYNC_TOKEN record.out; do
+    sleep 0
+done
+
+rrpid=$(parent_pid_of $(pidof $NEST_EXE-$nonce))
+echo "  done.  Delivering SIGTERM to $rrpid ..."
+kill -TERM $rrpid
+
+echo "  done."
+
+# Wait for 'record' to actually terminate.
+wait
+
+# Replay outer
+replay
+# Replay inner
+cd $workdir/inner
+workdir=$PWD
+replay
+check_replay_token $SYNC_TOKEN


### PR DESCRIPTION
Generally, when the main task being recorded exits, we proceed to
kill all other tasks. However, if the task was detached, we
intentionally keep it running such that e.g. detached rr recordings
can continue recording (just as such processes would keep running
if the main task exited without rr). However, I don't think this
policy necessarily makes sense when the user sends SIGTERM to rr,
since that is an explicit request to gracefully shut down the
recording. In this situation, I do think it makes sense to propagate
this SIGTERM to any detached tasks, so that any `--nested=detach`
recordings also gracefully exit (and moreover such that all recording
is complete by the time a SIGTERM'd rr exits). If this seems too
agressive as a default behavior, I can do it in our CI scripts instead,
but it seemed like a nice user-friendly default for rr to have.

Requested by @vtjnash