### PR TITLE
[`gh-pages`] Remove the `ci` link from the navigation bar at the top of the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
   <div id="old">
     <marquee scrollamount="40">
       <blink>
-        <div> 
+        <div>
           <div><img src="flag.gif"><img src="mchammer.gif"><img src="flag.gif">
             <img src="mchammer.gif"><img src="flag.gif"></div>
           <div><span>W</span><span>E</span><span>L</span><span>C</span><span>O</span><span>M</span><span>E</span> <span>T</span><span>O</span> <span>R</span><span>R</span></div>
@@ -160,7 +160,6 @@
     <div>
       <ul id="topmenu">
         <li><a href="https://github.com/rr-debugger/rr">github</a></li>
-        <li><a href="https://ci.rr-project.org">ci</a></li>
         <li><a href="https://groups.google.com/g/rr-devel">mailing
             list</a></li>
         <li><a href="https://github.com/rr-debugger/rr/wiki/News">news</a></li>
@@ -221,7 +220,7 @@ GNU gdb (GDB) ...
       execution.  The replayed execution's address spaces, register
       contents, syscall data etc are exactly the same in every run.
     <p>
-      Most of the common gdb commands can be used.  
+      Most of the common gdb commands can be used.
       <pre>(gdb) break mozilla::dom::HTMLMediaElement::HTMLMediaElement
 ...
 (gdb) continue


### PR DESCRIPTION
Note: the base (target) branch of this pull request is the `gh-pages` branch.

---

Currently, the navigation bar at the top of the website has a `ci` link that points to `https://ci.rr-project.org/`, which seems to no longer exist.

Therefore, I suggest removing the `ci` link from the navigation bar.

Once all tests are passing on Buildkite, I would suggest merging #3052, which adds a Buildkite badge to the README.