### PR TITLE
Suggest /etc/sysctl.d instead of /etc/sysctl.conf

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2142,8 +2142,9 @@ static string lookup_by_path(const string& name) {
           fprintf(stderr,
                   "rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is %d.\n"
                   "Change it to 1, or use 'rr record -n' (slow).\n"
-                  "Consider putting 'kernel.perf_event_paranoid = 1' in /etc/sysctl.conf.\n"
-                  "See 'man 8 sysctl', 'man 5 sysctl.d' and 'man 5 sysctl.conf' for more details.\n",
+                  "Consider putting 'kernel.perf_event_paranoid = 1' in /etc/sysctl.d/10-rr.conf.\n"
+                  "See 'man 8 sysctl', 'man 5 sysctl.d' (systemd systems)\n"
+                  "and 'man 5 sysctl.conf' (non-systemd systems) for more details.\n",
                   val);
           exit(1);
         }


### PR DESCRIPTION
On systemd systems, the latter is silently and confusingly ignored (see,
approximately, https://github.com/systemd/systemd/issues/12791). The
former is compatible with non-systemd systems according to man 5
sysctl.conf, so we should suggest it instead as it works everywhere.