### PR TITLE
Add cpu_type for Intel Alder Lake.

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -69,7 +69,8 @@ enum CpuMicroarch {
   IntelCometlake,
   IntelIcelake,
   IntelTigerlake,
-  LastIntel = IntelTigerlake,
+  IntelAlderlake,
+  LastIntel = IntelAlderlake,
   FirstAMD,
   AMDF15R30 = FirstAMD,
   AMDZen,
@@ -124,6 +125,7 @@ struct PmuConfig {
 // See Intel 64 and IA32 Architectures Performance Monitoring Events.
 // See check_events from libpfm4.
 static const PmuConfig pmu_configs[] = {
+  { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 0, 100, PMU_TICKS_RCB },
   { IntelTigerlake, "Intel Tigerlake", 0x5111c4, 0, 0, 0, 100, PMU_TICKS_RCB },
   { IntelIcelake, "Intel Icelake", 0x5111c4, 0, 0, 0, 100, PMU_TICKS_RCB },
   { IntelCometlake, "Intel Cometlake", 0x5101c4, 0, 0x5301cb, 0, 100, PMU_TICKS_RCB },

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -76,6 +76,8 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0xa0650:
     case 0xa0660:
 	return IntelCometlake;
+    case 0x90670:
+      return IntelAlderlake;
     case 0x30f00:
       return AMDF15R30;
     case 0x00f10: // Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen) (UNTESTED)


### PR DESCRIPTION
This adds the ```cpu_type``` definition, which is enough to make most 64-bits tests pass. All 32-bit tests fail with

```1358: rr: ../src/ExtraRegisters.cc:665: void rr::ExtraRegisters::reset(): Assertion `d.xsave_feature_bit == PKRU_FEATURE_BIT' failed.```

Still investigating that.