### PR TITLE
prevent use of bad commands like "jump"

### DIFF
--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -86,6 +86,17 @@ class RRWhere(gdb.Command):
 
 RRWhere()
 
+class RRDenied(gdb.Command):
+    """Helper to prevent use of breaking commands. Used by auto-args"""
+    def __init__(self):
+        gdb.Command.__init__(self, 'rr-denied',
+                             gdb.COMMAND_USER, gdb.COMPLETE_NONE, False)
+
+    def invoke(self, arg, from_tty):
+        raise gdb.GdbError("Execution of '" + arg + "' is not possible in recorded executions.")
+
+RRDenied()
+
 class RRCmd(gdb.Command):
     def __init__(self, name, auto_args):
         gdb.Command.__init__(self, name,

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -71,6 +71,9 @@ static const string& gdb_rr_macros() {
        << "document seek-ticks\n"
        << "restart at given ticks value\n"
        << "end\n"
+       << "define jump\n"
+       << "  rr-denied jump\n"
+       << "end\n"
        // In gdb version "Fedora 7.8.1-30.fc21", a raw "run" command
        // issued before any user-generated resume-execution command
        // results in gdb hanging just after the inferior hits an internal


### PR DESCRIPTION
Executing this command (I had that in a script) would otherwise lead to

> ERROR /tmp/install/rr/src/GdbServer.cc:631:dispatch_debugger_request()] Attempt to write register outside diversion session

Now it raises a nice user-visible gdb error

> Execution of 'jump' is not possible in recorded executions.


There are possibly more commands to "forbid", the suggested change can be easily extended to other commands.

[side note: sadly I found no way to redefine a mi command so `-exec-jump` still leads to the error above]