### PR TITLE
Do not wait for SYNC_TOKEN until timeout exceeds, if subshell died already.

### DIFF
--- a/src/test/ignored_async_usr1.run
+++ b/src/test/ignored_async_usr1.run
@@ -3,10 +3,12 @@ source `dirname $0`/util.sh
 SYNC_TOKEN=disabled
 
 record $TESTNAME &
+SUB_ID=$!
 
 echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
 until grep -q $SYNC_TOKEN record.out; do
         sleep 0
+        if ! kill -0 "$SUB_ID" >/dev/null 2>&1; then failed "subshell died, no need to longer wait for '$SYNC_TOKEN'"; exit; fi
 done
 
 echo "  done.  Delivering SIGUSR1 ..."

--- a/src/test/nested_detach_kill.run
+++ b/src/test/nested_detach_kill.run
@@ -11,10 +11,12 @@ save_exe "$NEST_EXE"
 save_exe "$SLEEP_EXE"
 touch record.out
 just_record $NEST_EXE-$nonce "$(which rr) record --nested=detach $PWD/$SLEEP_EXE-$nonce" &
+SUB_ID=$!
 
 echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
 until grep -q $SYNC_TOKEN record.out; do
     sleep 0
+    if ! kill -0 "$SUB_ID" >/dev/null 2>&1; then failed "subshell died, no need to longer wait for '$SYNC_TOKEN'"; exit; fi
 done
 
 rrpid=$(parent_pid_of $(pidof $NEST_EXE-$nonce))

--- a/src/test/term_trace_cpu.run
+++ b/src/test/term_trace_cpu.run
@@ -15,10 +15,12 @@ SYNC_TOKEN=spinning
 WAIT_SECS=1
 
 record $EXE &
+SUB_ID=$!
 
 echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
 until grep -q $SYNC_TOKEN record.out; do
         sleep 0
+        if ! kill -0 "$SUB_ID" >/dev/null 2>&1; then failed "subshell died, no need to longer wait for '$SYNC_TOKEN'"; exit; fi
 done
 
 rrpid=$(parent_pid_of $(pidof $EXE-$nonce))

--- a/src/test/term_trace_syscall.run
+++ b/src/test/term_trace_syscall.run
@@ -3,10 +3,12 @@ source `dirname $0`/util.sh
 SYNC_TOKEN=sleeping
 
 record $TESTNAME &             # sleep "forever"
+SUB_ID=$!
 
 echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
 until grep -q $SYNC_TOKEN record.out; do
     sleep 0
+    if ! kill -0 "$SUB_ID" >/dev/null 2>&1; then failed "subshell died, no need to longer wait for '$SYNC_TOKEN'"; exit; fi
 done
 
 rrpid=$(parent_pid_of $(pidof $TESTNAME-$nonce))


### PR DESCRIPTION
If the test `nested_detach_kill` fails to start, it waits currently for the sync token until the timeout is reached.
With this patch, if recording fails to startup, the test fails immediately.
