### PR TITLE
Handle backwards compatibility for traces without force_tick.

### DIFF
--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1390,7 +1390,7 @@ Completion ReplaySession::flush_syscallbuf(ReplayTask* t,
   r.set_ip(r.ip().increment_by_movrm_insn_length(t->arch()));
   t->set_regs(r);
 
-  if (current_step.flush.recorded_ticks <= t->tick_count()) {
+  if (current_step.flush.recorded_ticks <= t->tick_count() && has_trace_quirk(TraceReader::BufferedSyscallForcedTick)) {
     // We've reached the breakpoint and executed at least as many ticks as were recorded for the FLUSH_SYSCALLBUF.
     // That means the flush was actually performed before we left the syscallbuf code, i.e. due to a SIGKILL
     // in syscallbuf code. We will have recorded another execution event that triggered a flush, but just ignore it,

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -1419,6 +1419,7 @@ void TraceWriter::close(CloseStatus status, const TraceUuid* uuid) {
     quirks.setExplicitProcMem(false);
     quirks.setSpecialLibrrpage(false);
     quirks.setPkeyAllocRecordedExtraRegs(true);
+    quirks.setBufferedSyscallForcedTick(true);
   }
   // Add a random UUID to the trace metadata. This lets tools identify a trace
   // easily.
@@ -1592,6 +1593,9 @@ TraceReader::TraceReader(const string& dir)
     }
     if (quirks.getPkeyAllocRecordedExtraRegs()) {
       quirks_ |= PkeyAllocRecordedExtraRegs;
+    }
+    if (quirks.getBufferedSyscallForcedTick()) {
+      quirks_ |= BufferedSyscallForcedTick;
     }
   }
   Data::Reader uuid = header.getUuid();

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -25,7 +25,7 @@ namespace rr {
 /**
  * Bump this when rr changes mean that traces produced by new rr can't be replayed by old rr.
  */
-const int FORWARD_COMPATIBILITY_VERSION = 2;
+const int FORWARD_COMPATIBILITY_VERSION = 3;
 
 struct CPUIDRecord;
 struct DisableCPUIDFeatures;
@@ -482,7 +482,9 @@ public:
     // added in 3aaf792 and later removed.
     SpecialLibRRpage = 0x2,
     // Whether this trace recorded extra regs for pkey_alloc(2).
-    PkeyAllocRecordedExtraRegs = 0x4
+    PkeyAllocRecordedExtraRegs = 0x4,
+    // Whether this trace forced a tick after buffered syscalls.
+    BufferedSyscallForcedTick = 0x8
   };
 
   int quirks() const { return quirks_; }

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -110,6 +110,10 @@ struct Header {
     # Whether the version of rr that recorded this saved the extra registers
     # for the pkey_alloc syscall.
     pkeyAllocRecordedExtraRegs @20 :Bool = false;
+
+    # Whether the version of rr that recorded this forced a tick after each
+    # buffered syscall.
+    bufferedSyscallForcedTick @21 :Bool = false;
   }
   # Are we known to be in chaos mode? Useful for debugging.
   chaosMode @16 :ChaosMode = unknown;


### PR DESCRIPTION
Fixes #3041