### PR TITLE
Forward SIGKILL to detached children (fix #3016)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,7 @@ set(BASIC_TESTS
   desched_sigkill
   detach_state
   detach_threads
+  detach_sigkill
   deterministic_sigsys
   dev_zero
   direct

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -172,6 +172,7 @@ public:
 
   RecordTask* find_task(pid_t rec_tid) const;
   RecordTask* find_task(const TaskUid& tuid) const;
+  RecordTask* find_detached_proxy_task(pid_t proxt_tid) const;
 
   void on_proxy_detach(RecordTask *t, pid_t new_tid);
 
@@ -254,6 +255,11 @@ private:
    * When true, wait for all tracees to exit before finishing recording.
    */
   bool wait_for_all_;
+
+  /**
+   * Keeps track of detached tasks.
+   */
+  std::map<pid_t, RecordTask*> detached_task_map;
 
   std::string output_trace_dir;
 

--- a/src/test/detach_sigkill.c
+++ b/src/test/detach_sigkill.c
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util_internal.h"
+
+static int parent_to_child[2];
+static int child_to_parent[2];
+
+int main(__attribute__((unused)) int argc,
+         __attribute__((unused)) char **argv) {
+    int status;
+    char ch;
+    pid_t pid;
+
+    test_assert(0 == pipe(parent_to_child));
+    test_assert(0 == pipe(child_to_parent));
+
+    if (0 == (pid = fork())) {
+        if (running_under_rr()) {
+            rr_detach_teleport();
+        }
+        // Signal that we are ready
+        test_assert(1 == read(parent_to_child[0], &ch, 1) && ch == 'y');
+        test_assert(1 == write(child_to_parent[1], "x", 1));
+        pause();
+        test_assert(0);
+    }
+
+    test_assert(1 == write(parent_to_child[1], "y", 1));
+    test_assert(1 == read(child_to_parent[0], &ch, 1) && ch == 'x');
+
+    kill(pid, SIGKILL);
+
+    test_assert(pid == waitpid(pid, &status, 0));
+    test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL);
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+}


### PR DESCRIPTION
When we detach a child, we keep around the zombie (or more accurately,
we keep it in PTRACE_EVENT_EXIT state) of the original process to
prevent the kernel from re-using it's pid and to enable
basic wait4 processing using the original child's tid to make the
detach of the child as transparent as possible to any traced parent.
However so far, we did not handle signals targeting the original tid.
That's not really a big problem, because ptrace zombies don't really have
signal handling. As an exception to this however, a SIGKILL will advance
the ptrace zombie out of PTRACE_EVENT_EXIT state and into a proper zombie
state, which our `wait_any` listener will reap. This reaping then
confuses our later handling of this process leading to #3016. Fix that
by keeping track of the detached proxies and forwarding any received
SIGKILLs after which our regular processing will take care of notifying
the parent appropriately.

Fixes #3016.