### PR TITLE
test/ioctl_tty: Allow for 0 pid of controlling tty pgrp

### DIFF
--- a/src/test/ioctl_tty.c
+++ b/src/test/ioctl_tty.c
@@ -60,8 +60,12 @@ int main(void) {
   ALLOCATE_GUARD(pgrp, 'c');
   test_assert(0 == ioctl(fd, TIOCGPGRP, pgrp));
   VERIFY_GUARD(pgrp);
-  atomic_printf("TIOCGPGRP returned process group %d\n", *pgrp);
-  test_assert(0 == ioctl(fd, TIOCSPGRP, pgrp));
+  if (*pgrp != 0) {
+    atomic_printf("TIOCGPGRP returned process group %d\n", *pgrp);
+    test_assert(0 == ioctl(fd, TIOCSPGRP, pgrp));
+  } else {
+    atomic_printf("Skipping TIOCSPGRP test - controlling tty outside PID ns.");
+  }
 
   ALLOCATE_GUARD(navail, 'd');
   test_assert(0 == ioctl(fd, TIOCINQ, navail));


### PR DESCRIPTION
Similar to #3047, if the pgrp of the controlling tty is outside of
the current task's pid namespace, `TIOCGPGRP` will return 0, which
is not a valid argument for `TIOCSPGRP`.