### PR TITLE
Call an executable matching to rr signedness for the nested-release test.

### DIFF
--- a/src/test/hello.c
+++ b/src/test/hello.c
@@ -2,7 +2,11 @@
 
 #include "util.h"
 
-int main(void) {
-  atomic_puts("Hi");
+int main(int argc, char *argv[]) {
+  if (argc <= 1) {
+    atomic_puts("Hi");
+  } else {
+    atomic_puts(argv[1]);
+  }
   return 0;
 }

--- a/src/test/nested_release.run
+++ b/src/test/nested_release.run
@@ -1,5 +1,5 @@
 source `dirname $0`/util.sh
-just_record $(which rr) "record --nested=release echo NOT-IN-REPLAY"
+just_record $(which rr) "record --nested=release hello NOT-IN-REPLAY"
 # Replay outer
 replay
 if [[ $(grep -l NOT-IN-REPLAY replay.out) ]]; then


### PR DESCRIPTION
Otherwise tests with force32bit rr would fail with the following error:
    `ERROR: ld.so: object '..../librrpreload.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.`