### PR TITLE
Increase timeout for record_replay test.

### DIFF
--- a/src/test/record_replay.run
+++ b/src/test/record_replay.run
@@ -1,4 +1,5 @@
 source `dirname $0`/util.sh
+TIMEOUT=300
 record record_replay_subject$bitness
 just_record rr "--suppress-environment-warnings replay -a $workdir/*-0"
 replay


### PR DESCRIPTION
Running test record_replay takes more than the default 120 seconds
inside a VM at an i5-4210U, even when not running tests in parallel.

Related to #2765

To demonstrate I added some `echo $(date) before ...` statements to the test and got these times.
So the just_record is kind of tight at the default 120 seconds timeout.
This run was non-parallel and without any other load on that machine, except htop.
```
1176: Test command: /bin/bash "source_dir/src/test/record_replay.run" "record_replay" "" "bin_dir" "120"
1176: Test timeout computed to be: 1000
1176: Fri Jan 15 14:02:39 CET 2021 before record record_replay_subject$bitness
1176: Fri Jan 15 14:02:41 CET 2021 before just_record rr "--suppress-environment-warnings replay -a $workdir/*-0"
1176: Fri Jan 15 14:04:40 CET 2021 before replay
1176: Test 'record_replay' PASSED
1176: Fri Jan 15 14:06:12 CET 2021 after check EXIT-SUCCESS
1/1 Test #1176: record_replay ....................   Passed  212.59 sec

$ lscpu 
Architecture:                    i686
CPU op-mode(s):                  32-bit, 64-bit
Model name:                      Intel(R) Core(TM) i5-4210U CPU @ 1.70GHz
$ file bin/rr
bin/rr: ELF 32-bit LSB pie executable, Intel 80386, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=c55bc6e0e881502938674d76fd94f5b5d3e40e13, for GNU/Linux 3.2.0, with debug_info, not stripped
```