### PR TITLE
Fix rr vdso symbols on even older libc

### DIFF
--- a/src/preload/rr_page.ld
+++ b/src/preload/rr_page.ld
@@ -41,6 +41,8 @@ SECTIONS
 VERSION {
   LINUX_2.6 {
     global:
+      gettimeofday;
+      clock_gettime;
       __vdso_gettimeofday;
       __vdso_clock_getres;
       __vdso_time;

--- a/src/preload/rr_vdso.S
+++ b/src/preload/rr_vdso.S
@@ -38,6 +38,8 @@ WEAK_ALIAS(time, __vdso_time)
 WEAK_ALIAS(clock_gettime, __vdso_clock_gettime)
 WEAK_ALIAS(gettimeofday,__vdso_gettimeofday)
 
+.symver gettimeofday,gettimeofday@LINUX_2.6
+.symver clock_gettime,clock_gettime@LINUX_2.6
 .symver __vdso_gettimeofday,__vdso_gettimeofday@LINUX_2.6
 .symver __vdso_clock_getres,__vdso_clock_getres@LINUX_2.6
 .symver __vdso_time,__vdso_time@LINUX_2.6


### PR DESCRIPTION
In 38571520bee9360aeb454a14be1de43e7490f324, we added symbol versioning
to our fake vdso to support Chromium which was looking for these entries
in the vdso. Unfortunately, this broke older libcs' symbol lookup which
specified LINUX2.6 as a symbol version (if the vdso isn't versioned at
all, the symbol version specifier is ignored). This got fixed in
In 8a15f2acdd39d799001c98107e72c2bed4ec63e9, where vdso versioning was
added for __vdso symbols. However, even older libs appear to be looking
for symbols without the __vdso prefix (but still versioned), so add those
as well.