### PR TITLE
Avoid xsave call if cpuid does not return that it is supported.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1093,6 +1093,10 @@ bool cpuid_compatible(const vector<CPUIDRecord>& trace_records) {
 }
 
 bool cpu_has_xsave_fip_fdp_quirk() {
+  CPUIDData features = cpuid(CPUID_GETFEATURES, 0);
+  if ((features.ecx & XSAVE_FEATURE_FLAG) == 0) {
+    return false;
+  }
 #if defined(__i386__) || defined(__x86_64__)
   uint64_t xsave_buf[576/sizeof(uint64_t)] __attribute__((aligned(64)));
   xsave_buf[1] = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -193,6 +193,7 @@ enum cpuid_requests {
   CPUID_INTELBRANDSTRINGEND,
 };
 
+const int XSAVE_FEATURE_FLAG = 1 << 26;
 const int OSXSAVE_FEATURE_FLAG = 1 << 27;
 const int AVX_FEATURE_FLAG = 1 << 28;
 const int HLE_FEATURE_FLAG = 1 << 4;


### PR DESCRIPTION
Helps running rr with an Atom Z3735F (Bay Trail-T / Silvermont).

Feature flag description from
"Table 3-10. Feature Information Returned in the ECX Register"
64-ia-32-architectures-software-developer-vol-2a-manual.pdf

----

But still not sure if this is the right way to check for xsave support?
I guess this is kind of related to #1642?

With this CPU, with this patch, a first x86_64 test run completes with "ctest -j$(nproc)" like this:
`91% tests passed, 225 tests failed out of 2545`
And the second with "ctest -j1 --rerun-failed":
`13% tests passed, 196 tests failed out of 225`
