### PR TITLE
Fix SIGKILL racing with detached proxy exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,7 @@ set(BASIC_TESTS
   detach_state
   detach_threads
   detach_sigkill
+  detach_sigkill_exit
   deterministic_sigsys
   dev_zero
   direct

--- a/src/test/detach_sigkill_exit.c
+++ b/src/test/detach_sigkill_exit.c
@@ -1,0 +1,43 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util_internal.h"
+
+static int parent_to_child[2];
+static int child_to_parent[2];
+
+int main(__attribute__((unused)) int argc,
+         __attribute__((unused)) char **argv) {
+    int status;
+    char ch;
+    pid_t pid;
+    siginfo_t sig;
+
+    test_assert(0 == pipe(parent_to_child));
+    test_assert(0 == pipe(child_to_parent));
+
+    if (0 == (pid = fork())) {
+        if (running_under_rr()) {
+            rr_detach_teleport();
+        }
+        // Signal that we are ready
+        test_assert(1 == read(parent_to_child[0], &ch, 1) && ch == 'y');
+        exit(24);
+    }
+
+    test_assert(1 == write(parent_to_child[1], "y", 1));
+
+    // Give the child a chance to finish exiting
+    test_assert(0 == waitid(P_PID, pid, &sig, WNOWAIT | WEXITED));
+    test_assert(sig.si_pid == pid && sig.si_code == CLD_EXITED && sig.si_status == 24);
+
+    // Now kill the detach proxy before reaping the child
+    kill(pid, SIGKILL);
+
+    // Let rr listen for the SIGKILL event
+    usleep(100);
+
+    test_assert(pid == waitpid(pid, &status, 0));
+    test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 24);
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+}


### PR DESCRIPTION
This fixes the failure seen in [1], which in relevant part looks
like this:
```
[FATAL /workspace/srcdir/rr/src/Scheduler.cc:526:find_waited_task() errno: ECHILD]
 (task 6055 (rec:6087) at time 62487)
 -> Assertion `npid == waited->rec_tid' failed to hold.
[INFO log_pending_events()] SYSCALL: rrcall_detach_teleport
```

This is a supplement to cfb5163c2, which was incomplete. In particular, if a
detached process has already exited, then its PID was reaped, so we
must not attempt to SIGKILL it.

[1] https://build.julialang.org/#/builders/70/builds/919/steps/5/logs/stdio