### PR TITLE
More fully restore kernel state in AutoRemoteSyscalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,6 +873,7 @@ set(BASIC_TESTS
   futex_pi
   futex_priorities
   futex_requeue
+  futex_restart_race
   gcrypt_rdrand
   getcpu
   getgroups

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -308,6 +308,8 @@ private:
 
   MemParamsEnabled enable_mem_params_;
 
+  bool need_sigpending_renable;
+
   AutoRemoteSyscalls& operator=(const AutoRemoteSyscalls&) = delete;
   AutoRemoteSyscalls(const AutoRemoteSyscalls&) = delete;
 };

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -308,6 +308,9 @@ private:
 
   MemParamsEnabled enable_mem_params_;
 
+  bool restore_sigmask;
+  sig_set_t sigmask_to_restore;
+
   bool need_sigpending_renable;
 
   AutoRemoteSyscalls& operator=(const AutoRemoteSyscalls&) = delete;

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -601,6 +601,8 @@ public:
    */
   void send_synthetic_SIGCHLD_if_necessary();
 
+  void set_sigmask(sig_set_t mask);
+
 private:
   /* Retrieve the tid of this task from the tracee and store it */
   void update_own_namespace_tid();
@@ -798,6 +800,10 @@ public:
   // Set if the tracee requested an override of the ticks request.
   // Used for testing.
   TicksRequest tick_request_override;
+
+  // Set to prevent the scheduler from scheduling this tid, even
+  // if it is otherwise considered runnable. Used for testing.
+  bool schedule_frozen;
 };
 
 } // namespace rr

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -720,7 +720,7 @@ bool Registers::syscall_may_restart() const {
 }
 
 ostream& operator<<(ostream& stream, const Registers& r) {
-  stream << "{ args:(" << HEX(r.arg1()) << "," << HEX(r.arg2()) << ","
+  stream << "{ ip:" << HEX(r.ip().register_value()) << " args:(" << HEX(r.arg1()) << "," << HEX(r.arg2()) << ","
          << HEX(r.arg3()) << "," << HEX(r.arg4()) << "," << HEX(r.arg5()) << ","
          << r.arg6() << ") orig_syscall: " << r.original_syscallno() <<
          " syscallno: " << r.syscallno() << " }";

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -220,9 +220,14 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
     return false;
   }
 
+
   LOG(debug) << "Task event is " << t->ev();
   if (!t->may_be_blocked()) {
     LOG(debug) << "  " << t->tid << " isn't blocked";
+    if (t->schedule_frozen) {
+      LOG(debug) << "  " << t->tid << "  but is frozen";
+      return false;
+    }
     return true;
   }
 
