### PR TITLE
Fix more arg1 vs orig_arg1 usage for AArch64

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -6249,7 +6249,7 @@ static void rec_process_syscall_arch(RecordTask* t,
 
     case Arch::bpf:
       if (!t->regs().syscall_failed()) {
-        switch ((int)t->regs().arg1()) {
+        switch ((int)t->regs().orig_arg1()) {
           case BPF_MAP_CREATE: {
             int fd = t->regs().syscall_result_signed();
             auto attr = t->read_mem(remote_ptr<typename Arch::bpf_attr>(t->regs().arg2()));
@@ -6304,7 +6304,7 @@ static void rec_process_syscall_arch(RecordTask* t,
         r.set_syscall_result(-EACCES);
         t->set_regs(r);
       }
-      maybe_process_new_socket(t, r.arg1());
+      maybe_process_new_socket(t, r.orig_arg1());
       break;
     }
 
@@ -6465,7 +6465,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       t->set_regs(r);
 
       if (!r.syscall_failed() && r.arg3() == O_DIRECT) {
-        int fd = r.arg1();
+        int fd = r.orig_arg1();
         // O_DIRECT can impose unknown alignment requirements, in which case
         // syscallbuf records will not be properly aligned and will cause I/O
         // to fail. Disable syscall buffering for O_DIRECT files.
@@ -6617,7 +6617,7 @@ static void rec_process_syscall_arch(RecordTask* t,
           ASSERT(t,
                  ret == -ENOENT || ret == -ENODEV || ret == -ENOTBLK ||
                      ret == -EINVAL)
-              << " unknown quotactl(" << HEX(t->regs().arg1() >> SUBCMDSHIFT)
+              << " unknown quotactl(" << HEX(t->regs().orig_arg1() >> SUBCMDSHIFT)
               << ")";
           break;
         }

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -139,7 +139,7 @@ static bool syscall_shares_vm(Registers r)
 {
   switch (r.original_syscallno()) {
     case Arch::clone:
-      return (CLONE_VM & r.arg1());
+      return (CLONE_VM & r.orig_arg1());
     case Arch::vfork:
       return true;
     case Arch::fork:


### PR DESCRIPTION
* In post-processing syscall in recording, orig_arg1 is always the correct one to use
  since on aarch64 arg1 holds the syscall return value at this point.

  This was causing failure to register the correct BPF monitor
  and logging of socket addresses.

* Similarly, for post-processing syscall in replay of clone,
  we've already set arg1 to the return value and we need to get the clone flag
  from the original value of arg1.

  This causes rr to miss the VM cloning and failed to remove a breakpoint
  in detached process, causing a hang in gdb.

* For recovering registers in replay, we should set orig_arg1.

  The current code overrides syscall_result although it didn't seem to be causing any failures