### PR TITLE
Fixed Release build because of a missing `-flto` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ obj/
 Testing/
 .idea/
 .*.swp
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,11 @@ if(strip)
   set(RR_MAIN_LINKER_FLAGS "-s ${RR_MAIN_LINKER_FLAGS}")
 endif()
 
+# Add -flto option to linking step if release
+if(LOWERCASE_CMAKE_BUILD_TYPE STREQUAL "release")
+  set(RR_MAIN_LINKER_FLAGS "${RR_MAIN_LINKER_FLAGS} -flto")
+endif()
+
 target_link_libraries(rr
   ${CMAKE_DL_LIBS}
   -lrt


### PR DESCRIPTION
Reproduced with clang11 & ninja on Ubuntu 20.04 with Ryzen 3950X
The missing `-flto` flag caused an error in final linking as binary objects are now LLVM IR. 
```
...
CMakeFiles/rr.dir/src/AddressSpace.cc.o: file not recognized: file format not recognized
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[1994/2505] Building C object CMakeFil...ss_32.dir/32/simple_threads_stress.c.o
ninja: build stopped: subcommand failed.
```

Ran the tests locally, where one test fails, but it does both for Release as well as for Debug builds:

```
# Release
99% tests passed, 1 tests failed out of 2749

Total Test time (real) = 240.37 sec

The following tests FAILED:
	635 - setuid-no-syscallbuf (Failed)
Errors while running CTest
```

```
# Debug
ctest -R setuid-no-syscallbuf
Test project /home/themarpe/Documents/luxonis/rr/build
    Start 635: setuid-no-syscallbuf
1/1 Test #635: setuid-no-syscallbuf .............***Failed  Error regular expression found in output. Regex=[FAILED]  0.62 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.82 sec

The following tests FAILED:
	635 - setuid-no-syscallbuf (Failed)
Errors while running CTest
```

Also added a `build/` directory to `.gitignore` as it is common for CMake based tooling, to configure & build to