### PR TITLE
Increase number of vdso calls to guarantee a overflow

### DIFF
--- a/src/test/vdso_clock_gettime_stack.c
+++ b/src/test/vdso_clock_gettime_stack.c
@@ -5,7 +5,7 @@
 int main(void) {
   int i;
   struct timespec ts;
-  for (i = 0; i < 10000; ++i) {
+  for (i = 0; i < 160000; ++i) {
     clock_gettime(CLOCK_MONOTONIC, &ts);
   }
 

--- a/src/test/vdso_gettimeofday_stack.c
+++ b/src/test/vdso_gettimeofday_stack.c
@@ -5,7 +5,7 @@
 int main(void) {
   int i;
   struct timeval tv;
-  for (i = 0; i < 10000; ++i) {
+  for (i = 0; i < 160000; ++i) {
     gettimeofday(&tv, NULL);
   }
 

--- a/src/test/vdso_time_stack.c
+++ b/src/test/vdso_time_stack.c
@@ -4,7 +4,7 @@
 
 int main(void) {
   int i;
-  for (i = 0; i < 10000; ++i) {
+  for (i = 0; i < 160000; ++i) {
     time(NULL);
   }
 


### PR DESCRIPTION
On AArch64 where the page size may be as large as 64k,
it takes many more calls of the vdso function in order to guarantee we hit a overflow.