### PR TITLE
Use unsigned long instead of int for PTRACE_GETEVENTMSG.

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -236,8 +236,9 @@ WaitStatus Task::kill() {
       * the exit event, we already reaped it from the ptrace perspective,
       * which implicitly detached.
       */
-    if (ptrace_if_alive(PTRACE_GETEVENTMSG, nullptr, &raw_status)) {
-      status = WaitStatus(raw_status);
+    unsigned long long_status;
+    if (ptrace_if_alive(PTRACE_GETEVENTMSG, nullptr, &long_status)) {
+      status = WaitStatus(long_status);
     } else {
       status = WaitStatus::for_fatal_sig(SIGKILL);
     }


### PR DESCRIPTION
"int raw_status" is just 4 bytes, but PTRACE_GETEVENTMSG writes
"unsigned long" with 8 bytes at x86_64.

Visible in replay of accept test.

Included is also a patch to add a cmake option to build rr with address sanitizer.
Should that be a separate PR, or is such a option even desired?

```
==2334193==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffcd0809e54 at pc 0x7f4d61cd59ef bp 0x7ffcd0809c20 sp 0x7ffcd08093d0
WRITE of size 8 at 0x7ffcd0809e54 thread T0
    #0 0x7f4d61cd59ee in __interceptor_ptrace ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:3258
    #1 0x55e8eae433be in rr::Task::fallible_ptrace(int, rr::remote_ptr<void>, void*) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:2626
    #2 0x55e8eae48cba in rr::Task::ptrace_if_alive(int, rr::remote_ptr<void>, void*) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:3050
    #3 0x55e8eae2b459 in rr::Task::kill() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:239
    #4 0x55e8eade2b69 in rr::Session::kill_all_tasks() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Session.cc:224
    #5 0x55e8ead29df6 in rr::ReplaySession::~ReplaySession() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:219
    #6 0x55e8ead29f77 in rr::ReplaySession::~ReplaySession() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:223
    #7 0x55e8ead429ad in std::_Sp_counted_ptr<rr::ReplaySession*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/10/bits/shared_ptr_base.h:380
    #8 0x55e8ea983364 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/10/bits/shared_ptr_base.h:158
    #9 0x55e8ea975eb5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/10/bits/shared_ptr_base.h:733
    #10 0x55e8ead24a73 in std::__shared_ptr<rr::ReplaySession, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/10/bits/shared_ptr_base.h:1183
    #11 0x55e8ead24a8f in std::shared_ptr<rr::ReplaySession>::~shared_ptr() /usr/include/c++/10/bits/shared_ptr.h:121
    #12 0x55e8ead21a03 in serve_replay_no_debugger /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:341
    #13 0x55e8ead220f7 in replay /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:450
    #14 0x55e8ead24175 in rr::ReplayCommand::run(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
    #15 0x55e8eaf00681 in main /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
    #16 0x7f4d61629d09 in __libc_start_main ../csu/libc-start.c:308
    #17 0x55e8ea9428b9 in _start (/home/bernhard/data/entwicklung/2021/rr/2021-04-25/x86_64_asan/obj/bin/rr+0x3878b9)

Address 0x7ffcd0809e54 is located in stack of thread T0 at offset 52 in frame
    #0 0x55e8eae2ad33 in rr::Task::kill() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:201

  This frame has 13 object(s):
    [48, 52) 'raw_status' (line 222) <== Memory access at offset 52 overflows this variable
    [64, 68) 'wait_ret' (line 223)
    [80, 84) 'status' (line 224)
    [96, 100) '<unknown>'
    [112, 116) '<unknown>'
    [128, 136) '<unknown>'
    [160, 168) '<unknown>'
    [192, 200) '<unknown>'
    [224, 232) '<unknown>'
    [256, 264) '<unknown>'
    [288, 304) '<unknown>'
    [320, 336) '<unknown>'
    [352, 368) '<unknown>'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:3258 in __interceptor_ptrace
Shadow bytes around the buggy address:
  0x10001a0f9370: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10001a0f9380: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f3
  0x10001a0f9390: f3 f3 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x10001a0f93a0: 00 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 00 00 f2 f2
  0x10001a0f93b0: 00 00 00 00 f3 f3 f3 f3 00 00 00 00 00 00 00 00
=>0x10001a0f93c0: 00 00 00 00 f1 f1 f1 f1 f1 f1[04]f2 04 f2 04 f2
  0x10001a0f93d0: 04 f2 04 f2 f8 f2 f2 f2 f8 f2 f2 f2 00 f2 f2 f2
  0x10001a0f93e0: 00 f2 f2 f2 00 f2 f2 f2 f8 f8 f2 f2 f8 f8 f2 f2
  0x10001a0f93f0: f8 f8 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0x10001a0f9400: 00 00 00 00 f1 f1 f1 f1 f8 f2 f2 f2 00 f2 f2 f2
  0x10001a0f9410: 00 f2 f2 f2 00 f3 f3 f3 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2334193==ABORTING
```