### PR TITLE
CI: pass `verbose: true` to the sandbox plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
       - staticfloat/sandbox#v1:
           rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v4.17/rr.x86_64.tar.gz
           rootfs_treehash: "838680473e6ffd8977e1957904d418640e75f69e"
+          verbose: true
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled
           version: '1.6'


### PR DESCRIPTION
This allows us to see what versions of `Sandbox.jl` and `UserNSSandbox_jll.jl` are being used.