### PR TITLE
Add a few more v4l2 ioctls.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1931,6 +1931,7 @@ static Switchable prepare_ioctl(RecordTask* t,
     case IOCTL_MASK_SIZE(VIDIOC_S_CTRL):
     case IOCTL_MASK_SIZE(VIDIOC_G_INPUT):
     case IOCTL_MASK_SIZE(VIDIOC_QUERY_EXT_CTRL):
+    case IOCTL_MASK_SIZE(VIDIOC_G_PRIORITY):
     case IOCTL_MASK_SIZE(VFAT_IOCTL_READDIR_BOTH):
       syscall_state.reg_parameter(3, size, IN_OUT);
       return PREVENT_SWITCH;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1930,6 +1930,7 @@ static Switchable prepare_ioctl(RecordTask* t,
     case IOCTL_MASK_SIZE(VIDIOC_G_OUTPUT):
     case IOCTL_MASK_SIZE(VIDIOC_S_CTRL):
     case IOCTL_MASK_SIZE(VIDIOC_G_INPUT):
+    case IOCTL_MASK_SIZE(VIDIOC_QUERY_EXT_CTRL):
     case IOCTL_MASK_SIZE(VFAT_IOCTL_READDIR_BOTH):
       syscall_state.reg_parameter(3, size, IN_OUT);
       return PREVENT_SWITCH;

--- a/src/test/video_capture.c
+++ b/src/test/video_capture.c
@@ -78,6 +78,17 @@ static int open_device(void) {
     atomic_printf("%s VIDIOC_G_PRIORITY returns prio=%d\n", device_name, prio);
   }
 
+  struct v4l2_queryctrl qc;
+  memset(&qc, 0, sizeof(qc));
+  qc.id = V4L2_CTRL_FLAG_NEXT_CTRL;
+  ret = ioctl(fd, VIDIOC_QUERYCTRL, &qc);
+  if (ret < 0) {
+    atomic_printf("%s does not support VIDIOC_QUERYCTRL\n", device_name);
+  } else {
+    atomic_printf("%s VIDIOC_QUERYCTRL returns id=%d, type=%d, name=%s\n",
+                  device_name, qc.id, qc.type, qc.name);
+  }
+
   return fd;
 }
 

--- a/src/test/video_capture.c
+++ b/src/test/video_capture.c
@@ -58,6 +58,18 @@ static int open_device(void) {
   } else {
     atomic_printf("%s VIDIOC_G_INPUT returns %d\n", device_name, input);
   }
+
+  struct v4l2_query_ext_ctrl qec;
+  memset(&qec, 0, sizeof(qec));
+  qec.id = V4L2_CTRL_FLAG_NEXT_CTRL | V4L2_CTRL_FLAG_NEXT_COMPOUND;
+  ret = ioctl(fd, VIDIOC_QUERY_EXT_CTRL, &qec);
+  if (ret < 0) {
+    atomic_printf("%s does not support VIDIOC_QUERY_EXT_CTRL\n", device_name);
+  } else {
+    atomic_printf("%s VIDIOC_QUERY_EXT_CTRL returns id=%d, type=%d, name=%s\n",
+                  device_name, qec.id, qec.type, qec.name);
+  }
+
   return fd;
 }
 

--- a/src/test/video_capture.c
+++ b/src/test/video_capture.c
@@ -70,6 +70,14 @@ static int open_device(void) {
                   device_name, qec.id, qec.type, qec.name);
   }
 
+  enum v4l2_priority prio = V4L2_PRIORITY_UNSET;
+  ret = ioctl(fd, VIDIOC_G_PRIORITY, &prio);
+  if (ret < 0) {
+    atomic_printf("%s does not support VIDIOC_G_PRIORITY\n", device_name);
+  } else {
+    atomic_printf("%s VIDIOC_G_PRIORITY returns prio=%d\n", device_name, prio);
+  }
+
   return fd;
 }
 


### PR DESCRIPTION
These are used by `v4l2-ctl --all`.

Assuming that a partial support of VIDIOC_TRY_EXT_CTRLS,
that would lead to a diversion fault if an application uses it with
using the v4l2_ext_controls.controls pointer, I left that out.
In 307681ffa83 is a draft that supports just the v4l2_ext_controls.count==0 case.
