### PR TITLE
audit/stap-note-iter: map ELF header directly

### DIFF
--- a/src/audit/stap-note-iter.h
+++ b/src/audit/stap-note-iter.h
@@ -17,7 +17,6 @@ typedef struct {
 typedef struct {
   /*< private >*/
   const struct link_map* map;
-  const void* base;
   int fd;
   uintptr_t stapbase;
   const ElfW(Shdr) *shdrs, *shdr_iter, *shdr_end;


### PR DESCRIPTION
In order to dig around in a loaded object's STap probe sections,
stap_note_iter_init() tries to find the address at which the ELF
header was mapped by the linker/kernel; to do this, it uses a function
private to glibc (_dl_addr) to find the base address of an object in
memory given the provided pointer to its dynamic segment.

At some point (apparently due a toolchain update between F34 and F35,
but I'm not entirely sure) this stopped working because _dl_addr() is
no longer being exported in libc's DT_GNU_HASH table: the execution of
stap_note_iter_init() triggers an exit when the PLT stub fails to
resolve the symbol.

Rather than using some other functionality or poking around trying to
find where the header might already be mapped, this commit has the
function just map it as required. (I have no idea why I wrote it like
this in the first place; I suspect I was being too clever by half.)