### PR TITLE
Fix missing KEYCTL_GET_PERSISTENT operation for keyctl syscall.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4456,6 +4456,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         case KEYCTL_ASSUME_AUTHORITY:
         case KEYCTL_SESSION_TO_PARENT:
         case KEYCTL_INVALIDATE:
+        case KEYCTL_GET_PERSISTENT:
           break;
 
         case KEYCTL_DESCRIBE:


### PR DESCRIPTION
This fixes crash when running:
$ rr keyctl get_persistent @p
