### PR TITLE
Fix build on old glibc

### DIFF
--- a/src/EmuFs.cc
+++ b/src/EmuFs.cc
@@ -4,6 +4,7 @@
 
 #include <syscall.h>
 #include <sys/mman.h>
+#include <linux/fs.h>
 
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
Courtesy of the julia deployment system which wants to keep compatibility
with CentOS6 for certain HPC users ;). This is for the `SEEK_HOLE`/`SEEK_DATA`
definitions. Builds fine locally on modern libc also.