### PR TITLE
Shove any .note.gnu.property sections up into the header along with the other notes

### DIFF
--- a/src/preload/rr_page.ld
+++ b/src/preload/rr_page.ld
@@ -13,6 +13,7 @@ SECTIONS
   .eh_frame_hdr   : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } :header :eh_frame
   .eh_frame       : { KEEP (*(.eh_frame)) *(.eh_frame.*) } :header :eh_frame
   .note.gnu.build-id  : { *(.note.gnu.build-id) } :header :note
+  .note.gnu.property : { *(.note.gnu.property) } :header :note
   .hash           : { *(.hash) } :header
   .gnu.hash       : { *(.gnu.hash) } :header
   .dynsym         : { *(.dynsym) } :header


### PR DESCRIPTION
@sefeng reported an issue where this was dislocating .vdso.text with a .note.gnu.property section with gcc 10.2 and ld 2.36.

This fixes his immediate problem, but this is still not robust to other .note sections (or perhaps even other types of sections). Any thoughts @rocallahan @Keno 