### PR TITLE
Avoid crash in pthread_mutex_timedlock in nosyscallbuf mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -964,8 +964,6 @@ set(BASIC_TESTS
   pid_ns_reap
   pid_ns_segv
   pidfd
-  pthread_pi_mutex
-  pthread_rwlocks
   poll_sig_race
   ppoll
   prctl
@@ -981,6 +979,9 @@ set(BASIC_TESTS
   protect_rr_fds
   prw
   pthread_condvar_locking
+  pthread_mutex_timedlock
+  pthread_pi_mutex
+  pthread_rwlocks
   x86/ptrace
   ptrace_attach_null_status
   ptrace_attach_running

--- a/src/preload/overrides.c
+++ b/src/preload/overrides.c
@@ -80,6 +80,9 @@ int pthread_mutex_timedlock(pthread_mutex_t* mutex,
   /* No __pthread_mutex_timedlock stub exists, so we have to use the
    * indirect call no matter what.
    */
+  if (!real_pthread_mutex_timedlock) {
+    real_pthread_mutex_timedlock = dlsym(RTLD_NEXT, "pthread_mutex_timedlock");
+  }
   return real_pthread_mutex_timedlock(mutex, abstime);
 }
 

--- a/src/test/pthread_mutex_timedlock.c
+++ b/src/test/pthread_mutex_timedlock.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  pthread_mutexattr_t attr;
+  pthread_mutex_t mutex;
+  struct timespec abstime = {};
+
+  pthread_mutexattr_init(&attr);
+  pthread_mutex_init(&mutex, &attr);
+
+  pthread_mutex_timedlock(&mutex, &abstime);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Currently pthread_mutex_timedlock seems to always crash when recording is done in no-syscallbuf,
because `real_pthread_mutex_timedlock` never gets assigned the real function and still contains a null pointer.

The contained change just tries to do the dlsym call just before, if not yet set.
Would that be a good enough solution?