### PR TITLE
Some ASan-related fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,7 +342,12 @@ foreach(file ${RR_PAGE_FILES})
   set_source_files_properties("${CMAKE_SOURCE_DIR}/src/preload/${file}"
                               PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
 endforeach(file)
-set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostartfiles -nostdlib -Wl,-z,max-page-size=0x1000 ${LINKER_FLAGS}")
+
+# Since librrpage replaces the kernel vDSO for processes exec'd by rr,
+# we want it to have the same SONAME as the real vDSO to trick things
+# like AddressSanitizer into recognising it as the vDSO.
+set_target_properties(rrpage PROPERTIES NO_SONAME ON)
+set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostartfiles -nostdlib -Wl,-z,max-page-size=0x1000 -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
 set_target_properties(rrpage PROPERTIES LINK_DEPENDS ${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld)
 # CMake seems to have trouble generating the link line without this
 set_target_properties(rrpage PROPERTIES LINKER_LANGUAGE C)
@@ -672,7 +677,8 @@ if(rr_32BIT AND rr_64BIT)
                                 PROPERTIES COMPILE_FLAGS "-m32 ${PRELOAD_COMPILE_FLAGS}")
   endforeach(file)
 
-  set_target_properties(rrpage_32 PROPERTIES LINK_FLAGS "-m32 -Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostartfiles -nostdlib ${LINKER_FLAGS}")
+  set_target_properties(rrpage_32 PROPERTIES NO_SONAME ON)
+  set_target_properties(rrpage_32 PROPERTIES LINK_FLAGS "-m32 -Wl,-T -Wl,${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostartfiles -nostdlib -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
   set_target_properties(rrpage_32 PROPERTIES LINK_DEPENDS ${CMAKE_SOURCE_DIR}/src/preload/rr_page.ld)
   set_target_properties(rrpage_32 PROPERTIES LINKER_LANGUAGE C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1566,10 +1566,11 @@ if(BUILD_TESTS)
     set(TEST_MONITOR_DEFAULT_TIMEOUT 120)
   endif()
 
+  # The real timeouts are handled by test-monitor
+  set(CTEST_TEST_TIMEOUT 1000)
+
   function(configure_test test)
-    # The real timeouts are handled by test-monitor
-    set_tests_properties(${test}
-      PROPERTIES FAIL_REGULAR_EXPRESSION "FAILED" TIMEOUT 1000)
+    set_tests_properties(${test} PROPERTIES FAIL_REGULAR_EXPRESSION "FAILED")
   endfunction(configure_test)
 
   if(INSTALL_TESTSUITE)

--- a/src/test/64bit_child.c
+++ b/src/test/64bit_child.c
@@ -3,7 +3,7 @@
 #include "util.h"
 
 void callback(uint64_t env, char *name, __attribute__((unused)) map_properties_t* props) {
-  const char search[] = "librrpage.so";
+  const char search[] = "librrpreload.so";
   if (strlen(name) > strlen(search)) {
     if (sizeof(void*) == 4 &&
         strcmp(name + strlen(name) - strlen(search), search) == 0)


### PR DESCRIPTION
A couple of commits somewhat related to #2890. I've submitted it as a draft since there was one test timeout that I want to investigate but I didn't want to wait until tomorrow to follow up on #2890.

I would appreciate some extra scrutiny around the `64bit_child` test, since I'm not familiar with the details of how the kernel decides task arch-ness.