### PR TITLE
Add Goldmont Plus aka. Gemini Lake

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -63,6 +63,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x50670:
       return IntelSilvermont;
     case 0x506f0:
+    case 0x706a0:
       return IntelGoldmont;
     case 0x706e0:
     case 0x606a0:


### PR DESCRIPTION
This cpu_type is from an Intel J4105 [1]. Test logs can be found at [2].

Closes #3098.

[1] https://ark.intel.com/content/www/us/en/ark/products/128992/intel-celeron-j4005-processor-4m-cache-up-to-2-70-ghz.html
[2] https://github.com/rr-debugger/rr/issues/3098#issuecomment-1068920887
