### PR TITLE
WIP: Add support for ETHTOOL_GLINK and ETHTOOL_GRXRINGS.

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1862,6 +1862,30 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     __kernel_ulong_t __unused4;
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::semid64_ds, struct semid64_ds);
+
+  struct ethtool_rx_flow_spec {
+    uint32_t flow_type;
+    char h_u[52];
+    char h_ext[20];
+    char m_u[52];
+    char m_ext[20];
+    uint64_t ring_cookie;
+    uint32_t location;
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::ethtool_rx_flow_spec, struct ethtool_rx_flow_spec);
+
+  struct ethtool_rxnfc {
+    uint32_t cmd;
+    uint32_t flow_type;
+    uint64_t data;
+    struct ethtool_rx_flow_spec fs;
+    union {
+      uint32_t rule_cnt;
+      uint32_t rss_context;
+    };
+    uint32_t rule_locs[0];
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::ethtool_rxnfc, struct ethtool_rxnfc);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
@@ -2055,6 +2079,30 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
     __kernel_ulong_t __unused4;
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86, struct ::semid64_ds, struct semid64_ds);
+
+  struct __attribute__((packed)) ethtool_rx_flow_spec {
+    uint32_t flow_type;
+    char h_u[52];
+    char h_ext[20];
+    char m_u[52];
+    char m_ext[20];
+    uint64_t ring_cookie;
+    uint32_t location;
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, struct ::ethtool_rx_flow_spec, struct ethtool_rx_flow_spec);
+
+  struct __attribute__((packed)) ethtool_rxnfc {
+    uint32_t cmd;
+    uint32_t flow_type;
+    uint64_t data;
+    struct ethtool_rx_flow_spec fs;
+    union {
+      uint32_t rule_cnt;
+      uint32_t rss_context;
+    };
+    uint32_t rule_locs[0];
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, struct ::ethtool_rxnfc, struct ethtool_rxnfc);
 };
 
 // Archs that inherit Linux's "generic" data structures
@@ -2178,6 +2226,30 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
   };
 
   RR_VERIFY_TYPE_ARCH(SupportedArch::aarch64, struct ::semid64_ds, struct semid64_ds);
+
+  struct ethtool_rx_flow_spec {
+    uint32_t flow_type;
+    char h_u[52];
+    char h_ext[20];
+    char m_u[52];
+    char m_ext[20];
+    uint64_t ring_cookie;
+    uint32_t location;
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::aarch64, struct ::ethtool_rx_flow_spec, struct ethtool_rx_flow_spec);
+
+  struct ethtool_rxnfc {
+    uint32_t cmd;
+    uint32_t flow_type;
+    uint64_t data;
+    struct ethtool_rx_flow_spec fs;
+    union {
+      uint32_t rule_cnt;
+      uint32_t rss_context;
+    };
+    uint32_t rule_locs[0];
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::aarch64, struct ::ethtool_rxnfc, struct ethtool_rxnfc);
 };
 
 #define RR_ARCH_FUNCTION(f, arch, args...)                                     \

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1495,6 +1495,9 @@ template <typename Arch> void prepare_ethtool_ioctl(RecordTask* t, TaskSyscallSt
     case ETHTOOL_GLINK:
       syscall_state.mem_ptr_parameter<ethtool_value>(payload, IN_OUT);
       break;
+    case ETHTOOL_GRXRINGS:
+      syscall_state.mem_ptr_parameter<typename Arch::ethtool_rxnfc>(payload, IN_OUT);
+      break;
     case ETHTOOL_GREGS: {
       auto buf = t->read_mem(buf_ptr.cast<ethtool_regs>(), &ok);
       if (ok) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1492,6 +1492,9 @@ template <typename Arch> void prepare_ethtool_ioctl(RecordTask* t, TaskSyscallSt
     case ETHTOOL_GWOL:
       syscall_state.mem_ptr_parameter<ethtool_wolinfo>(payload, IN_OUT);
       break;
+    case ETHTOOL_GLINK:
+      syscall_state.mem_ptr_parameter<ethtool_value>(payload, IN_OUT);
+      break;
     case ETHTOOL_GREGS: {
       auto buf = t->read_mem(buf_ptr.cast<ethtool_regs>(), &ok);
       if (ok) {

--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -200,6 +200,7 @@ static void ethtool(int sockfd, struct ifreq* req) {
     struct ethtool_perm_addr et;
     uint8_t data[32];
   }* et_perm_addr;
+  struct ethtool_value* et_glink;
   int i;
   int err;
   int ret;
@@ -361,6 +362,12 @@ static void ethtool(int sockfd, struct ifreq* req) {
       atomic_printf("%02x ", et_perm_addr->data[i]);
     }
     atomic_printf("\n");
+  }
+
+  ALLOCATE_GUARD(et_glink, 'r');
+  GENERIC_ETHTOOL_REQUEST_BY_NAME(et_glink, ETHTOOL_GLINK);
+  if (-1 != ret) {
+    atomic_printf("interface is %s\n", et_glink->data ? "up" : "down");
   }
 }
 

--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -201,6 +201,7 @@ static void ethtool(int sockfd, struct ifreq* req) {
     uint8_t data[32];
   }* et_perm_addr;
   struct ethtool_value* et_glink;
+  struct ethtool_rxnfc* et_rxnfc;
   int i;
   int err;
   int ret;
@@ -368,6 +369,12 @@ static void ethtool(int sockfd, struct ifreq* req) {
   GENERIC_ETHTOOL_REQUEST_BY_NAME(et_glink, ETHTOOL_GLINK);
   if (-1 != ret) {
     atomic_printf("interface is %s\n", et_glink->data ? "up" : "down");
+  }
+
+  ALLOCATE_GUARD(et_rxnfc, 's');
+  GENERIC_ETHTOOL_REQUEST_BY_NAME(et_rxnfc, ETHTOOL_GRXRINGS);
+  if (-1 != ret) {
+    atomic_printf("interface has %d RX rings/queues\n", (__u32)et_rxnfc->data);
   }
 }
 


### PR DESCRIPTION
I tried to record a process smb4k that uses the samba library using some unimplemented ethtool features.

Is there a better way to avoid duplication but still express different packings?

Should the aarch64 part be included?
(Cannot test it for several unimplemented parts at aarch64 and maybe unsupported cpu/android kernel ...)
