### PR TITLE
Task::proceed_to_exit - ask return before death

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -169,6 +169,8 @@ void Task::proceed_to_exit(bool wait) {
   ASSERT(this, ret == 0 || (ret == -1 && errno == ESRCH))
     << "Got ret=" << ret << " errno=" << errno;
   if (wait) {
+    const int waitflag = PTRACE_O_TRACEEXIT;
+    fallible_ptrace(PTRACE_SETOPTIONS, nullptr, (void *)waitflag);
     wait_exit();
   }
 }


### PR DESCRIPTION
which should allow to get more information like registers at process end

WARNING NOTE: this is not tested other than "still runs some tests it did before".
The reason for this PR is that I've read a bit both in the issue tracker (also about the need to be able to peek the registers at different places) and the manpage which says:

> If the `PTRACE_O_TRACEEXIT` option is on, `PTRACE_EVENT_EXIT` will happen before actual death.  This applies to exits via exit(2), exit_group(2), and signal deaths (except `SIGKILL`, depending on the kernel version; see BUGS below), and when threads are torndown on execve(2) in a multithreaded process.

I have nearly no experience about this and just "hacked this together according to my understanding of the docs".

If it does what I think it is then it will allow RR to record more about the process end (if this isn't used now then it would still be available later).

This definitely needs to be checked by someone that _understands_ what happens here and ideally also knows where rr _may_ be enhanced afterwards.