### PR TITLE
Use orig_arg1 to access rrcall parameter during recording

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -778,7 +778,7 @@ KernelMapping AddressSpace::map(Task* t, remote_ptr<void> addr,
 
 template <typename Arch> void AddressSpace::at_preload_init_arch(Task* t) {
   auto params = t->read_mem(
-      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().arg1()));
+      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().orig_arg1()));
 
   if (t->session().is_recording()) {
     ASSERT(t,

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -837,7 +837,7 @@ template <>
 void patch_at_preload_init_arch<ARM64Arch>(RecordTask* t,
                                            Monkeypatcher&) {
   auto params = t->read_mem(
-      remote_ptr<rrcall_init_preload_params<ARM64Arch>>(t->regs().arg1()));
+      remote_ptr<rrcall_init_preload_params<ARM64Arch>>(t->regs().orig_arg1()));
   if (!params.syscallbuf_enabled) {
     return;
   }

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -372,7 +372,7 @@ void RecordTask::post_exec() {
 
 template <typename Arch> static void do_preload_init_arch(RecordTask* t) {
   auto params = t->read_mem(
-      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().arg1()));
+      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().orig_arg1()));
 
   t->syscallbuf_code_layout.syscallbuf_syscall_hook =
       params.syscallbuf_syscall_hook.rptr().as_int();
@@ -447,7 +447,7 @@ template <typename Arch> void RecordTask::init_buffers_arch() {
   AutoRemoteSyscalls remote(this);
 
   // Arguments to the rrcall.
-  remote_ptr<rrcall_init_buffers_params<Arch>> child_args = regs().arg1();
+  remote_ptr<rrcall_init_buffers_params<Arch>> child_args = regs().orig_arg1();
   auto args = read_mem(child_args);
 
   args.cloned_file_data_fd = -1;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3086,7 +3086,7 @@ bool Task::clone_syscall_is_complete(pid_t* new_pid,
 
 template <typename Arch> static void do_preload_init_arch(Task* t) {
   auto params = t->read_mem(
-      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().arg1()));
+      remote_ptr<rrcall_init_preload_params<Arch>>(t->regs().orig_arg1()));
 
   for (Task* tt : t->vm()->task_set()) {
     tt->preload_globals = params.globals.rptr();


### PR DESCRIPTION
These are called in the syscall exit stop at which point arg1 is already overwritten.