### PR TITLE
Mark parameter fd to ElfFileReader::is_x32_abi as possibly unused.

### DIFF
--- a/src/ElfReader.cc
+++ b/src/ElfReader.cc
@@ -513,7 +513,7 @@ SupportedArch ElfFileReader::identify_arch(ScopedFd& fd) {
   }
 }
 
-bool ElfFileReader::is_x32_abi(ScopedFd& fd) {
+bool ElfFileReader::is_x32_abi(__attribute__((unused)) ScopedFd& fd) {
 #if defined(__x86_64__)
   static const int header_prefix_size = 20;
   char buf[header_prefix_size];


### PR DESCRIPTION
When building for 32-bit:
ElfReader.cc:516:42: error: unused parameter ‘fd’

Related commit: 998f91090d