### PR TITLE
Update origin syscallno on SYSCALL entry stop

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -888,6 +888,9 @@ static void advance_to_disarm_desched_syscall(RecordTask* t) {
     if (t->is_dying()) {
       return;
     }
+    if (t->status().is_syscall()) {
+      t->apply_syscall_entry_regs();
+    }
     /* We can safely ignore TIME_SLICE_SIGNAL while trying to
      * reach the disarm-desched ioctl: once we reach it,
      * the desched'd syscall will be "done" and the tracee

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -533,6 +533,7 @@ Completion ReplaySession::cont_syscall_boundary(
     return INCOMPLETE;
   }
 
+  t->apply_syscall_entry_regs();
   return COMPLETE;
 }
 

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -426,6 +426,7 @@ static void handle_desched_event(RecordTask* t) {
     t->resume_execution(RESUME_SYSCALL, RESUME_WAIT, RESUME_UNLIMITED_TICKS);
 
     if (t->status().is_syscall()) {
+      t->apply_syscall_entry_regs();
       if (t->is_arm_desched_event_syscall()) {
         continue;
       }


### PR DESCRIPTION
These only affects AArch64.

There might be more of these but for now these are the ones that has caused problems for me (following call getting the wrong syscall number). I feel like this should probably be tracked in a central location to mimic the kernel behavior on x86 better but this seems to be the current solution used in other places as well....