### PR TITLE
Fix 32-bit build by adding cast.

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1667,7 +1667,7 @@ ssize_t RecordTask::record_remote_fallible(remote_ptr<void> addr,
     uintptr_t bytes = min(uintptr_t(4*1024*1024), num_bytes - offset);
     if (hole_iter != holes.end()) {
       ASSERT(this, hole_iter->offset > offset);
-      bytes = min(bytes, hole_iter->offset - offset);
+      bytes = min(bytes, uintptr_t(hole_iter->offset) - offset);
     }
     if (record_remote_by_local_map(addr + offset, bytes)) {
       offset += bytes;


### PR DESCRIPTION
Related to commit 5c6e992b2ad1.
----
error: invalid cast from type ‘uintptr_t’ {aka ‘unsigned int’} to type ‘uint64_t’ {aka ‘long long unsigned int’}