### PR TITLE
memfd_create_shared_huge test: Assert that mmap didn't fail

### DIFF
--- a/src/test/memfd_create_shared_huge.c
+++ b/src/test/memfd_create_shared_huge.c
@@ -28,6 +28,7 @@ int main(void) {
       *(uint32_t*)p1 = 0xdeadbeef;
       /* Map it again */
       p2 = mmap(0, MEMFD_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+      test_assert(p2 != MAP_FAILED);
       test_assert(*(uint32_t*)p2 == 0xdeadbeef);
       test_assert(0 == close(fd));
     }


### PR DESCRIPTION
Minor improvement to the memfd_create_shared_huge test.

(I actually was running into a mysterious SIGSEGV error when running this test in 32 bit. Adding this assert helped me figure out that the mmap was failing and the SIGSEGV was due to `p2` being accessed in the `test_assert`. Of course it turns out that running this test itself in 32 bit does not make sense due to lack of address space and @khuey fixed it in his subsequent commit fe0659f8dd67659acf5bca. However I think its still a good idea to add this test_assert)