### PR TITLE
Support ioctl BLKSSZGET and BLKGETSIZE64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,6 +882,7 @@ set(BASIC_TESTS
   io
   io_uring
   ioctl
+  ioctl_blk
   ioctl_fb
   ioctl_fs
   ioctl_pty

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1735,6 +1735,7 @@ static Switchable prepare_ioctl(RecordTask* t,
       syscall_state.reg_parameter<typename Arch::termio>(3);
       return PREVENT_SWITCH;
 
+    case BLKSSZGET:
     case KDGKBMODE:
     case TIOCINQ:
     case TIOCOUTQ:
@@ -1976,6 +1977,7 @@ static Switchable prepare_ioctl(RecordTask* t,
     case IOCTL_MASK_SIZE(JSIOCGNAME(0)):
     case IOCTL_MASK_SIZE(HIDIOCGRAWINFO):
     case IOCTL_MASK_SIZE(HIDIOCGRAWNAME(0)):
+    case IOCTL_MASK_SIZE(BLKGETSIZE64):
       syscall_state.reg_parameter(3, size);
       return PREVENT_SWITCH;
 

--- a/src/test/ioctl_blk.c
+++ b/src/test/ioctl_blk.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  int fd = open("/dev/sda1", O_NONBLOCK | O_RDONLY);
+  if (fd < 0) {
+    test_assert(errno == EACCES || errno == ENOENT);
+    atomic_printf("Opening a block device usually needs root permission, skipping test\n");
+  } else {
+    int sector_size;
+    test_assert(0 == ioctl(fd, BLKSSZGET, &sector_size));
+    atomic_printf("BLKSSZGET returned sector_size=%d\n", sector_size);
+
+    unsigned long long bytes = 0;
+    test_assert(0 == ioctl(fd, BLKGETSIZE64, &bytes));
+    atomic_printf("BLKGETSIZE64 returned bytes=%llu\n", bytes);
+  }
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Tried to investigate a crash in gparted, which executes `blkid`, which needs these ioctls.

I am not certain about the test, because in its current form will be mostly skipped because missing permission as regular user.
And should it be added to an existing test or stay separate?
What do you think?