### PR TITLE
Allow page size up to 64k on aarch64 in sysconf test

### DIFF
--- a/src/test/sysconf.c
+++ b/src/test/sysconf.c
@@ -7,7 +7,11 @@ int main(void) {
   long ncpus = sysconf(_SC_NPROCESSORS_ONLN);
 
   atomic_printf("sysconf says page size is %ld bytes\n", pagesize);
+#ifdef __aarch64__
+  test_assert((64 * 1024) % pagesize == 0);
+#else
   test_assert(4096 == pagesize);
+#endif
 
   atomic_printf("sysconf says %ld processors are online\n", ncpus);
   /* TODO: change this when rr supports parallel recording. */


### PR DESCRIPTION
Minor, non breaking part for https://github.com/rr-debugger/rr/issues/3143