### PR TITLE
Enable a stripped down version of librrpreload on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,19 +359,24 @@ add_custom_command(TARGET rrpage POST_BUILD
 
 # Order matters here! syscall_hook.S must be immediately before syscallbuf.c,
 # raw_syscall.S must be before overrides.c, which must be last.
-set(PRELOAD_FILES
-  syscall_hook.S
-  syscallbuf.c
-  raw_syscall.S
-  overrides.c
-)
+if(x86ish)
+  set(PRELOAD_FILES
+    syscall_hook.S
+    syscallbuf.c
+    raw_syscall.S
+    overrides.c
+    )
+else()
+  set(PRELOAD_FILES
+    overrides.c
+    )
+endif()
 set(PRELOAD_SOURCE_FILES
   ${PRELOAD_FILES}
   preload_interface.h
   rrcalls.h
   syscallbuf.h
 )
-if (x86ish)
 add_library(rrpreload)
 foreach(file ${PRELOAD_FILES})
   target_sources(rrpreload PUBLIC "${CMAKE_SOURCE_DIR}/src/preload/${file}")
@@ -380,7 +385,6 @@ foreach(file ${PRELOAD_FILES})
 endforeach(file)
 set_target_properties(rrpreload PROPERTIES LINK_FLAGS "-nostartfiles ${LINKER_FLAGS}")
 set_target_properties(rrpreload PROPERTIES INSTALL_RPATH "\$ORIGIN")
-endif()
 
 set(AUDIT_FILES
   rtld-audit.c
@@ -591,11 +595,9 @@ endif()
 
 set_target_properties(rr PROPERTIES LINK_FLAGS "${RR_MAIN_LINKER_FLAGS}")
 
-if (x86ish)
 target_link_libraries(rrpreload
   ${CMAKE_DL_LIBS}
 )
-endif()
 
 add_executable(rr_exec_stub src/exec_stub.c)
 post_build_executable(rr_exec_stub)
@@ -662,9 +664,7 @@ install(PROGRAMS scripts/rr_completion
   DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions RENAME rr)
 
 set(RR_INSTALL_LIBS rrpage rraudit rr_exec_stub)
-if (x86ish)
-  set(RR_INSTALL_LIBS rrpreload ${RR_INSTALL_LIBS})
-endif()
+set(RR_INSTALL_LIBS rrpreload ${RR_INSTALL_LIBS})
 install(TARGETS ${RR_BIN} ${RR_INSTALL_LIBS}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -146,13 +146,6 @@ static int buffer_enabled;
 static int process_inited;
 
 RR_HIDDEN struct preload_globals globals;
-RR_HIDDEN char impose_syscall_delay;
-RR_HIDDEN char impose_spurious_desched;
-RR_HIDDEN int (*real_pthread_mutex_init)(void* mutex, const void* attr);
-RR_HIDDEN int (*real_pthread_mutex_lock)(void* mutex);
-RR_HIDDEN int (*real_pthread_mutex_trylock)(void* mutex);
-RR_HIDDEN int (*real_pthread_mutex_timedlock)(void* mutex,
-                                              const struct timespec* abstime);
 
 static struct preload_thread_locals* const thread_locals =
     (struct preload_thread_locals*)PRELOAD_THREAD_LOCALS_ADDR;
@@ -858,11 +851,6 @@ static void __attribute__((constructor)) init_process(void) {
       return;
     }
   }
-
-  real_pthread_mutex_init = dlsym(RTLD_NEXT, "pthread_mutex_init");
-  real_pthread_mutex_lock = dlsym(RTLD_NEXT, "pthread_mutex_lock");
-  real_pthread_mutex_trylock = dlsym(RTLD_NEXT, "pthread_mutex_trylock");
-  real_pthread_mutex_timedlock = dlsym(RTLD_NEXT, "pthread_mutex_timedlock");
 
   process_inited = 1;
 }

--- a/src/preload/syscallbuf.h
+++ b/src/preload/syscallbuf.h
@@ -12,10 +12,4 @@ RR_HIDDEN extern struct preload_globals globals;
 RR_HIDDEN extern char impose_syscall_delay;
 RR_HIDDEN extern char impose_spurious_desched;
 
-RR_HIDDEN extern int (*real_pthread_mutex_init)(void* mutex, const void* attr);
-RR_HIDDEN extern int (*real_pthread_mutex_lock)(void* mutex);
-RR_HIDDEN extern int (*real_pthread_mutex_trylock)(void* mutex);
-RR_HIDDEN extern int (*real_pthread_mutex_timedlock)(void* mutex,
-                                                     const struct timespec* abstime);
-
 #endif /* RR_SYSCALLBUF_H_ */


### PR DESCRIPTION
Make syscallbuf and override more independent.

This allow some tests with pthread mutex to pass and I assume it'll be better for graphic programs as well (due to the x-related override)

It seems that there are some fairly delicate ordering issue here but I think the changes here are safe. No change in the test results when testing locally on x86.
