### PR TITLE
Fix patch page end test segfault

### DIFF
--- a/src/test/patch_page_end.c
+++ b/src/test/patch_page_end.c
@@ -37,7 +37,7 @@ static long do_call(uint8_t* p) {
 #elif defined(__aarch64__)
   register long x8 __asm__("x8") = SYS_getpid;
   register long x0 __asm__("x0") = 0;
-  __asm__ __volatile__("blr %2" : "=r"(x0) : "r"(x8), "r"(p));
+  __asm__ __volatile__("blr %2" : "=r"(x0) : "r"(x8), "r"(p) : "x30"); // x30 = lr
   ret = x0;
 #else
   #error unsupported arch


### PR DESCRIPTION
blr clobbers the link register causing the return from `do_call` to be completely messed up.

Similar to 8a8861a25777a444f75864a31e168ffd90799bd9, the test still doesn't pass but it should at least fail with the correct error now...