### PR TITLE
Improve ptrace emulation

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -724,7 +724,7 @@ void RecordTask::set_emulated_ptracer(RecordTask* tracer) {
   }
 }
 
-bool RecordTask::emulate_ptrace_stop(WaitStatus status,
+bool RecordTask::emulate_ptrace_stop(WaitStatus status, EmulatedStopType stop_type,
                                      const siginfo_t* siginfo, int si_code) {
   ASSERT(this, emulated_stop_type == NOT_STOPPED);
   if (!emulated_ptracer) {
@@ -744,12 +744,12 @@ bool RecordTask::emulate_ptrace_stop(WaitStatus status,
     }
     save_ptrace_signal_siginfo(si);
   }
-  force_emulate_ptrace_stop(status);
+  force_emulate_ptrace_stop(status, stop_type);
   return true;
 }
 
-void RecordTask::force_emulate_ptrace_stop(WaitStatus status) {
-  emulated_stop_type = status.group_stop() ? GROUP_STOP : SIGNAL_DELIVERY_STOP;
+void RecordTask::force_emulate_ptrace_stop(WaitStatus status, EmulatedStopType stop_type) {
+  emulated_stop_type = stop_type;
   emulated_stop_code = status;
   emulated_stop_pending = true;
   emulated_ptrace_SIGCHLD_pending = true;

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -36,6 +36,9 @@ enum EmulatedStopType {
   NOT_STOPPED,
   GROUP_STOP,          // stopped by a signal. This applies to non-ptracees too.
   SIGNAL_DELIVERY_STOP,// Stopped before delivering a signal. ptracees only.
+  SYSCALL_ENTRY_STOP,  // Stopped at syscall entry. ptracees only
+  SYSCALL_EXIT_STOP,   // Stopped at syscall exit. ptracees only
+  SECCOMP_STOP,        // Stopped at seccomp stop. ptracees only
   CHILD_STOP           // All other kinds of non-ptrace stops
 };
 
@@ -112,11 +115,17 @@ public:
    * Returns true if the task is stopped-for-emulated-ptrace, false otherwise.
    */
   bool emulate_ptrace_stop(WaitStatus status,
+                           const siginfo_t* siginfo = nullptr, int si_code = 0) {
+    return emulate_ptrace_stop(status, status.group_stop() ? GROUP_STOP : SIGNAL_DELIVERY_STOP,
+      siginfo, si_code);
+  }
+  bool emulate_ptrace_stop(WaitStatus status, EmulatedStopType stop_type,
                            const siginfo_t* siginfo = nullptr, int si_code = 0);
+
   /**
    * Force the ptrace-stop state no matter what state the task is currently in.
    */
-  void force_emulate_ptrace_stop(WaitStatus status);
+  void force_emulate_ptrace_stop(WaitStatus status, EmulatedStopType stop_type);
   /**
    * If necessary, signal the ptracer that this task has exited.
    */

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -9,6 +9,7 @@
 #include <dirent.h>
 #include <elf.h>
 #include <fcntl.h>
+#include <linux/audit.h>
 #include <linux/capability.h>
 #include <linux/cdrom.h>
 #include <linux/ethtool.h>
@@ -105,6 +106,22 @@ CHECK_ELF(EM_386 == EM::I386);
 CHECK_ELF(EM_X86_64 == EM::X86_64);
 
 CHECK_ELF(ELFDATA2LSB == ELFENDIAN::DATA2LSB);
+
+int to_audit_arch(SupportedArch arch) {
+  switch (arch) {
+    case x86:
+      return AUDIT_ARCH_I386;
+    case x86_64:
+      return AUDIT_ARCH_X86_64;
+#ifdef AUDIT_ARCH_AARCH64
+    case aarch64:
+      return AUDIT_ARCH_AARCH64;
+#endif
+    default:
+      FATAL() << "Unknown architecture";
+      return 0;
+  }
+}
 
 static const uint8_t int80_insn[] = { 0xcd, 0x80 };
 static const uint8_t sysenter_insn[] = { 0x0f, 0x34 };

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -32,6 +32,8 @@ inline bool is_x86ish(SupportedArch arch_) {
   return arch_ == x86 || arch_ == x86_64;
 }
 
+int to_audit_arch(SupportedArch arch);
+
 template <SupportedArch a, typename system_type, typename rr_type>
 struct Verifier {
   // Optimistically say we are the same size.
@@ -1860,6 +1862,28 @@ struct BaseArch : public wordsize,
     uint8_t cdte_datamode;
   };
   RR_VERIFY_TYPE(cdrom_tocentry);
+
+  struct ptrace_syscall_info {
+    uint8_t op;
+    uint32_t arch;
+    uint64_t instruction_pointer;
+    uint64_t stack_pointer;
+    union {
+        struct {
+            uint64_t nr;
+            uint64_t args[6];
+        } entry;
+        struct {
+            int64_t rval;
+            uint8_t is_error;
+        } exit;
+        struct {
+            uint64_t nr;
+            uint64_t args[6];
+            uint32_t ret_data;
+        } seccomp;
+    };
+  };
 };
 
 struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {

--- a/src/test/ptrace_exec.c
+++ b/src/test/ptrace_exec.c
@@ -3,9 +3,6 @@
 #include "util.h"
 #include "ptrace_util.h"
 
-/* Test that PTRACE_ATTACH produces a raw SIGTRAP after exiting exec, when
-   PTRACE_O_TRACEEXEC is not used. */
-
 static size_t read_all(int fd, char* buf, size_t size) {
   size_t total = 0;
   while (size > 0) {
@@ -42,16 +39,11 @@ static int proc_num_args(pid_t pid) {
   return count;
 }
 
-int main(int argc, __attribute__((unused)) char** argv) {
+void run_test(char** argv, int use_traceexec, int syscall_step)
+{
   pid_t child;
   int status;
   struct user_regs_struct regs;
-
-  test_assert(proc_num_args(getpid()) == argc);
-
-  if (argc == 2) {
-    return 77;
-  }
 
   if (0 == (child = fork())) {
     char* args[] = { argv[0], "hello", NULL };
@@ -59,36 +51,69 @@ int main(int argc, __attribute__((unused)) char** argv) {
     execve(argv[0], args, environ);
     /* should never reach here */
     test_assert(0);
-    return 1;
+    return;
   }
 
   test_assert(proc_num_args(child) == 1);
-  test_assert(0 == ptrace(PTRACE_ATTACH, child, NULL, NULL));
+  if (use_traceexec)
+    test_assert(0 == ptrace(PTRACE_SEIZE, child, NULL, (void*)PTRACE_O_TRACEEXEC));
+  else
+    test_assert(0 == ptrace(PTRACE_ATTACH, child, NULL,
+      (void*)PTRACE_O_TRACEEXEC));
   test_assert(child == waitpid(child, &status, 0));
   test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP);
 
-  while (1) {
-    test_assert(0 == ptrace(PTRACE_CONT, child, NULL, (void*)0));
-    test_assert(child == waitpid(child, &status, 0));
-    if (status == ((SIGTRAP << 8) | 0x7f)) {
-      break;
+  if (syscall_step) {
+    while (1) {
+      test_assert(0 == ptrace(PTRACE_SYSCALL, child, NULL, (void*)0));
+      test_assert(child == waitpid(child, &status, 0));
+      if (!(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) &&
+          !(status == ((SIGTRAP << 8) | 0x7f)))
+        break;
     }
-    test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP);
+  } else {
+    while (1) {
+      test_assert(0 == ptrace(PTRACE_CONT, child, NULL, (void*)0));
+      test_assert(child == waitpid(child, &status, 0));
+      if (!(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP))
+        break;
+    }
   }
+
+  if (use_traceexec)
+    test_assert(status >> 8 == (SIGTRAP | (PTRACE_EVENT_EXEC << 8)));
+  else
+    test_assert(status == ((SIGTRAP << 8) | 0x7f));
 
   ptrace_getregs(child, &regs);
 #if !defined(__aarch64__)
   // On aarch64, we may only ask this in a syscall-entry stop, which this is not
   test_assert(SYS_execve == regs.ORIG_SYSCALLNO);
 #endif
-  test_assert(0 == regs.SYSCALL_RESULT);
+  if (!use_traceexec)
+    test_assert(0 == regs.SYSCALL_RESULT);
   /* Check that we have actually transitioned */
   test_assert(proc_num_args(child) == 2);
 
   test_assert(0 == ptrace(PTRACE_CONT, child, NULL, (void*)0));
   test_assert(child == waitpid(child, &status, 0));
   test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 77);
+}
+
+int main(int argc, char** argv) {
+  test_assert(proc_num_args(getpid()) == argc);
+
+  if (argc == 2) {
+    return 77;
+  }
+
+  /* Test that PTRACE_ATTACH produces a raw SIGTRAP after exiting exec, when
+    PTRACE_O_TRACEEXEC is not used. */
+  run_test(argv, 0, 0);
+  /* Test that rr doesn't mind exec stops and syscall exit stops both happening */
+  run_test(argv, 1, 1);
 
   atomic_puts("EXIT-SUCCESS");
+
   return 0;
 }

--- a/src/test/ptrace_remote_unmap.c
+++ b/src/test/ptrace_remote_unmap.c
@@ -149,6 +149,12 @@ int main(void) {
   test_assert(wret == child);
   test_assert(status >> 8 == (SIGTRAP | (PTRACE_EVENT_EXEC << 8)));
 
+  // Continue to syscall exit event
+  checked_ptrace(PTRACE_SYSCALL, child, 0, 0);
+  wret = waitpid(child, &status, __WALL | WSTOPPED);
+  test_assert(wret == child);
+  test_assert(WSTOPSIG(status) == (SIGTRAP | 0x80));
+
   // On kernels with aggressive ASLR, the executable mapping may
   // not be in the same place that it is now. Find it again.
   ssize_t path_size = readlink("/proc/self/exe", exe_path, 200);

--- a/src/test/ptrace_seize.c
+++ b/src/test/ptrace_seize.c
@@ -39,6 +39,13 @@ int main(void) {
   test_assert(child == waitpid(child, &status, 0));
   test_assert(status == ((PTRACE_EVENT_STOP << 16) | (SIGSTOP << 8) | 0x7f));
 
+  test_assert(0 == ptrace(PTRACE_CONT, child, NULL, 0));
+  test_assert(0 == ptrace(PTRACE_INTERRUPT, child, NULL, 0));
+  test_assert(status == ((PTRACE_EVENT_STOP << 16) | (SIGSTOP << 8) | 0x7f) ||
+              status == (((SIGTRAP | 0x80) << 8) | 0x7f));
+
+  test_assert(WIFSTOPPED(status));
+
   test_assert(0 == kill(child, SIGKILL));
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/ptrace_syscall.c
+++ b/src/test/ptrace_syscall.c
@@ -3,6 +3,8 @@
 #include "util.h"
 #include "ptrace_util.h"
 
+#include <linux/ptrace.h>
+
 #ifdef SYS_geteuid32
 #define SYSCALLNO SYS_geteuid32
 #else
@@ -14,6 +16,7 @@ extern char syscall_addr __attribute__ ((visibility ("hidden")));
 int main(void) {
   pid_t child;
   int status;
+  int ret = 0;
   struct user_regs_struct regs;
   uid_t uid = geteuid();
 
@@ -35,6 +38,36 @@ int main(void) {
   test_assert(child == waitpid(child, &status, 0));
   test_assert(status == (((0x80 | SIGTRAP) << 8) | 0x7f));
   ptrace_getregs(child, &regs);
+
+#ifdef PTRACE_GET_SYSCALL_INFO
+  struct ptrace_syscall_info *info;
+  ALLOCATE_GUARD(info, 'a');
+  ret = ptrace(PTRACE_GET_SYSCALL_INFO, child, sizeof(*info), info);
+  if (ret > 0) {
+    test_assert((offsetof(struct ptrace_syscall_info, entry) + sizeof(info->entry)) == ret);
+    test_assert(info->op == PTRACE_SYSCALL_INFO_ENTRY);
+    test_assert(info->instruction_pointer == (__u64)regs.IP);
+    test_assert(info->stack_pointer == (__u64)(uintptr_t)regs.SP);
+    test_assert(info->entry.nr == SYSCALLNO);
+    test_assert(info->entry.args[0] == (__u64)regs.SYSCALL_ARG1);
+  } else {
+    test_assert(errno == EIO);
+  }
+  VERIFY_GUARD(info);
+
+  // Test truncation behavior
+  uint8_t *op;
+  ALLOCATE_GUARD(op, 'a');
+  ret = ptrace(PTRACE_GET_SYSCALL_INFO, child, sizeof(*op), op);
+  if (ret > 0) {
+    test_assert((offsetof(struct ptrace_syscall_info, entry) + sizeof(info->entry)) == ret);
+    test_assert(*op == PTRACE_SYSCALL_INFO_ENTRY);
+  } else {
+    test_assert(errno == EIO);
+  }
+  VERIFY_GUARD(op);
+#endif
+
   /* This assert will fail if we patched the syscall for syscallbuf. */
   test_assert(&syscall_addr + SYSCALL_SIZE == (char*)regs.IP);
   test_assert(SYSCALLNO == regs.ORIG_SYSCALLNO);
@@ -53,6 +86,22 @@ int main(void) {
 #endif
   test_assert(child == (int)regs.SYSCALL_RESULT);
   test_assert(&syscall_addr + SYSCALL_SIZE == (char*)regs.IP);
+
+#ifdef PTRACE_GET_SYSCALL_INFO
+  ALLOCATE_GUARD(info, 'a');
+  ret = ptrace(PTRACE_GET_SYSCALL_INFO, child, sizeof(*info), info);
+  if (ret > 0) {
+    test_assert((offsetof(struct ptrace_syscall_info, exit) + sizeof(uint64_t) + sizeof(uint8_t)) == ret);
+    test_assert(info->op == PTRACE_SYSCALL_INFO_EXIT);
+    test_assert(info->instruction_pointer == (__u64)regs.IP);
+    test_assert(info->stack_pointer == (__u64)(uintptr_t)regs.SP);
+    test_assert(info->exit.rval == (__s64)regs.SYSCALL_RESULT);
+  } else {
+    test_assert(errno == EIO);
+  }
+  VERIFY_GUARD(info);
+#endif
+
   regs.SYSCALL_RESULT = uid + 1;
   ptrace_setregs(child, &regs);
 

--- a/src/test/ptrace_util.h
+++ b/src/test/ptrace_util.h
@@ -39,6 +39,16 @@
 #error unknown architecture
 #endif
 
+#if defined(__i386__)
+#define SP esp
+#elif defined(__x86_64__)
+#define SP rsp
+#elif defined(__aarch64__)
+#define SP sp
+#else
+#error unknown architecture
+#endif
+
 #if defined(__i386__) || defined(__x86_64__)
 #define SYSCALL_SIZE 2
 #elif defined(__aarch64__)


### PR DESCRIPTION
This implements two missing ptrace commands: PTRACE_INTERRUPT and
PTRACE_GET_SYSCALL_INFO. While we're here, also fix a bug where
hitting a PTRACE_EVENT_EXEC using PTRACE_SYSCALL would cause rr
to assert, because it had no mechanism by which to wait for the
ptracer to acknowledge the PTRACE_EVENT_EXEC before continuing
to the syscall exit stop. Fix that by moving the point at which
we signal the emulated PTRACE_EVENT_EXEC to when rr receives the
real PTRACE_EVENT_EXEC, after which we get a full round trip to
record_step again and can thus handle the task being suspended
just fine. One minor complication is that this conflicts with
the threadgroup exec region from ee6df921, which currently
ends only upon return from the exec syscall (which happens
after the exec stop). I don't entirely understand the purpose
of that change, but I'm assuming it's to avoid attempting
to run tasks that the kernel may currently be shooting down
as part of the exec. In this PR I'm changing the region to
end upon the kernel's PTRACE_EVENT_EXEC notification. I think
that should be fine, since at this point, the exec has
semantically already happened, including all shootdowns, etc.