### PR TITLE
Increase timeout for conditional_breakpoint_offload test.

### DIFF
--- a/src/test/conditional_breakpoint_offload.run
+++ b/src/test/conditional_breakpoint_offload.run
@@ -1,2 +1,3 @@
 source `dirname $0`/util.sh
+TIMEOUT=300
 debug_test


### PR DESCRIPTION
This test, especially in the no-syscallbuf variants,
takes regularly more than 120 seconds at my Ryzen 7 1700,
when running the tests in parallel.