### PR TITLE
Fix test due to difference in symbol name/glibc implementations

### DIFF
--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -28,7 +28,8 @@ stopped_locations = {
                     '0x0*70000002 in \?\?',
                     '(0x[0-9a-f]+ in )?syscall_traced',
                     '(0x[0-9a-f]+ in )?rr_page_start'],
-    'aarch64': ['(0x[0-9a-f]+ in )?futex_wait']
+    'aarch64': ['(0x[0-9a-f]+ in )?pthread_barrier_wait',
+                '(0x[0-9a-f]+ in )?futex_wait']
 }
 
 for i in range(NUM_THREADS + 1, 1, -1):

--- a/src/test/reverse_step_signal.py
+++ b/src/test/reverse_step_signal.py
@@ -18,6 +18,7 @@ expect_gdb('Old value = 1')
 expect_gdb('New value = 0')
 
 send_gdb('reverse-finish')
+send_gdb('bt')
 expect_gdb('raise')
 
 send_gdb('reverse-stepi')


### PR DESCRIPTION
* On AArch64 with glibc, raise calls `__kill_implementation`
  so raise won't be in the output when the execution stopped.

  This test (reverse_step_signal) is simple enough that I think looking for the symbol
  in the backtrace is simpler and more general than looking for a range of
  implementation dependent names.

* Add `pthread_barrier_wait` to allowed symbols within `pthread_barrier_wait`
  on AArch64 as well.

  It matches what x86 has, is what I observed on my system, and in this case
  since we are counting occurance, is probably more preferred/simpler to do than printing
  the backtraces for each thread.