### PR TITLE
Implement vdso replacement on aarch64

### DIFF
--- a/src/preload/rr_page.ld.in
+++ b/src/preload/rr_page.ld.in
@@ -50,5 +50,9 @@ VERSION {
       __vdso_time;
       __vdso_clock_gettime;
       __vdso_getcpu;
+      __kernel_clock_getres;
+      __kernel_rt_sigreturn;
+      __kernel_gettimeofday;
+      __kernel_clock_gettime;
   };
 }

--- a/src/preload/rr_vdso.S
+++ b/src/preload/rr_vdso.S
@@ -1,5 +1,10 @@
+#ifdef __aarch64__
+#define STARTPROC_GLOBAL(name) .globl #name; .type #name, @function; \
+ #name:; .cfi_startproc
+#else
 #define STARTPROC_GLOBAL(name) .global #name; .type #name, @function; \
  #name:; .cfi_startproc
+#endif
 #define CFI_ENDPROC .cfi_endproc
 
 // Older libs don't use the __vdso symbols, but try to look for the syscall
@@ -104,8 +109,25 @@ WEAK_ALIAS(gettimeofday,__vdso_gettimeofday)
 .symver __vdso_getcpu,__vdso_getcpu@LINUX_2.6
 
 #elif defined(__aarch64__)
-.fill PRELOAD_LIBRARY_PAGE_SIZE, 1, 0
-// XXXkhuey there should probably be something here
+
+#define SYSCALL(which)          \
+        mov     x8, which;      \
+        svc     0;              \
+        ret
+
+STARTPROC_GLOBAL(__kernel_clock_getres)
+SYSCALL(114)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__kernel_rt_sigreturn)
+SYSCALL(139)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__kernel_gettimeofday)
+SYSCALL(169)
+CFI_ENDPROC
+STARTPROC_GLOBAL(__kernel_clock_gettime)
+SYSCALL(113)
+CFI_ENDPROC
+
 #else
 
 #error "VDSO Hooks not defined for this platform"


### PR DESCRIPTION
AFAICT the vdso on aarch64 doesn't have any alias

```
DYNAMIC SYMBOL TABLE:
0000000000000000 g    DO *ABS*  0000000000000000  LINUX_2.6.39 LINUX_2.6.39
0000000000000760 g    DF .text  0000000000000078  LINUX_2.6.39 __kernel_clock_getres
00000000000007dc g    D  .text  0000000000000008  LINUX_2.6.39 __kernel_rt_sigreturn
0000000000000740 g    DF .text  000000000000001c  LINUX_2.6.39 __kernel_gettimeofday
0000000000000720 g    DF .text  000000000000001c  LINUX_2.6.39 __kernel_clock_gettime
```

Tested locally that the vdso we put in indeed got called and I can get a backtrace from them.