### PR TITLE
Unconditionally print rr stack if something goes wrong

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1874,6 +1874,8 @@ void GdbServer::emergency_debug(Task* t) {
   unsigned short port = t->tid;
   ScopedFd listen_fd = open_socket(localhost_addr.c_str(), &port, PROBE_PORT);
 
+  dump_rr_stack();
+
   char* test_monitor_pid = getenv("RUNNING_UNDER_TEST_MONITOR");
   if (test_monitor_pid) {
     pid_t pid = atoi(test_monitor_pid);
@@ -1886,7 +1888,6 @@ void GdbServer::emergency_debug(Task* t) {
     }
     kill(pid, SIGURG);
   } else {
-    dump_rr_stack();
     fputs("Launch gdb with\n  ", stderr);
     print_debugger_launch_command(t, localhost_addr, port, "gdb", stderr);
   }

--- a/src/util.cc
+++ b/src/util.cc
@@ -1717,6 +1717,7 @@ ScopedFd open_socket(const char* address, unsigned short* port,
 
 void notifying_abort() {
   flush_log_buffer();
+  dump_rr_stack();
 
   char* test_monitor_pid = getenv("RUNNING_UNDER_TEST_MONITOR");
   if (test_monitor_pid) {
@@ -1725,8 +1726,6 @@ void notifying_abort() {
     // do so.
     kill(pid, SIGURG);
     sleep(10000);
-  } else {
-    dump_rr_stack();
   }
 
   abort();


### PR DESCRIPTION
In #3129, we're hitting some assertion, but the process is dead without
printing anything before we get a GDB backtrace. Hopefully this will shed
some light on the situation.