### PR TITLE
Add support for ioctl FS_IOC_FIEMAP.

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <linux/capability.h>
 #include <linux/ethtool.h>
+#include <linux/fiemap.h>
 #include <linux/filter.h>
 #include <linux/futex.h>
 #include <linux/if_bonding.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1708,6 +1708,26 @@ struct BaseArch : public wordsize,
     __u32 exe_fd;
   };
   RR_VERIFY_TYPE(prctl_mm_map);
+
+  struct fiemap_extent {
+    __u64 fe_logical;
+    __u64 fe_physical;
+    __u64 fe_length;
+    __u64 fe_reserved64[2];
+    __u32 fe_flags;
+    __u32 fe_reserved[3];
+  };
+  RR_VERIFY_TYPE(fiemap_extent);
+  struct fiemap {
+    __u64 fm_start;
+    __u64 fm_length;
+    __u32 fm_flags;
+    __u32 fm_mapped_extents;
+    __u32 fm_extent_count;
+    __u32 fm_reserved;
+    struct fiemap_extent fm_extents[0];
+  };
+  RR_VERIFY_TYPE(fiemap);
 };
 
 struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -9,6 +9,7 @@
 #include <linux/capability.h>
 #include <linux/elf.h>
 #include <linux/ethtool.h>
+#include <linux/fiemap.h>
 #include <linux/fs.h>
 #include <linux/futex.h>
 #include <linux/hidraw.h>
@@ -2002,6 +2003,14 @@ static Switchable prepare_ioctl(RecordTask* t,
       auto args = t->read_mem(argsp);
       syscall_state.mem_ptr_parameter(REMOTE_PTR_FIELD(argsp, data),
                                       args.wLength);
+      return PREVENT_SWITCH;
+    }
+    case IOCTL_MASK_SIZE(FS_IOC_FIEMAP): {
+      auto argsp = remote_ptr<typename Arch::fiemap>(t->regs().arg3());
+      auto args = t->read_mem(argsp);
+      size = sizeof(typename Arch::fiemap) +
+             sizeof(typename Arch::fiemap_extent) * args.fm_extent_count;
+      syscall_state.reg_parameter(3, size, IN_OUT);
       return PREVENT_SWITCH;
     }
   }

--- a/src/test/ioctl_fs.c
+++ b/src/test/ioctl_fs.c
@@ -6,6 +6,9 @@ int main(void) {
   int fd = open("dummy.txt", O_RDWR | O_CREAT, 0600);
   long version;
   long flags;
+  char filebuf[4096] = {};
+  char fmbuf[4096] = {};
+  struct fiemap *fm;
   int ret;
 
   test_assert(fd >= 0);
@@ -20,6 +23,24 @@ int main(void) {
     test_assert(errno == ENOTTY);
   } else {
     atomic_printf("flags=%lx\n", flags);
+  }
+
+  test_assert(sizeof(filebuf) == write(fd, &filebuf, sizeof(filebuf)));
+  fm = (struct fiemap*)fmbuf;
+  fm->fm_start = 0;
+  fm->fm_flags = 0;
+  fm->fm_extent_count = (sizeof(fmbuf) - offsetof(struct fiemap, fm_extents)) / sizeof(fm->fm_extents[0]);
+  fm->fm_length = FIEMAP_MAX_OFFSET - fm->fm_start;
+  ret = ioctl(fd, FS_IOC_FIEMAP, fm);
+  if (ret < 0) {
+    test_assert(errno == ENOTTY);
+  } else {
+    atomic_printf("fm->fm_mapped_extents=%d\n", fm->fm_mapped_extents);
+    for (unsigned int i=0; i < fm->fm_mapped_extents; i++) {
+      struct fiemap_extent* fe = fm->fm_extents + i;
+      atomic_printf("i=%d fe_logical=0x%llx fe_physical=0x%llx fe_length=0x%llx fe_flags=0x%x\n", i,
+                    fe->fe_logical, fe->fe_physical, fe->fe_length, fe->fe_flags);
+    }
   }
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -30,6 +30,7 @@
 #include <linux/audit.h>
 #include <linux/capability.h>
 #include <linux/ethtool.h>
+#include <linux/fiemap.h>
 #include <linux/filter.h>
 #include <linux/fs.h>
 #include <linux/futex.h>


### PR DESCRIPTION
I was trying to record a whole foreign-arch debootstrap run and came accross this ioctl FS_IOC_FIEMAP / 0xc020660b.
With this patch this could be completed.

Might fix #2289.


[FATAL /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/record_syscall.cc:5900:rec_process_syscall_arch()]
 (task 25999 (rec:25999) at time 201)
 -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result 0 (errno SUCCESS); Unknown ioctl(0xc020660b): type:0x66 nr:0xb dir:0x3 size:32 addr:0x7ffd80c4ba10

Testcase modelled after this:
https://github.com/coreutils/coreutils/blob/ba5e6885d2c255648cddb87b4e795659c1990374/src/extent-scan.c#L94
(Got removed from coreutils in 26eccf6c98696c50f4416ba2967edc8676870716.)
