### PR TITLE
Avoid crash on call_exit test caused by access after free to a task object.

### DIFF
--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -142,7 +142,7 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
   if (t->ptrace_event() == PTRACE_EVENT_EXIT) {
     handle_ptrace_exit_event(t);
     result.status = DIVERSION_EXITED;
-    result.break_status.task = t;
+    result.break_status.task = NULL;
     result.break_status.task_exit = true;
     return result;
   }

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -900,7 +900,7 @@ bool GdbServer::diverter_process_debugger_requests(
 static bool is_last_thread_exit(const BreakStatus& break_status) {
   // The task set may be empty if the task has already exited.
   return break_status.task_exit &&
-         break_status.task->thread_group()->task_set().size() <= 1;
+         (!break_status.task || break_status.task->thread_group()->task_set().size() <= 1);
 }
 
 static Task* is_in_exec(ReplayTimeline& timeline) {
@@ -957,7 +957,7 @@ void GdbServer::maybe_notify_stop(const GdbRequest& req,
     LOG(debug) << "Stopping for signal " << stop_siginfo;
   }
   if (is_last_thread_exit(break_status)) {
-    if (break_status.task->session().is_diversion()) {
+    if (!break_status.task || break_status.task->session().is_diversion()) {
       // If the last task of a diversion session has exited, we need
       // to make sure GDB knows it's unrecoverable. There's no good
       // way to do this: a stop is insufficient, but an inferior exit


### PR DESCRIPTION
In handle_ptrace_exit_event the task object gets deleted,
but still assigned to the break_status object,
and got therefore accessed after freeing it.

This seems to made not yet trouble with the 64-bit build,
but the test call_exit showed a crashing rr process
in 32-bit test run since e627c19b0a.

```
(gdb) bt
#0  0x00000000 in ?? ()
#1  0x5684b467 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x581ecd20) at /usr/include/c++/10/bits/shared_ptr_base.h:158
#2  0x56845823 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0xffd37b2c, __in_chrg=<optimized out>) at /usr/include/c++/10/bits/shared_ptr_base.h:733
#3  0x56843ae5 in std::__shared_ptr<rr::ThreadGroup, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0xffd37b28, __in_chrg=<optimized out>) at /usr/include/c++/10/bits/shared_ptr_base.h:1183
#4  0x56843b2e in std::shared_ptr<rr::ThreadGroup>::~shared_ptr (this=0xffd37b28, __in_chrg=<optimized out>) at /usr/include/c++/10/bits/shared_ptr.h:121
#5  0x568ca117 in rr::is_last_thread_exit (break_status=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:903
#6  0x568ca5d0 in rr::GdbServer::maybe_notify_stop (this=0xffd39b44, req=..., break_status=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:959
#7  0x568caf8e in rr::GdbServer::divert (this=0xffd39b44, replay=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1104
#8  0x568cb33f in rr::GdbServer::process_debugger_requests (this=0xffd39b44, state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1148
#9  0x568cc020 in rr::GdbServer::debug_one_step (this=0xffd39b44, last_resume_request=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1284
#10 0x568ce5bd in rr::GdbServer::serve_replay (this=0xffd39b44, flags=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1754
#11 0x569d2706 in rr::replay (trace_dir="simple-14", flags=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:495
#12 0x569d3151 in rr::ReplayCommand::run (this=0x56c901d4 <rr::ReplayCommand::singleton>, args=std::vector of length 0, capacity 2) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
#13 0x56aa1098 in main (argc=3, argv=0xffd3a2a4) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
```

I found this task object already deleted before here:
```
(gdb) bt
...
#20 0x56a42701 in rr::Task::~Task (this=0x581e9cb0, __in_chrg=<optimized out>) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:287
#21 0x5687009e in rr::handle_ptrace_exit_event (t=0x581e9cb0) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/DiversionSession.cc:127
#22 0x56870129 in rr::DiversionSession::diversion_step (this=0x581ced70, t=0x581e9cb0, command=rr::RUN_CONTINUE, signal_to_deliver=0) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/DiversionSession.cc:143
#23 0x568caf5e in rr::GdbServer::divert (this=0xffd39b44, replay=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1100
#24 0x568cb33f in rr::GdbServer::process_debugger_requests (this=0xffd39b44, state=rr::GdbServer::REPORT_NORMAL) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1148
#25 0x568cc020 in rr::GdbServer::debug_one_step (this=0xffd39b44, last_resume_request=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1284
#26 0x568ce5bd in rr::GdbServer::serve_replay (this=0xffd39b44, flags=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/GdbServer.cc:1754
#27 0x569d2706 in rr::replay (trace_dir="simple-14", flags=...) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:495
#28 0x569d3151 in rr::ReplayCommand::run (this=0x56c901d4 <rr::ReplayCommand::singleton>, args=std::vector of length 0, capacity 2) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
#29 0x56aa1098 in main (argc=3, argv=0xffd3a2a4) at /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
```

Following a very simple attempt to avoid this crash.

CC: @Bob131
