### PR TITLE
Avoid crash when recording and emergency gdb attaches.

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -439,7 +439,7 @@ void GdbServer::dispatch_debugger_request(Session& session,
       }
       {
         auto it = memory_files.find(read_req.fd);
-        if (it != memory_files.end()) {
+        if (it != memory_files.end() && timeline.is_running()) {
           // Search our mmap stream for a record that can satisfy this request
           TraceReader tmp_reader(timeline.current_session().trace_reader());
           tmp_reader.rewind();


### PR DESCRIPTION
This might be related to commit c979313cf0.

The crash happens just when attempting to execute the
printed emergency gdb command line.
It crashes because when recording the method
timeline.current_session() returns a null reference on
which the trace_reader() method is called when initializing
the tmp_reader variable.

----

Below the attempt to attach another gdb to the rr process before the emergency gdb command is executed.
```
5.4.0-97-ga8043d16

$ /home/bernhard/data/entwicklung/2021/rr/2021-02-01/x86_64/obj/bin/rr record smb4k
rr: Saving execution to trace directory `/home/bernhard/.local/share/rr/smb4k-1'.
[FATAL /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/record_syscall.cc:5811:rec_process_syscall_arch()] 
 (task 93232 (rec:93232) at time 10054)
 -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result 0 (errno SUCCESS); unknown ETHTOOL command 10
...
Launch gdb with
  gdb '-l' '10000' '-ex' 'set sysroot /' '-ex' 'target extended-remote 127.0.0.1:27696' /usr/bin/smb4k




$ ps aux | grep rr
bernhard   93220  8.5  0.4 795944 73772 pts/7    S+   10:43   0:02 /home/bernhard/data/entwicklung/2021/rr/2021-02-01/x86_64/obj/bin/rr record smb4k


$ gdb -q --pid 93220
(gdb) cont
Continuing.



# in other terminal
$ gdb '-l' '10000' '-ex' 'set sysroot /' '-ex' 'target extended-remote 127.0.0.1:27696' /usr/bin/smb4k



# in gdb for 93220
Program received signal SIGSEGV, Segmentation fault.
0x0000565061d5901a in rr::TraceStream::time (this=0x110) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/TraceStream.h:75
75        FrameTime time() const { return global_time; }
(gdb) bt
#0  0x0000565061d5901a in rr::TraceStream::time (this=0x110) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/TraceStream.h:75
#1  0x0000565061ee8e6b in rr::TraceReader::TraceReader (this=0x7fff6e607f80, other=...) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/TraceStream.cc:1528
#2  0x0000565061d4ee60 in rr::GdbServer::dispatch_debugger_request (this=0x7fff6e608ba0, session=..., req=..., state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/GdbServer.cc:444
#3  0x0000565061d52d33 in rr::GdbServer::process_debugger_requests (this=0x7fff6e608ba0, state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/GdbServer.cc:1126
#4  0x0000565061d56b0f in rr::GdbServer::emergency_debug (t=0x565063c3bf70) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/GdbServer.cc:1843
#5  0x0000565061d847e7 in rr::emergency_debug (t=0x565063c3bf70) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/log.cc:408
#6  0x0000565061d849e8 in rr::EmergencyDebugOstream::~EmergencyDebugOstream (this=0x7fff6e609440, __in_chrg=<optimized out>) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/log.cc:430
#7  0x0000565061df4ca4 in rr::rec_process_syscall_arch<rr::X64Arch> (t=0x565063c3bf70, syscall_state=...) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/record_syscall.cc:5811
#8  0x0000565061de0a11 in rr::rec_process_syscall_internal (t=0x565063c3bf70, arch=rr::x86_64, syscall_state=...) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/record_syscall.cc:6299
#9  0x0000565061de0b5e in rr::rec_process_syscall (t=0x565063c3bf70) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/record_syscall.cc:6319
#10 0x0000565061dc2f61 in rr::RecordSession::syscall_state_changed (this=0x565063c3a2b0, t=0x565063c3bf70, step_state=0x7fff6e60a074) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/RecordSession.cc:1182
#11 0x0000565061dc846f in rr::RecordSession::record_step (this=0x565063c3a2b0) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/RecordSession.cc:2359
#12 0x0000565061dbbbda in rr::record (args=std::vector of length 1, capacity 2 = {...}, flags=...) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/RecordCommand.cc:656
#13 0x0000565061dbc72b in rr::RecordCommand::run (this=0x5650620f6ed0 <rr::RecordCommand::singleton>, args=std::vector of length 1, capacity 2 = {...}) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/RecordCommand.cc:791
#14 0x0000565061f17a51 in main (argc=3, argv=0x7fff6e60a478) at /home/bernhard/data/entwicklung/2021/rr/2021-02-01/rr/src/main.cc:249
```