### PR TITLE
Avoid a few small leaks to make address sanitizer happy.

### DIFF
--- a/src/LsCommand.cc
+++ b/src/LsCommand.cc
@@ -172,6 +172,7 @@ static int ls(const string& traces_dir, const LsFlags& flags, FILE* out) {
       traces.back().ctime = st.st_ctim;
     }
   }
+  closedir(dir);
 
   if (flags.sort_by_time) {
     auto compare_by_time = [&](const TraceInfo& at,

--- a/src/LsCommand.cc
+++ b/src/LsCommand.cc
@@ -105,6 +105,7 @@ static bool get_folder_size(string dir_name, string& size_str) {
 
     bytes += st.st_size;
   }
+  closedir(dir);
 
   static const char suffixes[] = " KMGT";
   double size = bytes;

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -907,6 +907,7 @@ int SourcesCommand::run(vector<string>& args) {
   if (!files) {
     FATAL() << "Can't open trace dir";
   }
+  closedir(files);
 
   map<string, string> binary_file_names;
   while (true) {

--- a/src/log.cc
+++ b/src/log.cc
@@ -59,12 +59,12 @@ static char simple_to_lower(char ch) {
 }
 
 static string simple_to_lower(const string& s) {
-  char* buf = new char[s.size() + 1];
+  std::unique_ptr<char[]> buf(new char[s.size() + 1]);
   for (size_t i = 0; i < s.size(); ++i) {
     buf[i] = simple_to_lower(s[i]);
   }
   buf[s.size()] = 0;
-  return string(buf);
+  return string(buf.get());
 }
 
 #if __has_attribute(require_constant_initialization)

--- a/src/util.cc
+++ b/src/util.cc
@@ -2140,6 +2140,7 @@ std::vector<int> read_all_proc_fds(pid_t tid)
   while (struct dirent *dir = readdir(fddir)) {
     ret.push_back(atoi(dir->d_name));
   }
+  closedir(fddir);
   return ret;
 }
 


### PR DESCRIPTION
Those patches are just kind of cosmetic nature.
But, unless disabled by environment `ASAN_OPTIONS="detect_leaks=0"`, the first two are disturbing the test run.
The later three are just other uses of opendir without matching closedir.