### PR TITLE
Fixes #3182 - Overshooting sys calls

### DIFF
--- a/src/ProcFdDirMonitor.cc
+++ b/src/ProcFdDirMonitor.cc
@@ -17,18 +17,11 @@ namespace rr {
 ProcFdDirMonitor::ProcFdDirMonitor(Task* t, const string& pathname) {
   // XXX this makes some assumptions about namespaces... Probably fails
   // if |t| is not the same pid namespace as rr
-  int ends_with_slash = (pathname.back() == '/');
-  if (pathname.substr(0, 6) == string("/proc/") &&
-      pathname.substr(pathname.size() - 3 - ends_with_slash, 3) ==
-          string("/fd")) {
-    string s = pathname.substr(6, pathname.size() - 9 - ends_with_slash);
-    char* end;
-    int tid = strtol(s.c_str(), &end, 10);
-    if (!*end) {
-      Task* target = t->session().find_task(tid);
-      if (target) {
-        tuid = target->tuid();
-      }
+  int tid = parse_tid_from_proc_path(pathname, "/fd");
+  if (tid > 0) {
+    Task* target = t->session().find_task(tid);
+    if (target) {
+      tuid = target->tuid();
     }
   }
 }

--- a/src/ProcMemMonitor.cc
+++ b/src/ProcMemMonitor.cc
@@ -17,16 +17,11 @@ namespace rr {
 ProcMemMonitor::ProcMemMonitor(Task* t, const string& pathname) {
   // XXX this makes some assumptions about namespaces... Probably fails
   // if |t| is not the same pid namespace as rr
-  if (pathname.substr(0, 6) == string("/proc/") &&
-      pathname.substr(pathname.size() - 4, 4) == string("/mem")) {
-    string s = pathname.substr(6, pathname.size() - 10);
-    char* end;
-    int tid = strtol(s.c_str(), &end, 10);
-    if (!*end) {
-      Task* target = t->session().find_task(tid);
-      if (target) {
-        auid = target->vm()->uid();
-      }
+  int tid = parse_tid_from_proc_path(pathname, "/mem");
+  if (tid > 0) {
+    Task* target = t->session().find_task(tid);
+    if (target) {
+      auid = target->vm()->uid();
     }
   }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -566,6 +566,9 @@ void SAFE_FATAL(int err, const char *msg);
 
 bool coredumping_signal_takes_down_entire_vm();
 
+/* Parse tid from the proc file system path /proc/<pid>/<property> or /proc/<pid>/task/<tid>/<property> */
+int parse_tid_from_proc_path(const std::string& pathname, const std::string& property);
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
This patch fixes the parsing of the thread ID from
the proc filesystem. Man pages for proc on linux says;
There are two paths for a running thread that is not a
thread group leader;
/proc/[tid]/.. and /proc/[pid]/task/[tid]/...

rr currently does not register to watch on the latter.

The parsing of the tid is lifted into it's own function in util.h/cc,
which ProcMemMonitor and ProcFdDirMonitor calls.

Recording and replaying (issue #3182 was specifically for GDB)
is tested and with this patch, rr does not fail.

Test cases for /proc/pid/task/tid written by @khuey 