### PR TITLE
parse_threadid: Tolerate \0 or ; or ,

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -368,20 +368,22 @@ static GdbThreadId parse_threadid(const char* str, char** endptr) {
   }
   t.pid = strtol(str, &endp, 16);
   parser_assert(endp);
-  if ('\0' == *endp) {
+
+  /* terminators (single process, no PID or TID, depending on 'p' prefix) */ 
+  if (*endp == '\0' || *endp == ';' || *endp == ',') {
     if (multiprocess) {
       t.tid = -1;
     } else {
       t.tid = t.pid;
       t.pid = -1;
     }
-    *endptr = endp;
-    return t;
+  /* multiprocess syntax "<pid>.<tid>" */
+  } else if (*endp == '.') {
+    str = endp + 1;
+    t.tid = strtol(str, &endp, 16);
   }
 
-  parser_assert('.' == *endp);
-  str = endp + 1;
-  t.tid = strtol(str, &endp, 16);
+  parser_assert(*endp == '\0' || *endp == ';' || *endp == ',');
 
   *endptr = endp;
   return t;


### PR DESCRIPTION
Hello,

In single-process mode, lldb likes to send continue packets like this:
`vCont;c:1;c:2;c:3;c:4`

That is, a list of actions and threads, but no process IDs. 

The current code in `parse_threadid` accepts either `vCont;c:1` (one single thread), or `vCont;c:1.1;c:1.2` (multiple threads, but with PID for each). It does not support receiving a list of threads without PID, and it results in aborting the session with assertion failure: `Failed to parse gdb request`.

This PR changes `parse_threadid` to accept lists of threads without PIDs, as long as they are separated by `\0`, `,` or `;`, which is what the existing code appeared to care about in the various usages of `parse_threadid`.