### PR TITLE
add support for Intel Xeon Platinum 8352Y cpu

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -65,6 +65,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x506f0:
       return IntelGoldmont;
     case 0x706e0:
+    case 0x606a0:
       return IntelIcelake;
     case 0x806c0:
     case 0x806d0:


### PR DESCRIPTION
Add support for Intel Xeon Platinum 8352Y cpu, this a new product intel release recently, this pr add support to this cpu model.