### PR TITLE
PerfCounters: refer to our wiki rather than `perf record`

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -214,8 +214,17 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
                  "enabled? Try 'perf record'.";
     }
     if (errno == ENOENT) {
+      /*
+       * Note: PERF_COUNT_HW_CPU_CYCLES is known to have a software replacement
+       * counter that could be used. But we do not use that because usually
+       * PERF_COUNT_HW_CPU_CYCLES is the best supported hw counter, and we have yet
+       * to see a system, which would meet all the other requirements in terms of hw
+       * counters and yet would lack PERF_COUNT_HW_CPU_CYCLES.
+       */
       FATAL() << "Unable to open performance counter with 'perf_event_open'; "
-                 "are perf events enabled? Try 'perf record'.";
+                 "are perf events enabled? Please check out "
+                 "https://github.com/rr-debugger/rr/wiki/Will-rr-work-on-my-system%3F "
+                 "to make sure your system meets requirements.";
     }
     FATAL() << "Failed to initialize counter";
   }


### PR DESCRIPTION
`perf record` has lower requirements than `rr` does, so the fact it works does not mean `rr` would. Let's refer instead to the Wiki page which has the tests to check whether current system meets rr requirements.

The related discussion can be seen here https://github.com/rr-debugger/rr/issues/2815#issuecomment-784909689

Fixes: https://github.com/rr-debugger/rr/issues/2815
Supersedes: https://github.com/rr-debugger/rr/pull/2816
