### PR TITLE
Fix raw syscall for aarch64

### DIFF
--- a/src/preload/raw_syscall.S
+++ b/src/preload/raw_syscall.S
@@ -143,6 +143,8 @@ _raw_syscall:
         .type _raw_syscall, @function
 _raw_syscall:
         .cfi_startproc
+        // The two stack arguments are already on the stack
+        // right above the stack pointer just as what we need them
         mov x8,x0
         mov x0,x1
         mov x1,x2
@@ -150,8 +152,7 @@ _raw_syscall:
         mov x3,x4
         mov x4,x5
         mov x5,x6
-        svc #0
-        ret
+        br  x7
         .cfi_endproc
         .size _raw_syscall, . - _raw_syscall
 #else


### PR DESCRIPTION
The syscall must be made from one our the entries in rrpage.
Otherwise syscallbuf logic cannot detect it correctly.

Also add a comment regarding the extra stack arguments.
There's nothing we need to do about them ATM since we aren't doing
any post-processing, if we do, then we'll have to save/restore x30
which will require re-pushing those arguments.

This may require https://github.com/rr-debugger/rr/pull/3191 to avoid regression on aarch64. (I've never tested it without some of my WIP syscallbuf stuff)
