### PR TITLE
Fix build error -Werror=type-limits

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1509,7 +1509,7 @@ bool read_proc_net_socket_addresses(Task* t, int fd,
         LOG(warn) << "Remote address not in expected format";
         break;
       }
-      uint16_t rport = strtoul(remote_addr_str + 33, NULL, 16);
+      unsigned long rport = strtoul(remote_addr_str + 33, NULL, 16);
       if (rport > USHRT_MAX) {
         LOG(warn) << "Remote address not in expected format";
         break;


### PR DESCRIPTION
```
    rr/src/util.cc:1513:17: error: comparison is always false due to limited
    range of data type [-Werror=type-limits]
           if (rport > USHRT_MAX) {
```