### PR TITLE
Respect RR_LOG after detach / add --log cli switch

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -770,6 +770,9 @@ int RecordCommand::run(vector<string>& args) {
           exec_child(args);
           return 1;
         }
+        // running_under_rr() changed - respect the log specification from RR_LOG
+        // just as if we hadn't been running under rr.
+        apply_log_spec_from_env();
         break;
       }
       default:

--- a/src/log.h
+++ b/src/log.h
@@ -62,6 +62,18 @@ bool is_logging_enabled(LogLevel level, const char* file);
  */
 void flush_log_buffer();
 
+/**
+ * Parse the (RR_UNDER_)RR_LOG environment variable and logging
+ * levels appropriately.
+ */
+void apply_log_spec_from_env();
+
+/**
+ * Set log level according to the specification in spec, according to the format
+ * used by (RR_UNDER_)RR_LOG and `rr --log`.
+ */
+void apply_log_spec(const char *spec);
+
 struct NewlineTerminatingOstream {
   /**
    * `file` must be a pointer that is valid forever, preferably

--- a/src/main.cc
+++ b/src/main.cc
@@ -84,6 +84,7 @@ void print_global_options(FILE* out) {
       "  -S, --suppress-environment-warnings\n"
       "                             suppress warnings about issues in the\n"
       "                             environment that rr has no control over\n"
+      "  --log=<spec>               Set logging config to <spec>. See RR_LOG.\n"
       "\n"
       "Environment variables:\n"
       " $RR_LOG        logging configuration ; e.g. RR_LOG=all:warn,Task:debug\n"
@@ -125,6 +126,7 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 0, "disable-cpuid-faulting", NO_PARAMETER },
     { 1, "disable-ptrace-exit-events", NO_PARAMETER },
     { 2, "resource-path", HAS_PARAMETER },
+    { 3, "log", HAS_PARAMETER },
     { 'A', "microarch", HAS_PARAMETER },
     { 'C', "checksum", HAS_PARAMETER },
     { 'D', "dump-on", HAS_PARAMETER },
@@ -156,6 +158,9 @@ bool parse_global_option(std::vector<std::string>& args) {
       if (flags.resource_path.back() != '/') {
         flags.resource_path.append("/");
       }
+      break;
+    case 3:
+      apply_log_spec(opt.value.c_str());
       break;
     case 'A':
       flags.forced_uarch = opt.value;


### PR DESCRIPTION
Both #3037 and #3038 are missing log output, despite RR_LOG (and RR_LOG_BUFFER)
being set. This is because they were started under another rr session with
`--nested=detach`, so their configuration variable automatically changed to
`RR_UNDER_RR_LOG`. Given the use case of `--nested=detach` to parallelize a
bunch of recordings, I don't think this behavior is particularly useful.
This tries to improve the situation by:

1. Making rr reload the logging configuration after a detach
2. Adding an `rr --log=...` cli switch to make it easier to force
   a particular logging configuration for a particular rr execution
   independent of which nesting level they're at.