### PR TITLE
Fix two test failures seen locally

### DIFF
--- a/src/test/comm.py
+++ b/src/test/comm.py
@@ -2,6 +2,6 @@ from util import *
 import re
 
 send_gdb('info threads')
-expect_gdb(r'1\s+Thread \d+\.\d+ \(simple-[A-Za-z0-9]+\)')
+expect_gdb(r'1\s+Thread \d+\.\d+ \(simple(_32)?-[A-Za-z0-9]+\)')
 
 ok()

--- a/src/test/fcntl_misc.c
+++ b/src/test/fcntl_misc.c
@@ -9,10 +9,19 @@ int main(void) {
 
   ret = pipe(fds);
   test_assert(ret == 0);
-  ret = fcntl(fds[0], F_SETPIPE_SZ, 2 * page_size);
-  test_assert(ret == (int)(2 * page_size));
+  size_t new_size = 2 * page_size;
+  ret = fcntl(fds[0], F_SETPIPE_SZ, new_size);
+  if (ret == -EPERM) {
+    // Pipe resource buffer exhausted, e.g. due to
+    // /proc/sys/fs/pipe-max-size or /proc/sys/fs/pipe-user-pages-{hard, soft}.
+    atomic_puts("Pipe buffer exausted during F_SETPIPE_SZ. Skipping.");
+    new_size = page_size;
+  } else {
+    test_assert(ret == (int)(new_size));
+  }
+
   ret = fcntl(fds[1], F_GETPIPE_SZ);
-  test_assert(ret == (int)(2 * page_size));
+  test_assert(ret == (int)(new_size));
 
   atomic_puts("EXIT-SUCCESS");
   return 0;


### PR DESCRIPTION
- `test_fcntl`, which failed because the pipe limit was restricted on my kernel
- `comm`, which didn't account for 32bit