### PR TITLE
Workaround missing rseq support by returning ENOSYS.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3423,6 +3423,16 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
 // All the regular syscalls are handled here.
 #include "SyscallRecordCase.generated"
 
+    case Arch::rseq: {
+      // Hijack rseq and do a noop syscall instead, as a workaround.
+      // Will restore original syscall in postprocessing with ENOSYS.
+      // See https://github.com/rr-debugger/rr/issues/2277.
+      Registers r = t->regs();
+      r.set_original_syscallno(Arch::gettid);
+      t->set_regs(r);
+      return PREVENT_SWITCH;
+    }
+
     case Arch::splice: {
       syscall_state.reg_parameter<loff_t>(2, IN_OUT);
       syscall_state.reg_parameter<loff_t>(4, IN_OUT);
@@ -5969,6 +5979,15 @@ static void rec_process_syscall_arch(RecordTask* t,
                     attr));
       }
       break;
+
+    case Arch::rseq: {
+      // Restore hijacked call. See preprocessing.
+      Registers r = t->regs();
+      r.set_original_syscallno(Arch::rseq);
+      r.set_syscall_result(-ENOSYS);
+      t->set_regs(r);
+      break;
+    }
 
     case Arch::connect: {
       // Restore the registers that we may have altered.

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1682,7 +1682,7 @@ pkey_alloc = UnsupportedSyscall(x86=381, x64=330, generic=289)
 pkey_free = UnsupportedSyscall(x86=382, x64=331, generic=290)
 statx = EmulatedSyscall(x86=383, x64=332, generic=291, arg5="typename Arch::statx_struct")
 io_pgetevents = UnsupportedSyscall(x86=385, x64=333, generic=292)
-rseq = UnsupportedSyscall(x86=386, x64=334, generic=293)
+rseq = IrregularEmulatedSyscall(x86=386, x64=334, generic=293)
 
 clock_gettime64 = EmulatedSyscall(x86=403, arg2="typename Arch::Arch64::timespec")
 clock_settime64 = UnsupportedSyscall(x86=404)

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1682,6 +1682,8 @@ pkey_alloc = UnsupportedSyscall(x86=381, x64=330, generic=289)
 pkey_free = UnsupportedSyscall(x86=382, x64=331, generic=290)
 statx = EmulatedSyscall(x86=383, x64=332, generic=291, arg5="typename Arch::statx_struct")
 io_pgetevents = UnsupportedSyscall(x86=385, x64=333, generic=292)
+# Note: just returns ENOSYS as a workaround for now.
+# See https://github.com/rr-debugger/rr/issues/2277.
 rseq = IrregularEmulatedSyscall(x86=386, x64=334, generic=293)
 
 clock_gettime64 = EmulatedSyscall(x86=403, arg2="typename Arch::Arch64::timespec")


### PR DESCRIPTION
This change provides a workaround for #2277 - as suggested on the thread, just returns ENOSYS to indicate unsupported call. Not sure what the best way to do this, tried to replicate the `connect` hijacking setup. Please correct if the approach is wrong.

A test is missing yet - what would it look like? Try to execute `rseq`, verify the ENOSYS return value?

With this change, I could run `envoyproxy` through `rr`.