### PR TITLE
Fixes build on Ubuntu 16.04

### DIFF
--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -421,6 +421,10 @@ enum {
 #define CAP_PERFMON 38
 #endif
 
+#ifndef SEGV_PKUERR
+#define SEGV_PKUERR 4
+#endif
+
 } // namespace rr
 
 #endif /* RR_KERNEL_SUPPLEMENT_H_ */

--- a/src/test/x86/pkeys.c
+++ b/src/test/x86/pkeys.c
@@ -2,6 +2,7 @@
 
 #include "util.h"
 
+#ifdef PKEY_DISABLE_ACCESS
 static void wrpkru(unsigned int pkru) {
   unsigned int eax = pkru;
   unsigned int ecx = 0;
@@ -48,3 +49,10 @@ int main(void) {
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }
+#else
+int main(void) {
+  atomic_puts("pkeys not supported on the machine compiling this test, skipping");
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}
+#endif


### PR DESCRIPTION
Tried to run the tests in a rr enabled VM with Ubuntu 16.04, but these triggered
several times a kernel issue `kernel BUG at /build/linux-3Zqs18/linux-4.4.0/mm/memory.c:3214!`.
(With `4.4.0-210-generic`, `Description:    Ubuntu 16.04.7 LTS`)
Having now the first 1300 tests run, 95% did succeed.

Doing a build and test run on my usual setup, all tests succeed with these two patches.

Related to issue: #2919