### PR TITLE
WIP: PerfCounters_x86.h: add support for AMD A8-3530MX

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -86,6 +86,8 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x70f10: // Matisse (Zen 2) (UNTESTED)
       if (ext_family == 8) {
         return AMDZen;
+      } else if (ext_family == 3) {
+        return AMDF15R30;
       }
       break;
     case 0x20f10: // Vermeer (Zen 3)


### PR DESCRIPTION
Fixes: https://github.com/rr-debugger/rr/issues/2872

I did not compare the values at `PmuConfig` to the AMD documentation because I have no idea where to find any of these. However, trying to reuse an existing line for `AMDF15R30` worked, `rr record ls` and `rr replay` works for me, reverse execution works too.

Reason I'm marking this as WIP is because a few tests are failing and I'm not sure how to proceed here.

The exact number is `28 tests failed out of 2625`, however apparently only for 10 of them fail is not expected *(I rerun all 28 of them on another laptop with Intel CPU with the same commit my current branch is based off, and 18 of them failed there too)*.

The 10 tests whose failure is apparently not expected are:

```
vsyscall
vsyscall-no-syscallbuf
vsyscall_timeslice
vsyscall_timeslice-no-syscallbuf
seekticks
seekticks-no-syscallbuf
vsyscall_singlestep
vsyscall_singlestep-no-syscallbuf
seekticks-32
seekticks-32-no-syscallbuf
```