### PR TITLE
Avoid use-after-free of task object in ReplaySession::replay_step.

### DIFF
--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1788,7 +1788,11 @@ ReplayResult ReplaySession::replay_step(const StepConstraints& constraints) {
 
   // If try_one_trace_step set extra-registers already, the values it used from the frame
   // will already have FIP/FDP cleared if necessary. Clearing them again here is fine.
-  if (trace_reader().clear_fip_fdp()) {
+  if (trace_reader().clear_fip_fdp() &&
+      current_step.action != TSTEP_EXIT_TASK)
+      /* TSTEP_EXIT_TASK means the task object got already
+         deleted above in try_one_trace_step/exit_task/end_task. */
+  {
     const ExtraRegisters* maybe_extra = t->extra_regs_fallible();
     if (maybe_extra) {
       ExtraRegisters extra_registers = *maybe_extra;


### PR DESCRIPTION
The task object given to `ReplaySession::try_one_trace_step` gets deleted
with `TSTEP_EXIT_TASK` in `ReplaySession::exit_task` / `end_task`.

Visible in replay of accept test with asan enabled rr build.

```
==3526410==ERROR: AddressSanitizer: heap-use-after-free on address 0x619000038240 at pc 0x55ab4920de95 bp 0x7ffdf9bc83e0 sp 0x7ffdf9bc83d8
READ of size 1 at 0x619000038240 thread T0
    #0 0x55ab4920de94 in rr::Task::extra_regs_fallible() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:1041
    #1 0x55ab4911642f in rr::ReplaySession::replay_step(rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1792
    #2 0x55ab490ffc56 in rr::ReplaySession::replay_step(rr::RunCommand) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.h:285
    #3 0x55ab490fc411 in serve_replay_no_debugger /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:362
    #4 0x55ab490fd38b in replay /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:450
    #5 0x55ab490ff409 in rr::ReplayCommand::run(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
    #6 0x55ab492dca30 in main /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
    #7 0x7f810106fd09 in __libc_start_main ../csu/libc-start.c:308
    #8 0x55ab48d1d8b9 in _start (/home/bernhard/data/entwicklung/2021/rr/2021-04-25/x86_64_asan/obj/bin/rr+0x3868b9)

0x619000038240 is located 704 bytes inside of 944-byte region [0x619000037f80,0x619000038330)
freed by thread T0 here:
    #0 0x7f8101740467 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x55ab491417fc in rr::ReplayTask::~ReplayTask() /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayTask.h:16
    #2 0x55ab49113267 in end_task /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1534
    #3 0x55ab4911343c in rr::ReplaySession::exit_task(rr::ReplayTask*) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1541
    #4 0x55ab49112cfd in rr::ReplaySession::try_one_trace_step(rr::ReplayTask*, rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1495
    #5 0x55ab49115df1 in rr::ReplaySession::replay_step(rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1760
    #6 0x55ab490ffc56 in rr::ReplaySession::replay_step(rr::RunCommand) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.h:285
    #7 0x55ab490fc411 in serve_replay_no_debugger /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:362
    #8 0x55ab490fd38b in replay /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:450
    #9 0x55ab490ff409 in rr::ReplayCommand::run(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
    #10 0x55ab492dca30 in main /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
    #11 0x7f810106fd09 in __libc_start_main ../csu/libc-start.c:308

previously allocated by thread T0 here:
    #0 0x7f810173f647 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55ab49105d57 in rr::ReplaySession::new_task(int, int, unsigned int, rr::SupportedArch) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:293
    #2 0x55ab4921a557 in rr::Task::clone(rr::Task::CloneReason, int, rr::remote_ptr<void>, rr::remote_ptr<void>, rr::remote_ptr<int>, int, int, unsigned int, rr::Session*, std::shared_ptr<rr::FdTable>, std::shared_ptr<rr::ThreadGroup>) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:2287
    #3 0x55ab491bd803 in rr::Session::clone(rr::Task*, int, rr::remote_ptr<void>, rr::remote_ptr<void>, rr::remote_ptr<int>, int, int) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Session.cc:165
    #4 0x55ab49136fe4 in prepare_clone<rr::X64Arch> /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/replay_syscall.cc:263
    #5 0x55ab4912c0d3 in rep_after_enter_syscall_arch<rr::X64Arch> /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/replay_syscall.cc:972
    #6 0x55ab4912a515 in rr::rep_after_enter_syscall(rr::ReplayTask*) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/replay_syscall.cc:1028
    #7 0x55ab4910919a in rr::ReplaySession::enter_syscall(rr::ReplayTask*, rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:626
    #8 0x55ab49112b62 in rr::ReplaySession::try_one_trace_step(rr::ReplayTask*, rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1476
    #9 0x55ab49115df1 in rr::ReplaySession::replay_step(rr::ReplaySession::StepConstraints const&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.cc:1760
    #10 0x55ab490ffc56 in rr::ReplaySession::replay_step(rr::RunCommand) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplaySession.h:285
    #11 0x55ab490fc411 in serve_replay_no_debugger /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:362
    #12 0x55ab490fd38b in replay /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:450
    #13 0x55ab490ff409 in rr::ReplayCommand::run(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/ReplayCommand.cc:616
    #14 0x55ab492dca30 in main /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/main.cc:249
    #15 0x7f810106fd09 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-use-after-free /home/bernhard/data/entwicklung/2021/rr/2021-04-25/rr/src/Task.cc:1041 in rr::Task::extra_regs_fallible()
Shadow bytes around the buggy address:
  0x0c327fffeff0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c327ffff000: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c327ffff010: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c327ffff020: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c327ffff030: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c327ffff040: fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x0c327ffff050: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c327ffff060: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x0c327ffff070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c327ffff080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c327ffff090: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3526410==ABORTING
```