### PR TITLE
Avoid hard-coding bash path

### DIFF
--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install the prerequisites needed to build and run tests on travis-ci.
 

--- a/scripts/signal-rr-recording.sh
+++ b/scripts/signal-rr-recording.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 signal=$1
 if [[ "$signal" == "" ]]; then

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function fatal { why=$1;
     echo "[FATAL]" $why >&2

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function fatal { why=$1;
     echo "[FATAL]" $why >&2


### PR DESCRIPTION
Systems may have bash in different paths, so find bash with env.