### PR TITLE
Consistently use 4k as the size unit for mmap2-like internal functions

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -318,7 +318,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
                                                 child_fd, 0);
       }
       remote.infallible_mmap_syscall_if_alive(rr_page_start(), rr_page_size(), prot, flags,
-                                              child_fd, offset_pages);
+                                              child_fd, offset_bytes);
 
       struct stat fstat = t->stat_fd(child_fd);
       file_name = t->file_name_of_fd(child_fd);
@@ -326,7 +326,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
       remote.infallible_close_syscall_if_alive(child_fd);
 
       map(t, rr_page_start(), rr_page_size(), prot, flags,
-          offset_pages * page_size(), file_name,
+          offset_bytes, file_name,
           fstat.st_dev, fstat.st_ino);
       mapping_flags_of(rr_page_start()) = Mapping::IS_RR_PAGE;
       if (t->session().is_recording()) {

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -192,7 +192,7 @@ public:
    */
   remote_ptr<void> infallible_mmap_syscall_if_alive(remote_ptr<void> addr, size_t length,
                                                     int prot, int flags, int child_fd,
-                                                    uint64_t offset_pages);
+                                                    uint64_t offset_bytes);
 
   /** TODO replace with infallible_lseek_syscall_if_alive */
   int64_t infallible_lseek_syscall(int fd, int64_t offset, int whence);
@@ -262,7 +262,7 @@ public:
                           int prot, int flags,
                           const std::string& backing_file_name,
                           int backing_file_open_flags,
-                          off64_t backing_offset_pages,
+                          off64_t backing_offset_bytes,
                           struct stat& real_file, std::string& real_file_name);
 
   // Calling this with allow_death false is DEPRECATED.

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -99,7 +99,7 @@ public:
    * patch libpthread.so.
    */
   void patch_after_mmap(RecordTask* t, remote_ptr<void> start, size_t size,
-                        size_t offset_pages, int child_fd, MmapMode mode);
+                        size_t offset_bytes, int child_fd, MmapMode mode);
 
   /**
    * The list of pages we've allocated to hold our extended jumps.

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -416,7 +416,7 @@ static void remap_shared_mmap(AutoRemoteSyscalls& remote, EmuFs& emu_fs,
   auto ret = remote.infallible_mmap_syscall_if_alive(m.map.start(), m.map.size(), m.map.prot(),
                                                      (m.map.flags() & ~MAP_ANONYMOUS) | MAP_FIXED,
                                                      remote_fd,
-                                                     m.map.file_offset_bytes() / page_size());
+                                                     m.map.file_offset_bytes());
   if (!ret) {
     if (remote.task()->vm()->task_set().size() > remote.task()->thread_group()->task_set().size()) {
       // XXX not sure how to handle the case where the tracee died after

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3501,7 +3501,7 @@ static void create_mapping(Task *t, AutoRemoteSyscalls &remote, const KernelMapp
     struct stat real_file;
     string real_file_name;
     remote.finish_direct_mmap(km.start(), km.size(), km.prot(), km.flags(),
-      km.fsname(), O_RDONLY, km.file_offset_bytes()/page_size(),
+      km.fsname(), O_RDONLY, km.file_offset_bytes(),
       real_file, real_file_name);
   } else {
     auto ret = remote.infallible_mmap_syscall_if_alive(km.start(), km.size(), km.prot(),


### PR DESCRIPTION
Previously, the code uses a mixture of 4k, page_size() and rr_page_size() as unit.
We now switch to using 4k as the unit everywhere since,

1. This makes the number platform independent
2. Most of the time the caller already know the bytes offsets so it make sense to
   treat the argument as a offset in a larger unit
3. This is the convension used by the mmap2 system call. Some of the users directlly calls
   that so it's good to be consistent with mmap2.

This is another part of https://github.com/rr-debugger/rr/pull/3146 that should be completely non-breaking (though not so minor).