### PR TITLE
test/getsid: 0 is a valid session ID

### DIFF
--- a/src/test/getsid.c
+++ b/src/test/getsid.c
@@ -5,7 +5,7 @@
 int main(void) {
   pid_t sid = getsid(0);
   atomic_printf("getsid(0) session ID: %d\n", sid);
-  test_assert(sid > 0);
+  test_assert(sid >= 0);
 
   atomic_puts("EXIT-SUCCESS");
 


### PR DESCRIPTION
`getsid` can return `0` if the session leader is not a member of the calling process's pid namespace. Don't fail the test in this case. `getsid` returns -1 on error.