### PR TITLE
Do not throw an error in unpatching on aarch64

### DIFF
--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -473,7 +473,7 @@ void unpatch_syscalls_arch<X64Arch>(Monkeypatcher &patcher, Task *t) {
 template <>
 void unpatch_syscalls_arch<ARM64Arch>(Monkeypatcher &patcher, Task *t) {
   (void)patcher; (void)t;
-  FATAL() << "Unimplemented";
+  // FATAL() << "Unimplemented";
 }
 
 void Monkeypatcher::unpatch_syscalls_in(Task *t) {


### PR DESCRIPTION
It is still not implemented yet but since the syscallbuf isn't implemented the unpatching has nothing to do anyway.

This is currently causing test failures due to the rrcall made from the tests.

(The syscallbuf implementation will of course include an implementation for unpatch as well)