### PR TITLE
Use orig_arg1 to get the clone flag

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1197,7 +1197,7 @@ static CloneParameters extract_clone_parameters_arch(const Registers& regs) {
       result.ctid = regs.arg4();
       break;
   }
-  int flags = (int)regs.arg1();
+  int flags = (int)regs.orig_arg1();
   // If these flags aren't set, the corresponding clone parameters may be
   // invalid pointers, so make sure they're ignored.
   if (!(flags & (CLONE_PARENT_SETTID | CLONE_PIDFD))) {


### PR DESCRIPTION
Otherwise, on AArch64, the clone recording fails to record the write of child_tid
from the kernel with CLONE_CHILD_SETTID or CLONE_CHILD_CLEARTID.

I'm not 100% sure if this is the best fix but I believe this is a correct fix because,

* On x86, this is a no-op since the arg1 and orig_arg1 points to the same location.

* On AArch64 this makes sure we get the right value for the flags.

  Out of the three current callers of extract_clone_parameters:

  1. Pre-cloning one in prepare_clone(RecordTask*) always see the same value for the two
  2. Post-cloning one in prepare_clone(RecordTask*) only sees the correct value in
     orig_arg1. I believe arg1 is also expected to hold the return value at this point
     so it cannot be modified anymore.
  3. The one in prepare_clone(ReplayTask*) only sees the correct value in orig_arg1
     since arg1 now has the value of the result (ENOSYS) in it.