### PR TITLE
Do not try to access rseq structure if the task is dying

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3916,7 +3916,7 @@ void Task::move_to_signal_stop()
 
 bool Task::should_apply_rseq_abort(EventType event_type, remote_code_ptr* new_ip,
                                    bool* invalid_rseq_cs) {
-  if (!rseq_state) {
+  if (!rseq_state || is_dying()) {
     return false;
   }
   // We're relying on the fact that rseq_t is the same across architectures


### PR DESCRIPTION
With glibc initializing rseq by default now, this seems to be happening for quite a few cases.

Fixes #3160

I feel like this patch is correct, but what I'm not so sure about though, is why this only happen for some cases and not others, and if there's a more correct place to fix this.
