### PR TITLE
Correct GDB feature name for segment registers

### DIFF
--- a/third-party/gdb/64bit-seg.xml
+++ b/third-party/gdb/64bit-seg.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE feature SYSTEM "gdb-target.dtd">
-<feature name="org.gnu.gdb.i386.seg">
+<feature name="org.gnu.gdb.i386.segments">
   <reg name="fs_base" bitsize="64" type="data_ptr"/>
   <reg name="gs_base" bitsize="64" type="data_ptr"/>
 </feature>


### PR DESCRIPTION
I was playing with making use of these from the GDB side
and just got garbage because the name was off, so there
were actually two copies of these registers (the one that
GDB allocated and the one it got from the XML). Unfortunately,
I don't really know of a good test for this from the GDB prompt.

See https://github.com/bminor/binutils-gdb/blob/master/gdb/features/i386/64bit-segments.xml