### PR TITLE
Allow a syscall buffer size smaller than page size to be passed in

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -311,11 +311,10 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
       flags.use_file_cloning = false;
       break;
     case 2:
-      if (!opt.verify_valid_int(4, 1024 * 1024) ||
-          (opt.int_value & (page_size() / 1024 - 1))) {
+      if (!opt.verify_valid_int(4, 1024 * 1024)) {
         return false;
       }
-      flags.syscall_buffer_size = opt.int_value * 1024;
+      flags.syscall_buffer_size = ceil_page_size(opt.int_value * 1024);
       break;
     case 3:
       if (opt.value == "default" || opt.value == "error") {


### PR DESCRIPTION
Automatically round it up to the page size.
This way wrapper scripts (including the tests) don't have to detect the page size...

This is mainly to fix tests, which, I know, isn't a great reason for changing the behavior of normal code... However, this is just a command line option and unless there's a good reason to throw a error about using a slightly different size than the one requested, I feel like being slightly more relaxed here is going to make everyone's life easier. (If not, I could put `getconf PAGESIZE` in the test scripts as well as figuring out a way to do division in shell script...)
