### PR TITLE
CI: add an async timer to kill `ctest` before the Buildkite job times out

### DIFF
--- a/.buildkite/capture_tmpdir.jl
+++ b/.buildkite/capture_tmpdir.jl
@@ -144,7 +144,7 @@ mktempdir(my_temp_parent_dir) do dir
         end
 
         buildkite_upload_cmd = `buildkite-agent artifact upload $(dst_file_name)`
-        if is_buildkite && !success(proc)
+        if !success(proc)
             run(setenv(buildkite_upload_cmd; dir = my_archives_dir))
         end
     end

--- a/.buildkite/capture_tmpdir.jl
+++ b/.buildkite/capture_tmpdir.jl
@@ -26,20 +26,8 @@ function my_exit(process::Base.Process)
     exit(process.exitcode)
 end
 
-function get_bool_from_env(name::AbstractString, default_value::Bool)
-    value = get(ENV, name, "$(default_value)") |> strip |> lowercase
-    result = parse(Bool, value)::Bool
-    return result
-end
-
-const is_buildkite = get_bool_from_env("BUILDKITE", false)
-
 function get_from_env(name::AbstractString)
-    if is_buildkite
-        value = ENV[name]
-    else
-        value = get(ENV, name, "")
-    end
+    value = ENV[name]
     result = convert(String, strip(value))::String
     return result
 end
@@ -55,9 +43,24 @@ if length(ARGS) < 1
 end
 
 const build_number                      = get_from_env("BUILDKITE_BUILD_NUMBER") |> cleanup_string
-const job_name                          = get_from_env("BUILDKITE_STEP_KEY")     |> cleanup_string
 const commit_full                       = get_from_env("BUILDKITE_COMMIT")       |> cleanup_string
-const commit_short                      = first(commit_full, 10)
+const job_name                          = get_from_env("BUILDKITE_STEP_KEY")     |> cleanup_string
+const buildkite_timeout_minutes_string  = get_from_env("BUILDKITE_TIMEOUT")
+
+const commit_short = first(commit_full, 10)
+const buildkite_timeout_minutes = parse(Int, buildkite_timeout_minutes_string)::Int
+const cleanup_minutes = 15
+const ctest_timeout_minutes = buildkite_timeout_minutes - cleanup_minutes
+if ctest_timeout_minutes < 1
+    msg = "ctest_timeout_minutes must be strictly positive"
+    @error(
+        msg,
+        ctest_timeout_minutes,
+        buildkite_timeout_minutes,
+        cleanup_minutes,
+    )
+    throw(ErrorException(msg))
+end
 
 @info(
     "",
@@ -65,6 +68,9 @@ const commit_short                      = first(commit_full, 10)
     job_name,
     commit_full,
     commit_short,
+    ctest_timeout_minutes,
+    buildkite_timeout_minutes,
+    cleanup_minutes,
 )
 
 const my_archives_dir    = joinpath(pwd(), "my_archives_dir")
@@ -88,6 +94,26 @@ mktempdir(my_temp_parent_dir) do dir
     new_env["TMPDIR"] = TMPDIR
     command = setenv(`$ARGS`, new_env)
     global proc = run(command, (stdin, stdout, stderr); wait = false)
+
+    # Start asynchronous timer that will kill `ctest`
+    @async begin
+        sleep(ctest_timeout_minutes * 60)
+
+        # If we've exceeded the timeout and `ctest` is still running, kill it
+        if isopen(proc)
+            @error(
+                string(
+                    "Process timed out ",
+                    "(with a timeout of $(ctest_timeout_minutes) minutes). ",
+                    "Killing with SIGTERM.",
+
+                )
+            )
+            kill(proc, Base.SIGTERM)
+        end
+    end
+
+    # Wait for `ctest` to finish, either through naturally finishing its run, or `SIGTERM`
     wait(proc)
 
     if proc.termsignal != 0

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
           # Mount in the julia installation we used to create the sandbox in the first place
           workspaces:
             - "/cache:/cache"
-    timeout_in_minutes: 45
+    timeout_in_minutes: 14
     commands: |
       echo "--- Print kernel information"
       uname -a

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ agents:
   sandbox.jl: "true"
   os: "linux"
 steps:
-  - label: "x86_64"
-    key: "x86_64"
+  - label: "Test"
+    key: "Test"
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled
@@ -16,13 +16,13 @@ steps:
           # Mount in the julia installation we used to create the sandbox in the first place
           workspaces:
             - "/cache:/cache"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     commands: |
       echo "--- Print kernel information"
       uname -a
       echo "--- Print CPU information"
       # These machines have multiple cores. However, it should be sufficient to just print
-      # the information for one of the cores. 
+      # the information for one of the cores.
       sed -n '1,/^\$/p' /proc/cpuinfo
       echo "--- Generate build environment"
       cmake --version

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ agents:
   sandbox.jl: "true"
   os: "linux"
 steps:
-  - label: "Test"
-    key: "Test"
+  - label: "Run Tests (x86_64)"
+    key: "Run Tests (x86_64)"
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
           # Mount in the julia installation we used to create the sandbox in the first place
           workspaces:
             - "/cache:/cache"
-    timeout_in_minutes: 17
+    timeout_in_minutes: 45
     commands: |
       echo "--- Print kernel information"
       uname -a

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
           # Mount in the julia installation we used to create the sandbox in the first place
           workspaces:
             - "/cache:/cache"
-    timeout_in_minutes: 14
+    timeout_in_minutes: 17
     commands: |
       echo "--- Print kernel information"
       uname -a

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ agents:
   sandbox.jl: "true"
   os: "linux"
 steps:
-  - label: "Run Tests (x86_64)"
-    key: "Run Tests (x86_64)"
+  - label: "Run-Tests-x86_64"
+    key: "Run-Tests-x86_64"
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled


### PR DESCRIPTION
TODO:
- [x] Make sure that if we set the Buildkite timeout to `14`, it immediately throws an error and exits. (And nothing is uploaded.)
- [x] Make sure that if we set the Buildkite timeout to `17`, it `SIGTERM`s the `ctest` process, and the `TMPDIR` is uploaded as a build artifact.
- [x] Set the Buildkite timeout to `45` and make sure that CI is green.