### PR TITLE
Add AMD Lucienne; fix error message logic.

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -86,6 +86,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x30f10: // Rome, Castle Peak (Zen 2)
     case 0x60f00: // Renoir (Zen 2) (UNTESTED)
     case 0x70f10: // Matisse (Zen 2) (UNTESTED)
+    case 0x60f80: // Lucienne
       if (ext_family == 8) {
         return AMDZen;
       } else if (ext_family == 3) {

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -102,7 +102,7 @@ static CpuMicroarch compute_cpu_microarch() {
       break;
   }
 
-  if (!strcmp(vendor, "AuthenticAMD")) {
+  if (!strncmp(vendor, "AuthenticAMD", sizeof(vendor))) {
     CLEAN_FATAL() << "AMD CPU type " << HEX(cpu_type) << " unknown";
   } else {
     CLEAN_FATAL() << "Intel CPU type " << HEX(cpu_type) << " unknown";


### PR DESCRIPTION
```
The following tests FAILED:
	901 - cont_race-no-syscallbuf (Failed)
	1021 - perf_event_mmap-no-syscallbuf (Failed)
	2262 - crash_in_function-32 (Failed)
	2263 - crash_in_function-32-no-syscallbuf (Failed)
	2377 - perf_event_mmap-32-no-syscallbuf (Failed)
```
[The files in Testing/Temporary: ](https://drive.google.com/file/d/15mpgeb76qvUmGACOLzcCxV2Gij0jz0LG/view?usp=sharing)

