### PR TITLE
Give cont_race more time

### DIFF
--- a/src/test/cont_race.run
+++ b/src/test/cont_race.run
@@ -1,3 +1,4 @@
 source `dirname $0`/util.sh
+if [ $TIMEOUT -lt 300 ]; then TIMEOUT=300; fi
 ${OBJDIR}/bin/cont_race$bitness killer &
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
This test has been observed on AMD to take more time than the allotted 120s for the usual AMD-specific slowdown reasons. Give it more time to avoid it failing on CI.