### PR TITLE
Set up Buildkite CI on the `juliaecosystem` queue provided by the Julia Project

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,18 @@
+steps:
+  - label: "Build and test"
+    agents:
+      os: "linux"
+      queue: "juliaecosystem"
+    timeout_in_minutes: 60
+    commands: |
+      echo "Print kernel information"
+      uname -a
+      echo "--- Generate build environment"
+      rm -rf obj
+      mkdir obj
+      cd obj
+      cmake ..
+      echo "--- Build"
+      make -j8
+      echo "--- Test"
+      ctest -j8


### PR DESCRIPTION
In the Julia Project, we use Buildkite[^1] to run CI on our own machines. Most of our machines are reserved for use by Base Julia CI on the main Julia repository[^2]. However, we do have one Buildkite queue (the `juliaecosystem` queue) that is intended for use by repositories in the Julia ecosystem.

We thought it might be nice to use the `juliaecosystem` queue to offer some of our CI resources to the rr project.

[^1]: https://buildkite.com/julialang
[^2]: https://github.com/JuliaLang/julia