### PR TITLE
Tweaks for various test failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ else()
 endif()
 configure_file(src/preload/rr_page.ld.in src/preload/rr_page.ld @ONLY)
 
+include(CheckCCompilerFlag)
+CHECK_C_COMPILER_FLAG("-fmacro-prefix-map=$(srctree)/=" SUPPORTS_MACRO_PREFIX_MAP)
+if (SUPPORTS_MACRO_PREFIX_MAP)
+  set(FLAGS_COMMON "${FLAGS_COMMON} -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=")
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.

--- a/src/test/dev_tty.run
+++ b/src/test/dev_tty.run
@@ -7,6 +7,8 @@ if [[ "replay.err" != $(grep -l $token replay.err) ]]; then
     echo "--------------------------------------------------"
     cat replay.err
     echo "--------------------------------------------------"
+    cat replay.out
+    echo "--------------------------------------------------"
 else
     passed
 fi

--- a/src/test/ttyname.c
+++ b/src/test/ttyname.c
@@ -11,6 +11,7 @@ int main(void) {
     return 0;
   }
   int fd = open(tty, O_RDWR);
+  test_assert(fd >= 0);
   test_assert(13 == write(fd, "EXIT-SUCCESS\n", 13));
   return 0;
 }

--- a/src/test/ttyname.run
+++ b/src/test/ttyname.run
@@ -7,6 +7,8 @@ if [[ "replay.err" != $(grep -l $token replay.err) ]]; then
     echo "--------------------------------------------------"
     cat replay.err
     echo "--------------------------------------------------"
+    cat replay.out
+    echo "--------------------------------------------------"
 else
     passed
 fi

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -178,22 +178,17 @@ inline static int atomic_puts(const char* str) {
 #define printf(...) USE_atomic_printf_INSTEAD
 #define puts(...) USE_atomic_puts_INSTEAD
 
-inline static int check_cond(int cond) {
+inline static int atomic_assert(int cond, const char *str,
+				const char *file, const int line) {
   if (!cond) {
-    atomic_printf("FAILED: errno=%d (%s)\n", errno, strerror(errno));
-  }
-  return cond;
-}
-
-inline static int atomic_assert(int cond, const char *str) {
-  if (!check_cond(cond)) {
-    atomic_printf("FAILED: !(%s)\n", str);
+    atomic_printf("FAILED at %s:%d: !(%s) errno:%d (%s)\n", file, line, str,
+		  errno, strerror(errno));
     raise(SIGABRT);
   }
   return 1;
 }
 
-#define test_assert(cond) atomic_assert(cond, #cond)
+#define test_assert(cond) atomic_assert(cond, #cond, __FILE__, __LINE__)
 
 /**
  * Return the calling task's id.


### PR DESCRIPTION
These are some tweaks to improve test failure readability I ran into with ttyname and netfilter.