### PR TITLE
Handle unexpected exits in desched processing (fixes #3000)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,6 +814,7 @@ set(BASIC_TESTS
   cwd_inaccessible
   daemon
   desched_blocking_poll
+  desched_sigkill
   detach_state
   detach_threads
   deterministic_sigsys

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -874,6 +874,9 @@ static void advance_to_disarm_desched_syscall(RecordTask* t) {
   /* TODO: mask off signals and avoid this loop. */
   do {
     t->resume_execution(RESUME_SYSCALL, RESUME_WAIT, RESUME_UNLIMITED_TICKS);
+    if (t->is_dying()) {
+      return;
+    }
     /* We can safely ignore TIME_SLICE_SIGNAL while trying to
      * reach the disarm-desched ioctl: once we reach it,
      * the desched'd syscall will be "done" and the tracee

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1413,7 +1413,7 @@ void Task::resume_execution(ResumeRequest how, WaitRequest wait_how,
   flush_regs();
 
   pid_t wait_ret = 0;
-  if (session().is_recording()) {
+  if (session().is_recording() && !is_dying()) {
     /* There's a nasty race where a stopped task gets woken up by a SIGKILL
      * and advances to the PTRACE_EXIT_EVENT ptrace-stop just before we
      * send a PTRACE_CONT. Our PTRACE_CONT will cause it to continue and exit,
@@ -1446,7 +1446,7 @@ void Task::resume_execution(ResumeRequest how, WaitRequest wait_how,
           << "waitpid(" << tid << ", NOHANG) failed with " << wait_ret;
     }
   }
-  if (wait_ret > 0 || handled_ptrace_exit_event) {
+  if (wait_ret > 0 || is_dying()) {
     LOG(debug) << "Task " << tid << " exited unexpectedly";
     // wait() will see this and report the ptrace-exit event.
     detected_unexpected_exit = true;

--- a/src/test/desched_sigkill.c
+++ b/src/test/desched_sigkill.c
@@ -1,0 +1,72 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+#define NUM_READERS 10
+
+static int parent_to_child[2];
+static int child_to_parent[2];
+
+int main(void) {
+  int ret, status;
+  char ch;
+
+  // This test is a bit non-deterministic, because it relies on the kernel's
+  // scheduling behavior. The scheduling we're looking to test is:
+  //   1. The parent process releases the readers from `read` syscall.
+  //   2. The reader gets scheduled and advances to the syscall exit trap.
+  //   3. The parent gets scheduled and kills the reader.
+  //   4. `rr` gets scheduled and sees the exit trap.
+  //
+  // There are several ways this can go wrong. If the reader doesn't get scheduled
+  // before the parent's kill syscall, then rr will never see the syscall exit
+  // trap, which doesn't trigger the behavior we're interested in. Similarly,
+  // if the reader gets scheduled before `rr`, then it gets advanced to the
+  // exit trap again and rr will similarly never see it.
+  //
+  // To increase our chances of seeing this scheduling behavior, we lower the
+  // priority of the test executable here. The idea is to make rr more likely
+  // to run if it's runnable at all, in order to decrease the likelihood of
+  // the readers being scheduled again between points 3. and 4. above (while
+  // keeping the parent and the readers at the same priority to hopefully get
+  // the kernel to at least schedule one of the readers at point 2).
+  int prio = getpriority(PRIO_PROCESS, 0);
+  setpriority(PRIO_PROCESS, 0, prio >= 15 ? 20 : prio + 5);
+
+  test_assert(0 == pipe(parent_to_child));
+  test_assert(0 == pipe(child_to_parent));
+
+  pid_t pids[NUM_READERS];
+  for (int i = 0; i < NUM_READERS; ++i) {
+    pids[i] = fork();
+    if (pids[i] == 0) {
+        test_assert(1 == write(child_to_parent[1], "x", 1));
+        test_assert(1 == read(parent_to_child[0], &ch, 1) && ch == 'y');
+        pause();
+        return 77;
+    }
+  }
+
+  // Phase 1: Wait for all readers to become ready.
+  char chs[NUM_READERS];
+  int sum = 0;
+  while (sum < NUM_READERS) {
+    ret = read(child_to_parent[0], &chs, NUM_READERS);
+    test_assert(ret > 0);
+    sum += ret;
+  }
+
+  // Phase 2: Release readers from `read` syscall.
+  test_assert(NUM_READERS == write(parent_to_child[1], chs, NUM_READERS));
+
+  // Phase 3: Kill readers.
+  for (int i = 0; i < NUM_READERS; ++i) {
+    kill(pids[i], SIGKILL);
+  }
+
+  for (int i = 0; i < NUM_READERS; ++i) {
+    test_assert(waitpid(pids[i], &status, 0) == pids[i]);
+    test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL);
+  }
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/desched_sigkill.c
+++ b/src/test/desched_sigkill.c
@@ -40,7 +40,7 @@ int main(void) {
     pids[i] = fork();
     if (pids[i] == 0) {
         test_assert(1 == write(child_to_parent[1], "x", 1));
-        test_assert(1 == read(parent_to_child[0], &ch, 1) && ch == 'y');
+        test_assert(1 == read(parent_to_child[0], &ch, 1) && ch == 'x');
         pause();
         return 77;
     }


### PR DESCRIPTION
There are two issues here:
1. We shouldn't attempt to do a `waitpid` if we know the process is
   dying, because our `waitpid` calling is pretty carefully choreographed
   after receiving PTRACE_EVENT_EXIT and an extra waitpid messes that up.
2. `advance_to_disarm_desched_syscall` wasn't robust to the possibility
   that the task could die and would infinite loop.

Fix both by adding appropriate checks. Fixes #3000.