### PR TITLE
Make sure maybe_intercept_mem_request() does not write to invalid memory

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -338,6 +338,7 @@ static bool is_in_patch_stubs(Task* t, remote_code_ptr ip) {
 
 void GdbServer::maybe_intercept_mem_request(Task* target, const GdbRequest& req,
                                             vector<uint8_t>* result) {
+  DEBUG_ASSERT(req.mem_.len >= result->size());
   /* Crazy hack!
    * When gdb tries to read the word at the top of the stack, and we're in our
    * dynamically-generated stub code, tell it the value is zero, so that gdb's
@@ -348,7 +349,7 @@ void GdbServer::maybe_intercept_mem_request(Task* target, const GdbRequest& req,
    */
   size_t size = word_size(target->arch());
   if (target->regs().sp().as_int() >= req.mem_.addr &&
-      target->regs().sp().as_int() + size <= req.mem_.addr + req.mem_.len &&
+      target->regs().sp().as_int() + size <= req.mem_.addr + result->size() &&
       is_in_patch_stubs(target, target->ip())) {
     memset(result->data() + target->regs().sp().as_int() - req.mem_.addr, 0,
            size);


### PR DESCRIPTION
When dispatch_debugger_request() handles the DREQ_GET_MEM request,
gdb can ask for a memory range that is invalid or partially valid.
That is why a read_bytes_fallible() call is made. Depending on the
actually number of bytes read, the `mem` buffer is resized. It
could, for instance, be resized to 0 length. Then a maybe_intercept_mem_request()
call is made. This function will always assume the memory range
it needs to inspect (for writing a 0 word) is req.mem_.len long.
However that is wrong -- it should be the resized length of the
buffer into which the read_bytes_fallible() call mentioned above
wrote to.