### PR TITLE
Emulate ENOSYS for close_range.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,7 @@ set(BASIC_TESTS
   clone_untraced
   clone_vfork_pidfd
   cloned_sigmask
+  close_range
   constructor
   copy_file_range
   x86/cpuid_same_state

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4036,11 +4036,12 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
                  (size_t)regs.arg4()));
       return PREVENT_SWITCH;
 
+    case Arch::close_range:
     case Arch::clone3:
     case Arch::io_uring_setup:
     case Arch::io_setup: {
-      // Prevent the io_setup/io_uring_setup/clone3 from running and fake an ENOSYS return. We want
-      // to stop applications from using these APIs because we don't support them currently.
+      // Prevent the various syscalls that we don't support from being used by
+      // applications and fake an ENOSYS return.
       Registers r = regs;
       r.set_arg2(0);
       t->set_regs(r);
@@ -6482,6 +6483,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     }
 
     case Arch::clone3:
+    case Arch::close_range:
     case Arch::close:
     case Arch::dup2:
     case Arch::dup3:

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -121,6 +121,14 @@ open = IrregularEmulatedSyscall(x86=5, x64=2)
 # the lock).
 close = IrregularEmulatedSyscall(x86=6, x64=3, generic=57)
 
+#  int close_range(unsigned int first, unsigned int last, unsigned int flags);
+#
+# The close_range() system call closes all open file descriptors
+# from first to last (included).
+#
+# Errors closing a given file descriptor are currently ignored.
+close_range = IrregularEmulatedSyscall(x86=436, x64=436, generic=436)
+
 #  pid_t waitpid(pid_t pid, int *status, int options);
 #
 # The waitpid() system call suspends execution of the calling process

--- a/src/test/close_range.c
+++ b/src/test/close_range.c
@@ -1,0 +1,10 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  int ret = syscall(RR_close_range, 1, UINT32_MAX, 0);
+  test_assert(ret == -1 && errno == ENOSYS);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
This doesn't really fully fix #2994, but it allows to record programs
that use it and properly fall back to close(), like glib etc.