### PR TITLE
Check for unmapped uid in cwd_inaccessible test

### DIFF
--- a/src/test/cwd_inaccessible.c
+++ b/src/test/cwd_inaccessible.c
@@ -11,7 +11,7 @@ int main(void) {
   int ret;
   int status;
 
-  if (!p) {
+  if (!p || p->pw_uid == (uint16_t)-2) {
     atomic_puts("User 'nobody' does not exist, can't run test");
     atomic_puts("EXIT-SUCCESS");
     return 0;


### PR DESCRIPTION
Similar to #3069, unmapped UIDs in the container end up as
`(uint16_t)-2`. Treat that the same as the user not existing.