### PR TITLE
Increase timeout for vsyscall_reverse_next

### DIFF
--- a/src/test/vsyscall_reverse_next.run
+++ b/src/test/vsyscall_reverse_next.run
@@ -1,3 +1,3 @@
 source `dirname $0`/util.sh
-if [ $TIMEOUT -lt 300 ]; then TIMEOUT=300; fi
+if [ $TIMEOUT -lt 600 ]; then TIMEOUT=600; fi
 debug_test


### PR DESCRIPTION
This test has been observed to take 250s under regular conditions on CI,
which is too close for comfort. Let's see if we can at least get this test to
reliably finish.

Part of #3102.