### PR TITLE
handle plain exit for tasks

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -136,17 +136,22 @@ void Task::wait_exit() {
    * it as an indication that the task has execed.
    */
   while (true) {
-    int ret = waitid(P_PID, tid, &info, WSTOPPED | WNOWAIT);
+    int ret = waitid(P_PID, tid, &info, WEXITED | WSTOPPED | WNOWAIT);
     if (ret == 0) {
       ASSERT(this, info.si_pid == tid) << "Expected " << tid << " got " << info.si_pid;
-      if (WaitStatus(info).ptrace_event() == PTRACE_EVENT_EXIT) {
+      int event = WaitStatus(info).ptrace_event();
+      if (event == 0) { // PTRACE_EVENT_STOP
+        // already finished
+        break;
+      }
+      if (event == PTRACE_EVENT_EXIT) {
         // It's possible that the earlier exit event was synthetic, in which
         // case we're only now catching up to the real process exit. In that
         // case, just ask the process to actually exit. (TODO: We may want to
         // catch this earlier).
         return proceed_to_exit(true);
       }
-      ASSERT(this, WaitStatus(info).ptrace_event() == PTRACE_EVENT_EXEC)
+      ASSERT(this, event == PTRACE_EVENT_EXEC)
         << "Expected PTRACE_EVENT_EXEC, got " << WaitStatus(info);
       // The kernel will do the reaping for us in this case
       was_reaped = true;


### PR DESCRIPTION
fixes #2627, #2640 

Note: this definitely should get a code review (seeing the file's history I guess goes to @rocallahan), and likely also an adjustment of the comment in the code.

I've just tested a bit and found in the simple tests I've done (single thread, all child processes of the "inferior" are already finished) pass and that the "hang" is fixed, the record works and the replay is possible, too.

... but other programs (multiple shared objects loaded and oracle client invoked) do fail with:

~~~
[FATAL /tmp/rr-master/src/RecordSession.cc:347:handle_seccomp_traced_syscall()]
 (task 13911 (rec:13911) at time 960)
 -> Assertion `patch_ok' failed to hold. The tracee issues a vsyscall to 0xffffffffff600400 but we failed to moneypatch the caller (return address 0x7fe28deb1ca5, sp=0x7ffc38c6b4b8). Recording will not succeed. Exiting.
Tail of trace dump:
{
  real_time:507685.886496 global_time:940, event:`SYSCALLBUF_FLUSH' tid:13911, ticks:4964637
  { syscall:'read', ret:0x63c, size:0x64c, desched:1 }
  { syscall:'read', ret:0x0, size:0x10, desched:1 }
  { syscall:'close', ret:0x0, size:0x10 }
}
{
  real_time:507685.886512 global_time:941, event:`SYSCALL: munmap' (state:ENTERING_SYSCALL) tid:13911, ticks:4964637
rax:0xffffffffffffffda rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x0 rsi:0x1000 rdi:0x7fe29f896000 rbp:0xb rsp:0x681ffde0 r8:0x222cd00 r9:0x7fe29f884740 r10:0x0 r11:0x246 r12:0x0 r13:0x400 r14:0x7fe29f8846b0 r15:0x308b rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0xb fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.886521 global_time:942, event:`SYSCALLBUF_RESET' tid:13911, ticks:4964637
}
{
  real_time:507685.886590 global_time:943, event:`SYSCALL: munmap' (state:EXITING_SYSCALL) tid:13911, ticks:4964637
rax:0x0 rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x0 rsi:0x1000 rdi:0x7fe29f896000 rbp:0xb rsp:0x681ffde0 r8:0x222cd00 r9:0x7fe29f884740 r10:0x0 r11:0x246 r12:0x0 r13:0x400 r14:0x7fe29f8846b0 r15:0x308b rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0xb fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.887015 global_time:944, event:`SYSCALLBUF_FLUSH' tid:13911, ticks:4966826
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0xfffffffffffffffe, size:0x10, desched:1 }
  { syscall:'open', ret:0x3, size:0x10, desched:1 }
  { syscall:'readlinkat', ret:0x10, size:0x20 }
  { syscall:'fstat', ret:0x0, size:0xa0 }
}
{
  real_time:507685.887033 global_time:945, event:`SYSCALL: mmap' (state:ENTERING_SYSCALL) tid:13911, ticks:4966826
rax:0xffffffffffffffda rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x1 rsi:0xc6dd rdi:0x0 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x0 r10:0x2 r11:0x246 r12:0x2 r13:0x0 r14:0x3 r15:0x1 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.887042 global_time:946, event:`SYSCALLBUF_RESET' tid:13911, ticks:4966826
}
{
  real_time:507685.888248 global_time:947, event:`SYSCALL: mmap' (state:EXITING_SYSCALL) tid:13911, ticks:4966826
rax:0x7fe29f88a000 rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x1 rsi:0xc6dd rdi:0x0 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x0 r10:0x2 r11:0x246 r12:0x2 r13:0x0 r14:0x3 r15:0x1 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
  { map_file:"/etc/ld.so.cache", addr:0x7fe29f88a000, length:0xd000, prot_flags:"r--p", file_offset:0x0, device:64768, inode:35678126, data_file:"", data_offset:0x0, file_size:0xc6dd }
  { tid:13911, addr:0x7fe29f88a000, length:0xc6dd }
}
{
  real_time:507685.888570 global_time:948, event:`SYSCALLBUF_FLUSH' tid:13911, ticks:4968050
  { syscall:'close', ret:0x0, size:0x10 }
  { syscall:'open', ret:0x3, size:0x10, desched:1 }
  { syscall:'readlinkat', ret:0x1a, size:0x2a }
  { syscall:'read', ret:0x340, size:0x350, desched:1 }
  { syscall:'fstat', ret:0x0, size:0xa0 }
}
{
  real_time:507685.888587 global_time:949, event:`SYSCALL: mmap' (state:ENTERING_SYSCALL) tid:13911, ticks:4968050
rax:0xffffffffffffffda rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x5 rsi:0x208490 rdi:0x0 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x0 r10:0x802 r11:0x246 r12:0x802 r13:0x0 r14:0x3 r15:0x5 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.888597 global_time:950, event:`SYSCALLBUF_RESET' tid:13911, ticks:4968050
}
{
  real_time:507685.890664 global_time:951, event:`SYSCALL: mmap' (state:EXITING_SYSCALL) tid:13911, ticks:4968050
rax:0x7fe28deb0000 rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x5 rsi:0x208490 rdi:0x0 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x0 r10:0x802 r11:0x246 r12:0x802 r13:0x0 r14:0x3 r15:0x5 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
  { map_file:"/usr/lib64/libnss_sss.so.2", addr:0x7fe28deb0000, length:0x209000, prot_flags:"r-xp", file_offset:0x0, device:64768, inode:588541, data_file:"/usr/lib64/libnss_sss.so.2", data_offset:0x0, file_size:0x9130 }
}
{
  real_time:507685.890926 global_time:952, event:`SYSCALLBUF_FLUSH' tid:13911, ticks:4968091
  { syscall:'mprotect', ret:0x0, size:0x10 }
}
{
  real_time:507685.890939 global_time:953, event:`SYSCALL: mmap' (state:ENTERING_SYSCALL) tid:13911, ticks:4968091
rax:0xffffffffffffffda rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x3 rsi:0x2000 rdi:0x7fe28e0b7000 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x7000 r10:0x812 r11:0x246 r12:0x812 r13:0x7000 r14:0x3 r15:0x3 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.890947 global_time:954, event:`SYSCALLBUF_RESET' tid:13911, ticks:4968091
}
{
  real_time:507685.891034 global_time:955, event:`SYSCALL: mmap' (state:EXITING_SYSCALL) tid:13911, ticks:4968091
rax:0x7fe28e0b7000 rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x3 rsi:0x2000 rdi:0x7fe28e0b7000 rbp:0x9 rsp:0x681ffde0 r8:0x3 r9:0x7000 r10:0x812 r11:0x246 r12:0x812 r13:0x7000 r14:0x3 r15:0x3 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0x9 fs_base:0x7fe29f884740 gs_base:0x0
  { map_file:"/usr/lib64/libnss_sss.so.2", addr:0x7fe28e0b7000, length:0x2000, prot_flags:"rw-p", file_offset:0x7000, device:64768, inode:588541, data_file:"/usr/lib64/libnss_sss.so.2", data_offset:0x7000, file_size:0x9130 }
}
{
  real_time:507685.891284 global_time:956, event:`SYSCALLBUF_FLUSH' tid:13911, ticks:4973307
  { syscall:'close', ret:0x0, size:0x10 }
  { syscall:'mprotect', ret:0x0, size:0x10 }
}
{
  real_time:507685.891296 global_time:957, event:`SYSCALL: munmap' (state:ENTERING_SYSCALL) tid:13911, ticks:4973307
rax:0xffffffffffffffda rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x0 rsi:0xc6dd rdi:0x7fe29f88a000 rbp:0xb rsp:0x681ffde0 r8:0x7fe29f8884c8 r9:0x7fe29f8884c8 r10:0x0 r11:0x246 r12:0x80000001 r13:0x7ffc38c6b6a0 r14:0x7ffc38c6e508 r15:0x2 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0xb fs_base:0x7fe29f884740 gs_base:0x0
}
{
  real_time:507685.891303 global_time:958, event:`SYSCALLBUF_RESET' tid:13911, ticks:4973307
}
{
  real_time:507685.891357 global_time:959, event:`SYSCALL: munmap' (state:EXITING_SYSCALL) tid:13911, ticks:4973307
rax:0x0 rbx:0x681fffa0 rcx:0xffffffffffffffff rdx:0x0 rsi:0xc6dd rdi:0x7fe29f88a000 rbp:0xb rsp:0x681ffde0 r8:0x7fe29f8884c8 r9:0x7fe29f8884c8 r10:0x0 r11:0x246 r12:0x80000001 r13:0x7ffc38c6b6a0 r14:0x7ffc38c6e508 r15:0x2 rip:0x70000002 eflags:0x246 cs:0x33 ss:0x2b ds:0x0 es:0x0 fs:0x0 gs:0x0 orig_rax:0xb fs_base:0x7fe29f884740 gs_base:0x0
}
=== Start rr backtrace:
rr(_ZN2rr13dump_rr_stackEv+0x36)[0x9698ad]
rr(_ZN2rr9GdbServer15emergency_debugEPNS_4TaskE+0x168)[0x7bc696]
rr[0x7eadc9]
rr(_ZN2rr21EmergencyDebugOstreamD2Ev+0x5a)[0x7eafb4]
rr(_ZN2rr13RecordSession29handle_seccomp_traced_syscallEPNS_10RecordTaskEPNS0_9StepStateEPNS0_12RecordResultEPb+0x48c)[0x8264f0]
rr(_ZN2rr13RecordSession19handle_ptrace_eventEPPNS_10RecordTaskEPNS0_9StepStateEPNS0_12RecordResultEPb+0x324)[0x827558]
rr(_ZN2rr13RecordSession11record_stepEv+0x3a0)[0x82f126]
rr[0x822950]
rr(_ZN2rr13RecordCommand3runERSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE+0x37d)[0x823493]
rr(main+0x22a)[0x982c7e]
/usr/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f4b2a237555]
rr[0x725f39]
=== End rr backtrace
~~~

I have no clue if this is because of my change in this PR (then they shouldn't be merged) or if this is another issue (the please merge and let others test/fix on top of that)...