### PR TITLE
Fix sigcontext alignment on AArch64

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2380,7 +2380,7 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
     struct hw_bp dbg_regs[16];
   };
 
-  struct sigcontext {
+  struct __attribute((aligned(16))) sigcontext {
     __u64 fault_addr;
     user_pt_regs regs;
     // ISA extension state follows here


### PR DESCRIPTION
The actual structure contains saved vector registers and is therefore 16bytes aligned.
This causes the offset of uc_mcontext in ucontext to be wrong and in particular
the address where x7 is saved is wrong when we try to read it in the kernel bug workaround.