### PR TITLE
[ci] Don't install julia twice on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,9 +13,9 @@ steps:
           rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v4.17/rr.x86_64.tar.gz
           rootfs_treehash: "838680473e6ffd8977e1957904d418640e75f69e"
           verbose: true
-      - JuliaCI/julia#v1:
-          persist_depot_dirs: packages,artifacts,compiled
-          version: '1.6'
+          # Mount in the julia installation we used to create the sandbox in the first place
+          workspaces:
+            - "/cache:/cache"
     timeout_in_minutes: 30
     commands: |
       echo "--- Print kernel information"


### PR DESCRIPTION
We can avoid a second install of Julia (saving some precious seconds on CI) by mounting in our `/cache` directory explicitly.

Because `PATH` etc... are all inherited from the parent environment, we automatically have access to the `julia` executable within the sandbox, as long as it's mounted in the same place as it exists outside of the sandbox.