### PR TITLE
Get return address correctly on aarch64

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1523,7 +1523,14 @@ bool RecordTask::is_in_syscallbuf() {
                           p < syscallbuf_code_layout.get_pc_thunks_end)) {
     // Look at the caller to see if we're in the syscallbuf or not.
     bool ok = true;
-    uint64_t addr = read_ptr(this, regs().sp(), &ok);
+    uint64_t addr;
+    if (arch() == aarch64) {
+      addr = regs().xlr();
+    }
+    else {
+      ASSERT(this, is_x86ish(arch())) << "Unknown architecture";
+      addr = read_ptr(this, regs().sp(), &ok);
+    }
     if (ok) {
       p = addr;
     }

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -418,6 +418,11 @@ public:
     DEBUG_ASSERT(arch() == aarch64);
     return u.arm64regs.x[7];
   }
+
+  uintptr_t xlr() const {
+    DEBUG_ASSERT(arch() == aarch64);
+    return u.arm64regs.x[30];
+  }
   // End of aarch64 specific accessors
 
   /**


### PR DESCRIPTION
On aarch64, the return address is in lr after the call.
Not on the stack...