### PR TITLE
GdbServer: handle task switching during diversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1169,6 +1169,7 @@ set(BASIC_CPP_TESTS
 # Alphabetical, please.
 set(TESTS_WITH_PROGRAM
   abort_nonmain
+  alternate_thread_diversion
   args
   async_kill_with_threads
   async_kill_with_threads_main_running

--- a/src/test/alternate_thread_diversion.c
+++ b/src/test/alternate_thread_diversion.c
@@ -1,0 +1,23 @@
+#include "util.h"
+
+static volatile int value = 0;
+
+__attribute__((used)) static int get_value(void) { return value; }
+
+__attribute__((noinline)) static void break_here(void) { __asm__(""); }
+
+static void* thread_func(void* arg) {
+  (void)arg;
+
+  value = 1;
+  break_here();
+
+  return NULL;
+}
+
+int main(void) {
+  pthread_t thread_info;
+  pthread_create(&thread_info, NULL, &thread_func, NULL);
+  pthread_join(thread_info, NULL);
+  return 0;
+}

--- a/src/test/alternate_thread_diversion.py
+++ b/src/test/alternate_thread_diversion.py
@@ -1,0 +1,21 @@
+from util import *
+
+send_gdb('b break_here')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+send_gdb('info threads')
+expect_gdb('  1    Thread')
+expect_gdb('\\* 2    Thread')
+
+send_gdb('thread 1')
+expect_gdb('Switching to thread 1')
+send_gdb('set scheduler-locking on')
+send_gdb('call get_value()')
+expect_gdb('1')
+send_gdb('set scheduler-locking off')
+send_gdb('c')
+expect_gdb('SIGKILL')
+
+ok()

--- a/src/test/alternate_thread_diversion.run
+++ b/src/test/alternate_thread_diversion.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh
+debug_test


### PR DESCRIPTION
This more-or-less fixes #2836, but there's a bit of a usability snag: this only really makes sense with `scheduler-locking` set to `on`. Otherwise, GDB asks us to resume all threads and we end up just replaying the task that was stopped in the diversion session (which is pretty much the same as the behaviour currently).

I can't think of a way in which `scheduler-locking` is set to anything but `on` makes sense in this context (funnily enough, the default is `replay` which is equivalent to `on` when using GDB's built-in trace replay machinery) so it seems sensible to change rr's default similarly to the handling of `unwindonsignal`. Unfortunately this triggers a bug in GDB, so until there's fixes upstream the user just has to be careful about surrounding alternate-thread diversions with `set scheduler-locking on` and `set scheduler-locking off`.