### PR TITLE
Do not wait for force_close_record_session.

### DIFF
--- a/src/test-monitor/test-monitor.cc
+++ b/src/test-monitor/test-monitor.cc
@@ -145,10 +145,16 @@ static void dump_gdb_stacktrace(pid_t child, FILE* out) {
 
 static void force_trace_closure(pid_t child, FILE* out) {
   char cmdline[1024 * 10];
-  sprintf(cmdline, "gdb -p %d -ex 'set confirm off' -ex 'set height 0' -ex "
-                   "'p rr::force_close_record_session()' -ex q </dev/null 2>&1",
+  sprintf(cmdline, "gdb -p %d "
+                   "-ex 'set confirm off' "
+                   "-ex 'set height 0' "
+                   "-ex 'b rr::force_close_record_session' "
+                   "-ex 'p rr::force_close_record_session()' "
+                   "-ex detach "
+                   "-ex q </dev/null 2>&1",
           child);
   dump_popen_cmdline(cmdline, out);
+  sleep(2); /* give the force_close_record_session time to take effect */
 }
 
 static void dump_emergency_debugger(char* gdb_cmd, FILE* out) {


### PR DESCRIPTION
Certain tests exceed the "internal" timeout for some tests.
Then it is tried to close any recording session by force_close_record_session.
If that fails the gdb session has to wait until it reaches the ctest timeout.
This patch attempts to just trigger the record closing, but if that does not
help the test fails immediately after a short wait.
