### PR TITLE
Properly use cpu_lock for replay

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -731,6 +731,9 @@ void Session::do_bind_cpu(TraceStream &trace) {
         FATAL() << "Can't bind to requested CPU " << cpu_index
                 << ", and CPUID faulting not available";
       }
+    } else if (!is_recording()) {
+      // Make sure to mark this CPU as in use in the cpu_lock.
+      (void)choose_cpu((BindCPU)cpu_index, cpu_lock);
     }
   }
 }


### PR DESCRIPTION
In rr, we have a mechanism to have several rr workers coordinate which
CPUs to pin to. However, because we have no freedom to choose the CPU
to pin to during replay, we were not marking those CPUs as in use, thus
allowing concurrent record calls to pin themselves to the same CPUs
(and even worse then causing their subsequent replay to also be bound
to the same CPU). Try to fix that by making sure to still acquire the
appropriate CPU lock in the replay path. There is still a small window
between the end of the record and the start of the replay where another
record could start on the same CPU, but let's assume that race isn't
hit for the moment.