### PR TITLE
Support apple M1

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -92,7 +92,9 @@ enum CpuMicroarch {
   LastAMD = AMDZen,
   FirstARM,
   ARMNeoverseN1 = FirstARM,
-  LastARM = ARMNeoverseN1,
+  AppleM1Icestorm,
+  AppleM1Firestorm,
+  LastARM = AppleM1Firestorm,
 };
 
 /*
@@ -169,7 +171,11 @@ static const PmuConfig pmu_configs[] = {
   // 0x6F == STREX_SPEC - Speculatively executed strex instructions
   // 0x11 == CPU_CYCLES - Cycle
   { ARMNeoverseN1, "ARM Neoverse N1", 0x21, 0, 0x6F, 1000, PMU_TICKS_TAKEN_BRANCHES,
-    "armv8_pmuv3_0", 0x11, -1, -1 }
+    "armv8_pmuv3_0", 0x11, -1, -1 },
+  { AppleM1Icestorm, "Apple M1 Icestorm", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
+    "apple_icestorm_pmu", 0x8c, -1, -1 },
+  { AppleM1Firestorm, "Apple M1 Firestorm", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
+    "apple_firestorm_pmu", 0x8c, -1, -1 },
 };
 
 #define RR_SKID_MAX 10000

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -39,6 +39,14 @@ static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
       return ARMNeoverseN1;
     }
     break;
+  case 0x61: // Apple
+    switch (cpuid.part) {
+    case 0x22:
+      return AppleM1Icestorm;
+    case 0x23:
+      return AppleM1Firestorm;
+    }
+    break;
   }
   CLEAN_FATAL() << "Unknown aarch64 CPU type " << cpuid;
   return UnknownCpu; // not reached


### PR DESCRIPTION
## TODO and limitations

- [x] This currently changes rrpage layout which I assume will break backward compatibility on x86. https://github.com/rr-debugger/rr/pull/3146
- [x] This hardcodes 16k on aarch64. AFAICT the maximum allowed page size is actually 64k so we should probably switch to that instead. https://github.com/rr-debugger/rr/pull/3146
- [x] lse linker is disabled since archlinux arm doesn't have that. (should either remove that before merge or make that an option) #3145
- [ ] I've not finished my PMU testing yet and I'm not sure if the counters are used correctly here. Relevant counters that I've identified so far are (in decimal since it I accidentally printed it as such in an earlier version of my processing script and then stuck with it...),
    * 140: total instruction count. (This is actually not 100% stable when running the same code)
    * 141: total branch instructions (stable)
    * 142: total calls (stable)
    * 143: total return (stable)
    * 144: total branch taken (stable)
    * 147: total indirect branch (stable)
    * 148/159: total conditional branch (both stable and have the same values so far)
    * 179: exclusive access or cas failed (stable) (note that this includes lse atomic instruction so it can't be used to determine if llsc is used)
        Also note that I've measured a significant slow down when cas fails with no contention (simply supplying the wrong comparison values) and potentionally measured a marger larger uops count so I wonder if lse instructions are actually micro coded....
    * 180: exclusive access or cas success (stable) (same as above)
- [x] The P cores and E cores don't use the same event type. This patch currently only support E cores and requires the user to pin the thread first. The counters used here should have the same meaning on both cores but the kernel does not handle things transparently... I was told to ask about it on the mailing list (http://lists.infradead.org/pipermail/linux-arm-kernel/2022-March/729267.html) but I've not got any reply so far....
    I think this can be done for now by just measuring the event on both cores (P core requires a event type of 7) if necessary.


Currently, I can use this to trace and reply a simple hello world C program successfully after pinning it on the E core.