### PR TITLE
Remove bad `atexit` call

### DIFF
--- a/src/log.cc
+++ b/src/log.cc
@@ -118,7 +118,6 @@ static void init_log_globals() {
     log_buffer_size = atoi(buffer);
     if (log_buffer_size) {
       log_buffer = unique_ptr<deque<char>>(new deque<char>());
-      atexit(flush_log_buffer);
     }
   }
 
@@ -347,6 +346,7 @@ CleanFatalOstream::CleanFatalOstream(const char* file, int line,
 CleanFatalOstream::~CleanFatalOstream() {
   cerr << endl;
   flush_log_stream();
+  flush_log_buffer();
   exit(1);
 }
 


### PR DESCRIPTION
We've been turning on RR_LOG_BUFFER by default for our deployed
version of rr in the hopes of catching rare transient rr issues.
However, people have been complaining that rr then dumps the entire
log, even on completed exits. I didn't see this locally, so I was
quite confused, but after some debugging it turns out that the
`atexit` here may or may not actually work, depending on compiler,
linker and C++ standard library versions. The reason is the
sequencing with the destructor of the global log_buffer unique_ptr.
While C++ does guarantee that calls to atexit are properly sequenced
with respect to static initializers, it turns that we are calling
`init_log_globals` at static init time also, so the sequence of
the log_buffer destructor and calls to `atexit` here is undefined.

I'm proposing to just delete the `atexit` call here (while introducing
one before the call to exit in CLEAN_FATAL). We already call this
function explicitly in all the abnormal exit cases which is where
you really want to see the log. I don't think the log in the success
case is ever likely to be all that interesting (and if it is, maybe
the proper thing to do is just to use RR_LOG_FILE rather than
the ring buffer).