### PR TITLE
RFC: Add some functionality from winedbg to enable loading of debug informations for PE images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,8 +620,10 @@ set(RR_GDB_RESOURCES
   64bit-seg.xml
   64bit-sse.xml
   amd64-avx-linux.xml
+  amd64-avx-wine.xml
   amd64-linux.xml
   i386-avx-linux.xml
+  i386-avx-wine.xml
   i386-linux.xml
   aarch64-core.xml
   aarch64-fpu.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,7 @@ set(RR_SOURCES
   src/VirtualPerfCounterMonitor.cc
   src/util.cc
   src/WaitStatus.cc
+  src/Wine.cc
   ${CMAKE_CURRENT_BINARY_DIR}/rr_trace.capnp.c++
   ${BLAKE_ARCH_DIR}/blake2b.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1309,6 +1309,7 @@ set(TESTS_WITH_PROGRAM
   sysconf_onln
   target_fork
   target_process
+  target_wine
   term_nonmain
   term_rr
   term_trace_reset

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -609,6 +609,8 @@ public:
    */
   std::vector<WatchConfig> consume_watchpoint_changes();
 
+  bool consume_executable_mappings_changed();
+
   void set_shm_size(remote_ptr<void> addr, size_t bytes) {
     shm_sizes[addr] = bytes;
   }
@@ -662,6 +664,8 @@ public:
   }
 
   bool syscallbuf_enabled() const { return syscallbuf_enabled_; }
+
+  bool executable_mappings_changed() const { return executable_mappings_changed_; }
 
   /**
    * We'll map a page of memory here into every exec'ed process for our own
@@ -1144,6 +1148,8 @@ private:
    * 0 if no such event has occurred.
    */
   FrameTime first_run_event_;
+
+  bool executable_mappings_changed_;
 
   std::set<remote_ptr<uint16_t>> stap_semaphores;
 

--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -421,7 +421,7 @@ static string read_target_desc(const char* file_name) {
   return ss.str();
 }
 
-static const char* target_description_name(uint32_t cpu_features) {
+static const char* target_description_name(uint32_t cpu_features, bool target_wine) {
   // This doesn't scale, but it's what gdb does...
   switch (cpu_features) {
     case 0:
@@ -429,9 +429,9 @@ static const char* target_description_name(uint32_t cpu_features) {
     case GdbConnection::CPU_X86_64:
       return "amd64-linux.xml";
     case GdbConnection::CPU_AVX:
-      return "i386-avx-linux.xml";
+      return target_wine ? "i386-avx-wine.xml" : "i386-avx-linux.xml";
     case GdbConnection::CPU_X86_64 | GdbConnection::CPU_AVX:
-      return "amd64-avx-linux.xml";
+      return target_wine ? "amd64-avx-wine.xml" : "amd64-avx-linux.xml";
     case GdbConnection::CPU_AARCH64:
       return "aarch64-core.xml";
     default:
@@ -526,7 +526,7 @@ bool GdbConnection::xfer(const char* name, char* args) {
     string target_desc =
         read_target_desc((strcmp(annex, "") && strcmp(annex, "target.xml"))
                              ? annex
-                             : target_description_name(cpu_features_));
+                             : target_description_name(cpu_features_, features().target_wine));
     write_xfer_response(target_desc.c_str(), target_desc.size(), offset, len);
     return false;
   }

--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -142,6 +142,9 @@ enum GdbRequestType {
   DREQ_FILE_PREAD,
   // vFile:close packet, uses params.file_close.
   DREQ_FILE_CLOSE,
+
+  // qXfer:libraries, uses params.library
+  DREQ_GET_LIBRARY_LIST,
 };
 
 enum GdbRestartType {
@@ -245,6 +248,10 @@ struct GdbRequest {
   struct FileClose {
     int fd;
   } file_close_;
+  struct Library {
+    uintptr_t addr;
+    size_t len;
+  } library_;
 
   Mem& mem() {
     DEBUG_ASSERT(type >= DREQ_MEM_FIRST && type <= DREQ_MEM_LAST);
@@ -337,6 +344,14 @@ struct GdbRequest {
   const FileClose& file_close() const {
     DEBUG_ASSERT(type == DREQ_FILE_CLOSE);
     return file_close_;
+  }
+  Library& library() {
+    DEBUG_ASSERT(type == DREQ_GET_LIBRARY_LIST);
+    return library_;
+  }
+  const Library& library() const {
+    DEBUG_ASSERT(type == DREQ_GET_LIBRARY_LIST);
+    return library_;
   }
 
   /**
@@ -486,6 +501,11 @@ public:
    * |len|.
    */
   void reply_get_thread_list(const std::vector<GdbThreadId>& threads);
+
+  /**
+   * Reply to the DREQ_GET_LIBRARY_LIST request.
+   */
+  void reply_get_library_list(Task *t);
 
   /**
    * |ok| is true if the request was successfully applied, false if

--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -368,8 +368,9 @@ struct GdbRequest {
 class GdbConnection {
 public:
   struct Features {
-    Features() : reverse_execution(true) {}
+    Features() : reverse_execution(true), target_wine(false) {}
     bool reverse_execution;
+    bool target_wine;
   };
 
   /**

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -772,6 +772,10 @@ void GdbServer::dispatch_debugger_request(Session& session,
       dbg->reply_tls_addr(ok, address);
       return;
     }
+    case DREQ_GET_LIBRARY_LIST: {
+      dbg->reply_get_library_list(target);
+      return;
+    }
     default:
       FATAL() << "Unknown debugger request " << req.type;
   }

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -922,6 +922,13 @@ void GdbServer::maybe_notify_stop(const GdbRequest& req,
   remote_ptr<void> watch_addr;
   char watch[1024];
   watch[0] = '\0';
+  if (dbg->features().target_wine && break_status.executable_mappings_changed) {
+    snprintf(watch, sizeof(watch) - 1, "library:;");
+    do_stop = true;
+    memset(&stop_siginfo, 0, sizeof(stop_siginfo));
+    stop_siginfo.si_signo = SIGTRAP;
+    LOG(debug) << "Notify GDB about a shared library change";
+  }
   if (!break_status.watchpoints_hit.empty()) {
     do_stop = true;
     memset(&stop_siginfo, 0, sizeof(stop_siginfo));

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -30,13 +30,15 @@ class GdbServer {
 
 public:
   struct Target {
-    Target() : pid(0), require_exec(false), event(0) {}
+    Target() : pid(0), require_exec(false), event(0), target_wine(false) {}
     // Target process to debug, or 0 to just debug the first process
     pid_t pid;
     // If true, wait for the target process to exec() before attaching debugger
     bool require_exec;
     // Wait until at least 'event' has elapsed before attaching
     FrameTime event;
+
+    bool target_wine;
   };
 
   struct ConnectionFlags {
@@ -87,7 +89,8 @@ public:
   static void launch_gdb(ScopedFd& params_pipe_fd,
                          const std::string& gdb_binary_file_path,
                          const std::vector<std::string>& gdb_options,
-                         bool serve_files);
+                         bool serve_files,
+                         bool target_wine);
 
   /**
    * Start a debugging connection for |t| and return when there are no

--- a/src/PE.h
+++ b/src/PE.h
@@ -1,0 +1,61 @@
+/*
+Following structure definitions got rewritten with looking at
+this (MIT like) "Boost Software License, Version 1.0" licensed file:
+    https://github.com/boostorg/dll/blob/develop/include/boost/dll/detail/pe_info.hpp
+
+The actual size informations were retrieved by following gdb session:
+  $ cat test.cpp
+  #include <boost/dll/detail/pe_info.hpp>
+  int main() {
+    std::ifstream ifs;
+    boost::dll::detail::pe_info32 a; a.parsing_supported(ifs); a.sections(ifs);
+    boost::dll::detail::pe_info64 b; b.parsing_supported(ifs); b.sections(ifs);
+  }
+  $ g++ -g test.cpp
+  $ gdb -q --args a.out
+      b boost::dll::detail::pe_info32::parsing_supported
+      b boost::dll::detail::pe_info64::parsing_supported
+      run
+      ptype /o dos_t
+      ptype /o header_t
+      ptype /o section_t
+
+Not used, but another source could be this MIT licensed repository:
+    https://github.com/microsoft/xlang/blob/master/src/library/impl/meta_reader/pe.h
+*/
+
+#ifndef WINE_H_
+#define WINE_H_
+
+struct __attribute__((packed)) IMAGE_DOS_HEADER_ {
+    uint16_t e_magic;
+    char unused[58];
+    uint32_t e_lfanew;
+};
+
+struct __attribute__((packed)) IMAGE_FILE_HEADER_ {
+    char unused1[2];
+    uint16_t NumberOfSections;
+    char unused2[12];
+    uint16_t SizeOfOptionalHeader;
+    char unused3[2];
+};
+
+struct __attribute__((packed)) IMAGE_OPTIONAL_HEADER_ {
+    uint32_t Magic;
+    char unused[236];
+};
+
+struct __attribute__((packed)) IMAGE_NT_HEADERS_ {
+    uint32_t Signature;
+    struct IMAGE_FILE_HEADER_ FileHeader;
+    struct IMAGE_OPTIONAL_HEADER_ OptionalHeader;
+};
+
+struct __attribute__((packed)) IMAGE_SECTION_HEADER_ {
+    char unused1[12];
+    uint32_t VirtualAddress;
+    char unused2[24];
+};
+
+#endif /* WINE_H_ */

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1832,6 +1832,7 @@ ReplayResult ReplaySession::replay_step(const StepConstraints& constraints) {
     debug_memory(t);
 
     check_for_watchpoint_changes(t, result.break_status);
+    check_for_executable_mappings_changed(t, result.break_status);
     check_approaching_ticks_target(t, constraints, result.break_status);
   }
 

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -337,6 +337,11 @@ void Session::check_for_watchpoint_changes(Task* t, BreakStatus& break_status) {
   break_status.watchpoints_hit = t->vm()->consume_watchpoint_changes();
 }
 
+void Session::check_for_executable_mappings_changed(Task* t, BreakStatus& break_status) {
+  assert_fully_initialized();
+  break_status.executable_mappings_changed = t->vm()->consume_executable_mappings_changed();
+}
+
 void Session::assert_fully_initialized() const {
   DEBUG_ASSERT(!clone_completion && "Session not fully initialized");
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -39,7 +39,8 @@ struct BreakStatus {
         breakpoint_hit(false),
         singlestep_complete(false),
         approaching_ticks_target(false),
-        task_exit(false) {}
+        task_exit(false),
+        executable_mappings_changed(false) {}
   BreakStatus(const BreakStatus& other)
       : task(other.task),
         watchpoints_hit(other.watchpoints_hit),
@@ -49,7 +50,8 @@ struct BreakStatus {
         breakpoint_hit(other.breakpoint_hit),
         singlestep_complete(other.singlestep_complete),
         approaching_ticks_target(other.approaching_ticks_target),
-        task_exit(other.task_exit) {}
+        task_exit(other.task_exit),
+        executable_mappings_changed(other.executable_mappings_changed) {}
   const BreakStatus& operator=(const BreakStatus& other) {
     task = other.task;
     watchpoints_hit = other.watchpoints_hit;
@@ -60,6 +62,7 @@ struct BreakStatus {
     singlestep_complete = other.singlestep_complete;
     approaching_ticks_target = other.approaching_ticks_target;
     task_exit = other.task_exit;
+    executable_mappings_changed = other.executable_mappings_changed;
     return *this;
   }
 
@@ -81,6 +84,8 @@ struct BreakStatus {
   bool approaching_ticks_target;
   // True when we stopped because |task| is about to exit.
   bool task_exit;
+  // True when there were executable mapping changes to notify gdb.
+  bool executable_mappings_changed;
 
   // True when we stopped because we hit a software or hardware breakpoint at
   // |task|'s current ip().
@@ -377,6 +382,8 @@ protected:
 
   BreakStatus diagnose_debugger_trap(Task* t, RunCommand run_command);
   void check_for_watchpoint_changes(Task* t, BreakStatus& break_status);
+
+  void check_for_executable_mappings_changed(Task* t, BreakStatus& break_status);
 
   void copy_state_to(Session& dest, EmuFs& emu_fs, EmuFs& dest_emu_fs);
 

--- a/src/Wine.cc
+++ b/src/Wine.cc
@@ -1,0 +1,160 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <algorithm>
+#include <cstdint>
+#include <list>
+#include <sstream>
+#include <string>
+
+#include "AddressSpace.h"
+#include "log.h"
+#include "PE.h"
+#include "Task.h"
+
+using namespace std;
+
+namespace rr {
+
+string create_library_response_from_mappings(Task *t) {
+
+  // create an own list of the current mappings
+  list<KernelMapping> mapping_list;
+  for (KernelMapIterator it(t); !it.at_end(); ++it) {
+    auto km = it.current();
+    if (km.fsname().substr(0, 7) == "/memfd:") {
+      continue;
+    }
+    if (km.is_vdso() || km.is_heap() || km.is_stack() || km.is_vvar() || km.is_vsyscall()) {
+      continue;
+    }
+    LOG(debug) << "Possible mapping for GDB reply: " << km;
+    mapping_list.push_back(km);
+  }
+
+  struct library {
+    library() : has_exec(false) {};
+    vector<remote_ptr<void>> segments;
+    bool has_exec;
+  };
+  map<string, library> libraries;
+
+  // iterate through the mappings and search for PE libraries
+  // see wine, packet_query_libraries_cb
+  char buf[0x400];
+  for (auto it = mapping_list.begin(); it != mapping_list.end(); it++) {
+    auto km = *it;
+    bool ok = true;
+    t->read_bytes_helper(km.start(), sizeof(buf), buf, &ok);
+    if (!ok) {
+      continue;
+    }
+
+    struct IMAGE_DOS_HEADER_* dosheader = reinterpret_cast<struct IMAGE_DOS_HEADER_*>(buf);
+    if (memcmp(&dosheader->e_magic, "MZ", 2) != 0 ||
+        dosheader->e_lfanew >= sizeof(buf)-4)
+    {
+      continue;
+    }
+
+    struct IMAGE_NT_HEADERS_* ntheader = reinterpret_cast<struct IMAGE_NT_HEADERS_*>(buf + dosheader->e_lfanew);
+    if (memcmp(&ntheader->Signature, "PE\0\0", 4) != 0) {
+      continue;
+    }
+
+    if (ntheader->OptionalHeader.Magic != 0x10b /*32-bit*/ &&
+        ntheader->OptionalHeader.Magic != 0x20b /*64-bit*/)
+    {
+      continue;
+    }
+
+    vector<remote_ptr<void>> segments;
+    struct IMAGE_SECTION_HEADER_* sec = reinterpret_cast<struct IMAGE_SECTION_HEADER_*>
+        (((char*)&ntheader->OptionalHeader) + ntheader->FileHeader.SizeOfOptionalHeader);
+    int number_of_sections = ntheader->FileHeader.NumberOfSections;
+    for (int i = 0; sec && i < std::max(number_of_sections, 1); ++i) {
+      struct IMAGE_SECTION_HEADER_* seci = sec + i;
+      if (reinterpret_cast<char*>(seci) + sizeof(*seci) > buf + sizeof(buf)) {
+        break;
+      }
+      segments.push_back(km.start() + seci->VirtualAddress);
+    }
+
+    string name = km.fsname();
+
+    // If the mapping with the PE signature has no name assigned search the other segments for a name.
+    for (auto it2 = mapping_list.begin(); name.empty() && it2 != mapping_list.end(); it2++) {
+      if (find(segments.begin(), segments.end(), it2->start()) != segments.end()) {
+        if (!it2->fsname().empty()) {
+          name = it2->fsname();
+        }
+      }
+    }
+
+    // we found no name
+    if (name.empty()) {
+      continue;
+    }
+
+    // e.g. gdi32.so is prepared by wine to be found as PE image, but gdb does not like it.
+    if (name.substr(name.length() - 3, 3) == ".so") {
+      continue;
+    }
+
+    libraries[name].segments = segments;
+    libraries[name].has_exec = true;
+  }
+
+  // remove mappings related to PE libraries
+  for (auto m = mapping_list.begin(); m != mapping_list.end(); ) {
+    bool del = false;
+    for (auto lib : libraries) {
+      if (m->fsname() == lib.first) {
+        del = true;
+      }
+      if (!del) {
+        for (auto seg : lib.second.segments) {
+          if (seg == m->start()) {
+            del = true;
+          }
+        }
+      }
+    }
+    if (del) {
+      m = mapping_list.erase(m);
+    } else {
+      m++;
+    }
+  }
+
+  // search remaining for regular shared objects
+  for (auto it = mapping_list.begin(); it != mapping_list.end(); it++) {
+    auto km = *it;
+    string name = km.fsname();
+    if (!name.empty()) {
+      libraries[name].segments.push_back(km.start());
+      if (km.prot() & PROT_EXEC) {
+        libraries[name].has_exec = true;
+      }
+    }
+  }
+
+  // now create the output string from what we found
+  stringstream sstr;
+  sstr << "<library-list>";
+  sstr << hex;
+
+  for (auto lib : libraries) {
+    if (lib.second.has_exec) {
+      sstr << "<library name=\"" << lib.first << "\">";
+      for (auto seg : lib.second.segments) {
+        sstr << "<segment address=\"" << seg << "\"/>";
+      }
+      sstr << "</library>";
+    }
+  }
+
+  sstr << "</library-list>";
+  return sstr.str();
+}
+
+} // namespace rr

--- a/src/test/target_wine.c
+++ b/src/test/target_wine.c
@@ -1,0 +1,15 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+#define _FILE_OFFSET_BITS 64
+
+#include "util.h"
+#include <stdlib.h>
+
+static __attribute__((noinline)) void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+int main(void) {
+  breakpoint();
+  return 0;
+}

--- a/src/test/target_wine.py
+++ b/src/test/target_wine.py
@@ -1,0 +1,8 @@
+from util import *
+
+send_gdb('break breakpoint')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+ok()

--- a/src/test/target_wine.run
+++ b/src/test/target_wine.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record target_wine$bitness
+debug target_wine --target-wine

--- a/third-party/gdb/amd64-avx-wine.xml
+++ b/third-party/gdb/amd64-avx-wine.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2010-2014 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- AMD64 with AVX - Includes Linux-only special "register".  -->
+<!-- Copy of amd64-avx-linux.xml, just modified to convince gdb to load libraries through gdbserver -->
+
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target>
+  <architecture>i386:x86-64</architecture>
+  <osabi>GNU/Linux</osabi>
+  <xi:include href="64bit-core.xml"/>
+  <xi:include href="64bit-sse.xml"/>
+  <feature name="org.gnu.gdb.i386.linux">
+    <reg name="orig_rax_renamed" bitsize="64" type="int" regnum="57"/>
+  </feature>
+  <xi:include href="64bit-seg.xml"/>
+  <xi:include href="64bit-avx.xml"/>
+</target>

--- a/third-party/gdb/i386-avx-wine.xml
+++ b/third-party/gdb/i386-avx-wine.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2010-2014 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- I386 with AVX- Includes Linux-only special "register".  -->
+<!-- Copy of i386-avx-linux.xml, just modified to convince gdb to load libraries through gdbserver -->
+
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target>
+  <architecture>i386</architecture>
+  <osabi>GNU/Linux</osabi>
+  <xi:include href="32bit-core.xml"/>
+  <xi:include href="32bit-sse.xml"/>
+<feature name="org.gnu.gdb.i386.linux">
+  <reg name="orig_eax_renamed" bitsize="32" type="int" regnum="41"/>
+</feature>
+  <xi:include href="32bit-avx.xml"/>
+</target>


### PR DESCRIPTION
Since wine switched to use mostly PE images for their dlls the replay gdb is
not able ro load the symbol informations for these anymore.

This patches do basically the same as 'winedbg --gdb' does, mostly tell gdb to ask rr
to get the library list instead of inspecting the linux dynamic loader by himself.

Currently recording should behave exactly the same as without these patches.
One note: the whole wine process tree needs to be in the record, or something like in 2805 can happen.

My replayings were done by 'rr replay --target-wine -p <PID> -g <time>' to replay
the right process (list with 'rr ps') and testing some values for -g to land when wine
finished process creating. This is kind of try and error currently.

I tested some combinations of 32- and 64-bit rr and wine builds.
One thing I found is, a 'finish' in the __wine_syscall_dispatcher frame runs until the end of the recording.
But can be worked around by single stepping some instructions out with 'stepi'.

What would be a proper place for the structs IMAGE_DOS_HEADER and related defines?

Previous discussion in #2751.
What do you think?