### PR TITLE
Change tweak_librrpage.py to relocate the last three sections.

### DIFF
--- a/src/preload/tweak_librrpage.py
+++ b/src/preload/tweak_librrpage.py
@@ -97,7 +97,7 @@ with open(sys.argv[1], 'rb+') as f:
 	write_uptr(is64, f, new_table_offset)
 
 	alloc_offset = new_table_offset + size
-	for n in range(12, 15):
+	for n in range(e_shnum-3, e_shnum):
 		seek_nth_section_sh_offset(f, new_table_offset, e_shentsize, n, sh_offset_offset)
 		sh_offs = read_uptr(is64, f)
 		sh_size = read_uptr(is64, f)


### PR DESCRIPTION
By the commit 38571520 two new sections get now added to librrpage.so.
Therefore the assumption to relocate sections 12 to 14 did not work
anymore.

Also, librrpage.so had one section more than librrpage_32.so.

This patch assumes now, not much better but a little, that the last three
sections are .symtab, .strtab and .shstrtab, and have to be relocated.

----


And just for informational purposes:

`readelf --headers ./lib/rr/librrpage_32.so` looked like this, notice the offset greater than 0x4000:
```
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
...
  [11] .vdso.text        PROGBITS        6ffff000 002000 00006f 00   A  0   0 4096
  [12] .record.text      PROGBITS        70000000 0012b0 000023 00   A  0   0 4096
  [13] .replay.text      PROGBITS        70001000 0012e0 00001a 00      0   0 4096
  [14] .symtab           SYMTAB          00000000 001300 0002a0 10     15  29  4
  [15] .strtab           STRTAB          00000000 0042bc 0001cf 00      0   0  1
  [16] .shstrtab         STRTAB          00000000 00448b 0000ba 00      0   0  1
Key to Flags:
...
```

```
$ bin/rr record bin/morestack_unwind_32

$ cat ../../gdb.sh 
#!/bin/sh
exec bin/rr record gdb "$@"

$ bin/rr replay --debugger=../../gdb.sh morestack_unwind_32-10
break main
c
break _syscall_hook_trampoline
c
fin
fin
fin
```

