### PR TITLE
Skip building counters.c on non-x86_64 platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1750,7 +1750,7 @@ if(BUILD_TESTS)
   add_executable(test-monitor src/test-monitor/test-monitor.cc)
 
   add_executable(ftrace_helper src/ftrace/ftrace_helper.c)
-  if (x86ish)
+  if (x86ish AND rr_64BIT)
     add_executable(counters src/counters-test/counters.c)
   endif()
 endif()


### PR DESCRIPTION
From time to time I try a force32bit build.
Today it stopped with this message:
```
.../rr/src/counters-test/counters.c: In function ‘child_wait’:
.../rr/src/counters-test/counters.c:305:3: error: the register ‘r11’ cannot be clobbered in ‘asm’ for the current target
  305 |   __asm__ __volatile__ ("syscall" : : "a"(__NR_write), "D"(child_to_parent_fds[1]), "S"("x"), "d"(1) : "rcx", "r11", "flags");
      |   ^~~~~~~
```

The commit message of de389f7 mentions this test just targets x86_64, but 983607124 did just limit it to x86_64 and i386.

Just for information, with this small modification all tests succeeded (a few at least in the second non-parallel attempt) with regular x86_64 build and with a force32bit build with my AMD Ryzen 7 1700 and a kernel `Debian 5.15.15-1`.