### PR TITLE
add support for TIOC{G,S}SERIAL ioctls

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -20,6 +20,7 @@
 #include <linux/net.h>
 #include <linux/netfilter/x_tables.h>
 #include <linux/sem.h>
+#include <linux/serial.h>
 #include <linux/shm.h>
 #include <linux/sockios.h>
 #include <linux/sysctl.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -622,6 +622,28 @@ struct BaseArch : public wordsize,
   };
   RR_VERIFY_TYPE(termio);
 
+  struct serial_struct {
+    signed_int type;
+    signed_int line;
+    unsigned_int port;
+    signed_int irq;
+    signed_int flags;
+    signed_int xmit_fifo_size;
+    signed_int custom_divisor;
+    signed_int baud_base;
+    unsigned_short close_delay;
+    char io_type;
+    char reserved_char[1];
+    signed_int hub6;
+    unsigned_short closing_wait;
+    unsigned_short closing_wait2;
+    ptr<unsigned char> iomem_base;
+    unsigned_short iomem_reg_shift;
+    unsigned_int port_high;
+    unsigned_long iomap_base;
+  };
+  RR_VERIFY_TYPE(serial_struct);
+
   struct winsize {
     unsigned_short ws_row;
     unsigned_short ws_col;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1745,6 +1745,12 @@ static Switchable prepare_ioctl(RecordTask* t,
       syscall_state.reg_parameter<typename Arch::pid_t>(3);
       return PREVENT_SWITCH;
 
+    case TIOCGSERIAL:
+      syscall_state.reg_parameter<typename Arch::serial_struct>(3);
+      return PREVENT_SWITCH;
+    case TIOCSSERIAL:
+      return PREVENT_SWITCH;
+
     case SNDRV_CTL_IOCTL_PVERSION:
       syscall_state.reg_parameter<int>(3);
       return PREVENT_SWITCH;


### PR DESCRIPTION
I haven't written a test for this since AFAICT there's no userspace API for creating virtual serial ports on Linux (the PTY driver doesn't implement these ioctls)