### PR TITLE
Add microarch id for Zen 3 Cezanne APUs

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -89,6 +89,7 @@ static CpuMicroarch compute_cpu_microarch() {
       }
       break;
     case 0x20f10: // Vermeer (Zen 3)
+    case 0x50f00: // Cezanne (Zen 3)
       if (ext_family == 0xa) {
         return AMDZen;
       }


### PR DESCRIPTION
Confirmed to match on a laptop with an AMD Ryzen 7 5800HS, I expect it will also cover other 5000 H-, U- and G-series APUs.

(I haven’t actually done anything *useful* with it yet—I’m only just about to start playing with rr—but at least it *matches*.)