### PR TITLE
[RFC/WIP] GDB support for replay diversions

### DIFF
--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -224,6 +224,10 @@ static vector<string> parse_cmd(string& str) {
 
   if (resp == GdbCommandHandler::cmd_end_diversion()) {
     LOG(debug) << "cmd must run outside of diversion (" << resp << ")";
+    if (gdb_server.remote_supports_replay_diversion()) {
+      return gdb_escape(string() + "Command '" + cmd->name() +
+                        "' cannot run in a replay diversion.\n");
+    }
     return resp;
   }
 

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -120,6 +120,10 @@ public:
 
   ReplayTimeline& get_timeline() { return timeline; }
 
+  bool remote_supports_replay_diversion() {
+    return dbg != nullptr && dbg->replay_diversion_supported();
+  }
+
 private:
   GdbServer(std::unique_ptr<GdbConnection>& dbg, Task* t);
 

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -17,7 +17,9 @@
 #
 # Test runners may set the environment variable $RECORD_ARGS to pass
 # arguments to rr for recording.  This is only useful for tweaking the
-# scheduler, don't use it for anything else.
+# scheduler, don't use it for anything else.  Test runners may also
+# set $REPLAY_ARGS to pass arguments to rr for replay, allowing the
+# use of an alternate GDB, for instance.
 #
 
 #  delay_kill <sig> <delay_secs> <proc>
@@ -277,7 +279,7 @@ function record_async_signal { sig=$1; delay_secs=$2; exe=$3; exeargs=$4;
 
 function replay { replayflags=$1
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT replay.err \
-        $RR_EXE $GLOBAL_OPTIONS replay -a $replayflags 1> replay.out 2> replay.err
+        $RR_EXE $GLOBAL_OPTIONS replay -a $replayflags $REPLAY_ARGS 1> replay.out 2> replay.err
 }
 
 function rerun { rerunflags=$1
@@ -296,7 +298,7 @@ function do_ps { psflags=$1
 function debug { expectscript=$1; replayargs=$2
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT debug.err \
         python3 $TESTDIR/$expectscript.py \
-        $RR_EXE $GLOBAL_OPTIONS replay -o-n -x $TESTDIR/test_setup.gdb $replayargs
+        $RR_EXE $GLOBAL_OPTIONS replay -o-n -x $TESTDIR/test_setup.gdb $replayargs $REPLAY_ARGS
     if [[ $? == 0 ]]; then
         passed
     else

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -46,23 +46,20 @@ if tid2 != tid:
 # Ensure 'when' terminates a diversion
 send_gdb('call strlen("abcd")')
 send_gdb('when')
-expect_gdb(re.compile(r'Current event: (\d+)'))
-t3 = eval(last_match().group(1));
-if t3 != t2:
+expect_gdb(re.compile(r'(Current event: (\d+)|cannot run in a replay diversion)'))
+if last_match().group(2) and int(last_match().group(2)) != t2:
     failed('ERROR ... diversion changed event')
 
 send_gdb('call strlen("abcd")')
 send_gdb('when-ticks')
-expect_gdb(re.compile(r'Current tick: (\d+)'))
-ticks3 = eval(last_match().group(1));
-if ticks3 != ticks2:
+expect_gdb(re.compile(r'(Current tick: (\d+)|cannot run in a replay diversion)'))
+if last_match().group(2) and int(last_match().group(2)) != ticks2:
     failed('ERROR ... diversion changed ticks')
 
 send_gdb('call strlen("abcd")')
 send_gdb('when-tid')
-expect_gdb(re.compile(r'Current tid: (\d+)'))
-tid3 = eval(last_match().group(1));
-if tid3 != tid2:
+expect_gdb(re.compile(r'(Current tid: (\d+)|cannot run in a replay diversion)'))
+if last_match().group(2) and int(last_match().group(2)) != tid2:
     failed('ERROR ... diversion changed tid')
 
 ok()


### PR DESCRIPTION
I've been thinking about some of the awkwardness that currently exists around diversions: scheduling issues touched on in #2840, hidden state confusing GDB (e.g. #2867) and users (e.g. #1968) and the hacks and heuristics involved in trying to determine when diversion sessions should be set up/torn down. These problems aren't intractable, but it seems like they'll continue to crop up until GDB gains explicit support for a notion similar to that of rr's diversion session.

This patchset implements a (yet to be) proposed extension to the GDB remote protocol that would move control over diversion state out of rr and into GDB. The protocol introduces a new protocol feature and packet: `vReplayDiversion`. GDB can send `vReplayDiversion:1` to request a switch to a diversion session, and `vReplayDiversion:0` to end a diversion session. rr may additionally notify GDB of a premature diversion session exit by sending an inferior-exit stop packet. The GDB-side implementation mimics rr's logic (`vReplayDiversion:1` on inferior call, `vReplayDiversion:0` on `continue`) but could have commands like `replay-diversion {enter,exit}` in the future.

I've not yet submitted my proposal to the GDB mailing list; it seemed like a good idea to solicit feedback from the rr developers first, to make sure the approach is considered appropriate on the rr side. Given that I don't know if any such proposal will be accepted for GDB or how much any accepted proposal may differ from above, I've submitted this as a draft PR for the time being.

### Potential future directions

I'm also interested in feedback on the following ideas. I understand a discussion on these may be out of scope for this PR; let me know if you'd prefer separate issue(s).

- Expose seeking/checkpoints/bookmarks: GDB has bits of support for these (seeking and bookmarks likely just need remote protocol extensions, and the core is checkpoint-aware). This would eliminate the need for about half of `GdbCommand.cc`, allow (eventual?) removal of some of the GDB macros and hopefully bring a more consistent interface.
- `info replay`: Replace `elapsed-time`, `when`, `when-ticks` and `when-tid` with an `info replay` subcommand. Strictly speaking, this doesn't _need_ support from GDB, but it would be a good complement to GDB's `info record` subcommand and GDB support would make it an interface consistent with other (hypothetical) GDB targets.
