### PR TITLE
Fix syscall restart after signal on aarch64

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1628,7 +1628,12 @@ bool RecordSession::signal_state_changed(RecordTask* t, StepState* step_state) {
               r.set_syscallno(syscall_number_for_restart_syscall(t->arch()));
               break;
           }
-          r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
+          // On aarch64, the kernel modifies the registers before the signal stop.
+          // so we should not decrement the pc again or we'll rerun the instruction
+          // before the syscall.
+          // [1] https://github.com/torvalds/linux/blob/caffb99b6929f41a69edbb5aef3a359bf45f3315/arch/arm64/kernel/signal.c#L855-L862
+          if (t->arch() != aarch64)
+            r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
           // Now that we've mucked with the registers, we can't switch tasks. That
           // could allow more signals to be generated, breaking our assumption
           // that we are the last signal.


### PR DESCRIPTION
Unlike x86, the pc is already moved to before the syscall on aarch64 before the kernel inform us about it.

I have not really gone through all the code paths and confirm the state of the pc when it gets here but the change is consistent with the comment above https://github.com/rr-debugger/rr/blob/b8368dd96b7e25f4cc0b2faa6fd3eeadf6d0f22e/src/RecordSession.cc#L1614 as well as https://github.com/rr-debugger/rr/blob/b8368dd96b7e25f4cc0b2faa6fd3eeadf6d0f22e/src/ReplaySession.cc#L1786 .

I've also put in an assertion here to make sure that the instruction the ip points to is indeed the syscall instruction. There are about 40 tests that hits this path and all of them confirms the observation.

I suspect this don't usually show up because the instruction is fixed length and the instruction before the syscall can usually be reexecuted without any side-effects... (out of the ~400 instances of `svc 0` in my libc, only 2 are potentially problematic). This is a more severe issue with syscallbuf though since the syscalls on the rrpage are surrounded by `ret` that shouldn't be executed...