@@ -261,7 +266,11 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
   if (t->waiting_for_ptrace_exit) {
     LOG(debug) << "  " << t->tid << " is waiting to exit; checking status ...";
   } else if (!t->is_running()) {
-    LOG(debug) << "  was already stopped with status " << t->status();
+    LOG(debug) << "  " << t->tid << "  was already stopped with status " << t->status();
+    if (t->schedule_frozen && t->status().ptrace_event() != PTRACE_EVENT_SECCOMP) {
+      LOG(debug) << "   but is frozen";
+      return false;
+    }
     // If we have may_be_blocked, but we aren't running, then somebody noticed
     // this event earlier and already called did_waitpid for us. Just pretend
     // we did that here.
@@ -271,6 +280,10 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
   } else if (EV_SYSCALL == t->ev().type() &&
       PROCESSING_SYSCALL == t->ev().Syscall().state &&
       treat_syscall_as_nonblocking(t->ev().Syscall().number, t->arch())) {
+    if (t->schedule_frozen) {
+      LOG(debug) << "  " << t->tid << " is frozen in sched_yield";
+      return false;
+    }
     // These syscalls never really block but the kernel may report that
     // the task is not stopped yet if we pass WNOHANG. To make them
     // behave predictably, do a blocking wait.
@@ -288,10 +301,14 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
   bool did_wait_for_t;
   did_wait_for_t = t->try_wait();
   if (did_wait_for_t) {
+    LOG(debug) << "  ready with status " << t->status();
+    if (t->schedule_frozen && t->status().ptrace_event() != PTRACE_EVENT_SECCOMP) {
+      LOG(debug) << "   but is frozen";
+      return false;
+    }
     *by_waitpid = true;
     ntasks_running--;
     must_run_task = t;
-    LOG(debug) << "  ready with status " << t->status();
     return true;
   }
   LOG(debug) << "  still blocked";

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -941,6 +941,7 @@ void Task::post_exec(const string& exe_file, const string& original_exe_file) {
     }
   }
   if (stopped_task_in_address_space) {
+    LOG(warn) << "Unmapping buffers using tid " << stopped_task_in_address_space->tid;
     AutoRemoteSyscalls remote(stopped_task_in_address_space);
     unmap_buffers_for(remote, this, syscallbuf_child);
   } else if (other_task_in_address_space) {

--- a/src/preload/rrcalls.h
+++ b/src/preload/rrcalls.h
@@ -84,3 +84,14 @@
  * cases between the time slice signal and other rr behavior.
  */
 #define SYS_rrcall_arm_time_slice (RR_CALL_BASE + 10)
+/**
+ * Use as
+ *
+ *  int rr_freeze_tid(pid_t tid, int freeze) {
+ *      return syscall(SYS_rrcall_freeze_tid, tid, freeze, 0, 0, 0, 0); }
+ *
+ * With `freeze=1`, requests that rr's Scheduler not schedule task `tid` again
+ * until unfrozen using `rr_freeze_tid(tid, 0)`. Note that kernel scheduling
+ * behavior is unaffected. Used for testing Scheduler-sensitive scenarios.
+ */
+#define SYS_rrcall_freeze_tid (RR_CALL_BASE + 11)

--- a/src/test/futex_restart_race.c
+++ b/src/test/futex_restart_race.c
@@ -1,0 +1,135 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+#include "util_internal.h"
+
+// This test is extremely sensitive to scheduling differences.
+// Essentially the key ingredients that need to happen are:
+//
+// Condition 1. A futex system call gets interrupted by a signal
+// Condition 2. ... But the signal gets dequeued by another thread
+// Condition 3. ... and before rr schedules it again, yet another thread performs an execve
+// Condition 4. ... and rr notices that the signal-interrupted happened
+// Condition 5. ... and every other thread is blocked, so it is forced to use the signal-interrupted thread for execve-cleanup
+// Condition 6. ... And the AutoRemoteSyscall is forced through the non-singlestep path
+
+int pid_pipe[2];
+pid_t parent_pid;
+
+static int futex(int* uaddr, int op, int val, const struct timespec* timeout,
+                 int* uaddr2, int val2) {
+  sigset_t set;
+  sigemptyset(&set);
+  // Block SIGTRAP to force non-singlestep path in AutoRemoteSyscall (Condition 6)
+  sigaddset(&set, SIGTRAP);
+  pthread_sigmask(SIG_BLOCK, &set, NULL);
+  return syscall(SYS_futex, uaddr, op, val, timeout, uaddr2, val2);
+}
+
+static void handle_usr1(__attribute__((unused)) int sig) {
+  test_assert(0 && "Should have been dequeued in sigtimedwait");
+}
+
+static void *do_thread(void* futex_addr) {
+  atomic_printf("Thread tid is %d\n", gettid());
+  pid_t thread_tid = gettid();
+  int ret = write(pid_pipe[1], &thread_tid, sizeof(pid_t));
+  test_assert(ret == sizeof(pid_t));
+  futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+  test_assert(0); // Should not return. If the bug happens, futex returns with -512 (ERESTARTSYS)
+  return NULL;
+}
+
+char* execv_argv[] = {"/proc/self/exe", "--inner", NULL};
+static int clone_child(void *unused) {
+  (void)unused;
+  // Give the parent a chance to enter wait4.
+  for (int i = 0; i < 5; ++i)
+    sched_yield();
+  kill(parent_pid, SIGUSR1);
+  execve("/proc/self/exe", execv_argv, NULL);
+  test_assert(0 && "Exec should not have failed");
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc == 2) {
+    test_assert(strcmp(argv[1], "--inner") == 0);
+    return 0;
+  }
+
+  if (!running_under_rr()) {
+    atomic_puts("WARNING: This test only works under rr.");
+    atomic_puts("EXIT-SUCCESS");
+    exit(0);
+  }
+
+  parent_pid = getpid();
+  int ret = pipe(pid_pipe);
+  test_assert(ret == 0);
+
+  // Make sure that SIGUSR1 is able to be sent to both threads.
+  signal(SIGUSR1, handle_usr1);
+
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  int* futex_addr = (int*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                               MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  test_assert(futex_addr != MAP_FAILED);
+  *futex_addr = 0;
+
+  char *child_stack = (char*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  test_assert(child_stack != MAP_FAILED);
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, do_thread, futex_addr);
+
+  pid_t thread_tid;
+  ret = read(pid_pipe[0], &thread_tid, sizeof(pid_t));
+  test_assert(ret == sizeof(pid_t));
+
+  siginfo_t info;
+  sigset_t set;
+  sigemptyset(&set);
+  // Block all relevant singals on the main thread to make sure that
+  // the thread gets selected to receive the signal (Condition 1).
+  // Corner case: Because we do waitpid below, the kernel internally removes
+  // SIGCHLD from the blocked list for this thread and does not wake up
+  // the thread. To work around this, we send SIGUSR1 as well.
+  sigaddset(&set, SIGCHLD);
+  sigaddset(&set, SIGUSR1);
+  ret = pthread_sigmask(SIG_BLOCK, &set, NULL);
+  test_assert(ret == 0);
+
+  // Make sure the thread had a chance to enter the futex.
+  for (int i = 0; i < 10; ++i) {
+    sched_yield();
+  }
+
+  // Prevent rr from scheduling the thread until we've properly established all
+  // the required conditions for reproducing the bug.
+  rr_freeze_tid(thread_tid, 1);
+  // Like vfork, but without suspending the parent thread
+  pid_t child = clone(clone_child, child_stack + page_size, CLONE_VM | SIGCHLD, NULL);
+  test_assert(child != -1);
+  int status;
+  // Make sure that this thread is blocked while the child's execve
+  // happens, to make sure the thread is selected to perform execve
+  // cleanup (Condition 5).
+  // N.B.: vfork could work here also (and was used in the original bug report),
+  // but is racy, because vfork gets released before the ptrace exec notification happens.
+  pid_t waited = waitpid(-1, &status, 0);
+  test_assert(waited == child);
+  test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  // Dequeue all signals before we allow the thread to run again (Condition 2).
+  for (int i = 0; i < 2; ++i) {
+    int sig = sigwaitinfo(&set, &info);
+    test_assert(sig == SIGCHLD || sig == SIGUSR1);
+  }
+  rr_freeze_tid(thread_tid, 0);
+  // Make sure the thread gets a chance to run before it's shot down.
+  sched_yield();
+
+  atomic_puts("EXIT-SUCCESS");
+  exit(0);
+}

--- a/src/test/util_internal.h
+++ b/src/test/util_internal.h
@@ -15,4 +15,9 @@ void rr_detach_teleport(void) {
   test_assert(err == 0);
 }
 
+void rr_freeze_tid(pid_t tid, int freeze) {
+  int err = syscall(SYS_rrcall_freeze_tid, tid, freeze, 0, 0, 0, 0);
+  test_assert(err == 0 && "Failed to freeze tid");
+}
+
 #endif /* RRUTIL_INTERNAL_H */


### PR DESCRIPTION
Fix #3141 and #3147. In essence the issue is that AutoRemoteSyscall needs to work harder to actually restore the state that it was in at the start. Details are in the individual commit messages.