This is where gdb attempts to load the debug information for the vdso:
```
(rr) print/x nwhere
$12 = 0x448b
(rr) print/x bim->size
$13 = 0x4000
(rr) bt
#0  memory_bseek (abfd=0x559723850aa0, position=17547, direction=0) at .../gdb/try2/gdb-10.1/bfd/bfdio.c:657
#1  0x00005597217ab2be in bfd_seek (abfd=0x559723850aa0, position=17547, direction=0) at .../gdb/try2/gdb-10.1/bfd/bfdio.c:364
#2  0x00005597217d5249 in bfd_elf_get_str_section (abfd=0x559723850aa0, shindex=16) at .../gdb/try2/gdb-10.1/bfd/elf.c:299
#3  0x00005597217d53ad in bfd_elf_string_from_elf_section (abfd=0x559723850aa0, shindex=16, strindex=27) at .../gdb/try2/gdb-10.1/bfd/elf.c:342
#4  0x00005597217d973e in bfd_section_from_shdr (abfd=0x559723850aa0, shindex=1) at .../gdb/try2/gdb-10.1/bfd/elf.c:2090
#5  0x00005597218322d3 in bfd_elf32_object_p (abfd=0x559723850aa0) at .../gdb/try2/gdb-10.1/bfd/elfcode.h:831
#6  0x00005597217af18f in bfd_check_format_matches (abfd=0x559723850aa0, format=bfd_object, matching=0x0) at .../gdb/try2/gdb-10.1/bfd/format.c:277
#7  0x00005597217aec7a in bfd_check_format (abfd=0x559723850aa0, format=bfd_object) at .../gdb/try2/gdb-10.1/bfd/format.c:94
#8  0x00005597216e2a7f in symbol_file_add_from_memory (templ=<optimized out>, addr=<optimized out>, size=<optimized out>, name=0x55972370d0e0 "system-supplied DSO at 0x6fffd000", from_tty=0) at .../gdb/try2/gdb-10.1/gdb/symfile-mem.c:107
#9  0x00005597216e2db4 in add_vsyscall_page (target=<optimized out>, from_tty=<optimized out>) at /usr/include/c++/10/bits/basic_string.h:186
#10 0x00005597215ae6a3 in std::function<void (target_ops*, int)>::operator()(target_ops*, int) const (__args#1=<optimized out>, __args#0=<optimized out>, this=0x55972366f6a8) at /usr/include/c++/10/bits/std_function.h:622
#11 gdb::observers::observable<target_ops*, int>::notify (args#1=1, args#0=0x55972378f1f0, this=<optimized out>) at .../gdb/try2/gdb-10.1/gdb/../gdbsupport/observable.h:106
#12 post_create_inferior (target=0x55972378f1f0, from_tty=from_tty@entry=1) at .../gdb/try2/gdb-10.1/gdb/infcmd.c:350
#13 0x00005597215c6d27 in start_remote (from_tty=1) at .../gdb/try2/gdb-10.1/gdb/infrun.c:3188
#14 0x00005597216adf1b in remote_target::start_remote (this=this@entry=0x55972378f1f0, from_tty=from_tty@entry=1, extended_p=extended_p@entry=1) at .../gdb/try2/gdb-10.1/gdb/remote.c:4792
#15 0x00005597216ae411 in remote_target::open_1 (name=<optimized out>, from_tty=1, extended_p=1) at .../gdb/try2/gdb-10.1/gdb/remote.c:5668
#16 0x000055972171ccbe in open_target (args=0x7ffcd3cc61c1 "127.0.0.1:32655", from_tty=1, command=<optimized out>) at .../gdb/try2/gdb-10.1/gdb/target.c:242
#17 0x00005597214af76c in cmd_func (cmd=0x5597237305c0, args=0x7ffcd3cc61c1 "127.0.0.1:32655", from_tty=1) at .../gdb/try2/gdb-10.1/gdb/cli/cli-decode.c:2181
#18 0x0000559721727a54 in execute_command (p=<optimized out>, p@entry=<error reading variable: value has been optimized out>, from_tty=1, from_tty@entry=<error reading variable: value has been optimized out>) at .../gdb/try2/gdb-10.1/gdb/top.c:668
#19 0x00005597215ff833 in catch_command_errors (command=<optimized out>, arg=<optimized out>, from_tty=<optimized out>) at .../gdb/try2/gdb-10.1/gdb/main.c:457
#20 0x0000559721603147 in captured_main_1 (context=<optimized out>) at .../gdb/try2/gdb-10.1/gdb/main.c:1218
#21 0x000055972160357b in captured_main (data=data@entry=0x7ffcd3cc3ea0) at .../gdb/try2/gdb-10.1/gdb/main.c:1243
#22 gdb_main (args=args@entry=0x7ffcd3cc3ed0) at .../gdb/try2/gdb-10.1/gdb/main.c:1268
#23 0x000055972141d90c in main (argc=<optimized out>, argv=<optimized out>) at .../gdb/try2/gdb-10.1/gdb/gdb.c:32
```

This "end" is retrieved by gdb from `"/proc/%ld/task/%ld/maps"`:
```
(rr) bt
#0  linux_vsyscall_range_raw (gdbarch=<optimized out>, range=0x555ab8a59aa0) at /home/benutzer/source/gdb/try2/gdb-10.1/gdb/linux-tdep.c:2360
#1  linux_vsyscall_range (gdbarch=<optimized out>, range=0x7ffdd9f4bd60) at /home/benutzer/source/gdb/try2/gdb-10.1/gdb/linux-tdep.c:2402
#2  0x0000555ab7862731 in svr4_current_sos () at /home/benutzer/source/gdb/try2/gdb-10.1/gdb/solib-svr4.c:1461
...
```
