### PR TITLE
Fix patch page end test on aarch64

### DIFF
--- a/src/test/patch_page_end.c
+++ b/src/test/patch_page_end.c
@@ -21,9 +21,6 @@ static const uint8_t code[] = {
 #elif defined(__aarch64__)
 static const uint8_t code[] = {
     0x1, 0x0, 0x0, 0xd4,    // svc #0
-    0x1f, 0x20, 0x03, 0xd5, // nop
-    0x1f, 0x20, 0x03, 0xd5, // nop
-    0x1f, 0x20, 0x03, 0xd5, // nop
     0xc0, 0x03, 0x5f, 0xd6, // ret
 };
 #else
@@ -45,7 +42,19 @@ static long do_call(uint8_t* p) {
   return ret;
 }
 
-static void check_patch(uint8_t* p) { test_assert(p[0] == 0xe9); }
+static void check_patch(uint8_t* p)
+{
+#if defined (__i386__) || defined(__x86_64__)
+  test_assert(p[0] == 0xe9);
+#elif defined(__aarch64__)
+  uint32_t inst;
+  memcpy(&inst, p, sizeof(inst));
+  // b to immediate instruction
+  test_assert((inst & 0xfc000000) == 0x14000000);
+#else
+  #error unsupported arch
+#endif
+}
 
 int main(void) {
   size_t page_size = sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
On AArch64, we only need to patch the syscall instruction to a branch so updating the test for that. I specifically removed the nops for aarch64 in this test to make sure we can achieve that.