### PR TITLE
Handle F_(GET|SET)_FILE_RW_HINT removal

### DIFF
--- a/src/test/fcntl_rw_hints.c
+++ b/src/test/fcntl_rw_hints.c
@@ -58,6 +58,12 @@ int main(void) {
 
   hint = RWH_WRITE_LIFE_LONG;
   ret = fcntl(fd, F_SET_FILE_RW_HINT, &hint);
+  if (ret < 0) {
+    test_assert(errno == EINVAL);
+    atomic_puts("F_SET_FILE_RW_HINT support removed");
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
   test_assert(ret == 0);
   hint = 99;
   ret = fcntl(fd, F_GET_FILE_RW_HINT, &hint);


### PR DESCRIPTION
This is removed in https://github.com/torvalds/linux/commit/7b12e49669c99f63bc12351c57e581f1f14d4adf which is in 5.18-rc releases.