### PR TITLE
CI: more readable job names

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ agents:
   os: "linux"
 steps:
   - label: "Run Tests (x86_64)"
-    key: "runtests.linux.x86_64"
+    key: "runtests:linux:x86_64"
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ agents:
   sandbox.jl: "true"
   os: "linux"
 steps:
-  - label: "Run-Tests-x86_64"
-    key: "Run-Tests-x86_64"
+  - label: "Run Tests (x86_64)"
+    key: "runtests.linux.x86_64"
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled


### PR DESCRIPTION
This PR allows us to have a more readable CI job name that includes spaces, while still having a key (not displayed directly to the end user) that adheres to Buildkite's restrictions.