### PR TITLE
Qt uses rdrnd instead of rdrand in cpu feature exclusion list.

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2193,7 +2193,7 @@ static string lookup_by_path(const string& name) {
     // bit for RDRAND support.
     env.push_back("OPENSSL_ia32cap=~4611686018427387904:~0");
     // Disable Qt's use of RDRAND/RDSEED/RTM
-    env.push_back("QT_NO_CPU_FEATURE=rdrand rdseed rtm");
+    env.push_back("QT_NO_CPU_FEATURE=rdrnd rdseed rtm");
     // Disable systemd's use of RDRAND
     env.push_back("SYSTEMD_RDRAND=0");
   }


### PR DESCRIPTION
Qt used RDRAND for the macro name but value "rdrnd":
  https://github.com/qt/qtbase/commit/0829baf902dbf5982732aa54454178f55b50bdc6#diff-4828ff220a163bad0e8f0c93ecd62de669caf5feb902c436246b328a0d0fbb41R232
  https://github.com/qt/qtbase/commit/cf63b0e1dfc0bf3d11a92c5bf82840ddb6bb22ac#diff-490557b780a00c7df3fbed1f2d0e2e0895360969c68e9339b6b15b85bbbedff9R36
  https://github.com/qt/qtbase/commit/cf63b0e1dfc0bf3d11a92c5bf82840ddb6bb22ac#diff-d1e14cfc882ae33f370a125f43cbccc681f0e6bd68820213a5d5831e973ba84fR13

The rr issue https://github.com/rr-debugger/rr/issues/2214 that introduced the QT_NO_CPU_FEATURE line back then
seems got fixed by rdseed or rtm instead rdrand, therefore got unnoticed until today.

Related to #2804

With this applied I notice no issues any longer with my minimal Qt helloworld or other Qt applications,
even while the Qt feature detection still executes a few rdrand instructions before QT_NO_CPU_FEATURE gets examined.
