### PR TITLE
Add dynamic PMU type support for aarch64

### DIFF
--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -12,7 +12,8 @@ using namespace std;
 
 namespace rr {
 
-DiversionSession::DiversionSession() : emu_fs(EmuFs::create()) {}
+DiversionSession::DiversionSession(int cpu_binding) :
+  emu_fs(EmuFs::create()), cpu_binding_(cpu_binding) {}
 
 DiversionSession::~DiversionSession() {
   // We won't permanently leak any OS resources by not ensuring

--- a/src/DiversionSession.h
+++ b/src/DiversionSession.h
@@ -29,7 +29,7 @@ class ReplaySession;
  */
 class DiversionSession : public Session {
 public:
-  DiversionSession();
+  DiversionSession(int cpu_binding);
 
   typedef std::shared_ptr<DiversionSession> shr_ptr;
 
@@ -54,6 +54,7 @@ public:
                                  int signal_to_deliver = 0);
 
   virtual DiversionSession* as_diversion() override { return this; }
+  virtual int cpu_binding() const override { return cpu_binding_; }
 
   void set_tracee_fd_number(int fd_number) { tracee_socket_fd_number = fd_number; }
   void on_create(Task *t) override { this->Session::on_create(t); }
@@ -62,6 +63,7 @@ private:
   friend class ReplaySession;
 
   std::shared_ptr<EmuFs> emu_fs;
+  int cpu_binding_;
 };
 
 } // namespace rr

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -124,6 +124,9 @@ struct PmuConfig {
   unsigned llsc_cntr_event;
   uint32_t skid_size;
   uint32_t flags;
+  unsigned cycle_event = PERF_COUNT_HW_CPU_CYCLES;
+  int cycle_type = PERF_TYPE_HARDWARE;
+  int event_type = PERF_TYPE_RAW;
 };
 
 // XXX please only edit this if you really know what you're doing.
@@ -195,9 +198,9 @@ static int get_pmu_index(int cpu_binding)
 }
 
 static void init_perf_event_attr(struct perf_event_attr* attr,
-                                 perf_type_id type, unsigned config) {
+                                 unsigned type, unsigned config) {
   memset(attr, 0, sizeof(*attr));
-  attr->type = type;
+  attr->type = perf_type_id(type);
   attr->size = sizeof(*attr);
   attr->config = config;
   // rr requires that its events count userspace tracee code
@@ -429,14 +432,15 @@ static void init_attributes() {
       perf_attr.skid_size = pmu_uarch.skid_size;
       perf_attr.pmu_flags = pmu_uarch.flags;
       perf_attr.bug_flags = (int)pmu_uarch.uarch;
-      init_perf_event_attr(&perf_attr.ticks, PERF_TYPE_RAW, pmu_uarch.rcb_cntr_event);
+      init_perf_event_attr(&perf_attr.ticks, pmu_uarch.event_type,
+                           pmu_uarch.rcb_cntr_event);
       if (pmu_uarch.minus_ticks_cntr_event != 0) {
-        init_perf_event_attr(&perf_attr.minus_ticks, PERF_TYPE_RAW,
+        init_perf_event_attr(&perf_attr.minus_ticks, pmu_uarch.event_type,
                              pmu_uarch.minus_ticks_cntr_event);
       }
-      init_perf_event_attr(&perf_attr.cycles, PERF_TYPE_HARDWARE,
-                           PERF_COUNT_HW_CPU_CYCLES);
-      init_perf_event_attr(&perf_attr.llsc_fail, PERF_TYPE_RAW,
+      init_perf_event_attr(&perf_attr.cycles, pmu_uarch.cycle_type,
+                           pmu_uarch.cycle_event);
+      init_perf_event_attr(&perf_attr.llsc_fail, pmu_uarch.event_type,
                            pmu_uarch.llsc_cntr_event);
     }
   }

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -376,7 +376,7 @@ static void init_attributes() {
   }
 }
 
-static void check_pmu() {
+static void check_pmu(int pmu_index) {
   if (pmu_checked) {
     return;
   }
@@ -437,8 +437,9 @@ uint32_t PerfCounters::skid_size() {
   return rr::skid_size;
 }
 
-PerfCounters::PerfCounters(pid_t tid, TicksSemantics ticks_semantics)
-    : tid(tid), ticks_semantics_(ticks_semantics), started(false), counting(false) {
+PerfCounters::PerfCounters(pid_t tid, int cpu_binding,
+                           TicksSemantics ticks_semantics)
+    : tid(tid), pmu_index(cpu_binding), ticks_semantics_(ticks_semantics), started(false), counting(false) {
   if (!supports_ticks_semantics(ticks_semantics)) {
     FATAL() << "Ticks semantics " << ticks_semantics << " not supported";
   }
@@ -453,7 +454,7 @@ static void make_counter_async(ScopedFd& fd, int signal) {
 
 void PerfCounters::reset(Ticks ticks_period) {
   DEBUG_ASSERT(ticks_period >= 0);
-  check_pmu();
+  check_pmu(pmu_index);
 
   if (ticks_period == 0 && !always_recreate_counters()) {
     // We can't switch a counter between sampling and non-sampling via

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -2,6 +2,7 @@
 
 #include "PerfCounters.h"
 
+#include <dirent.h>
 #include <err.h>
 #include <fcntl.h>
 #include <linux/perf_event.h>
@@ -15,6 +16,9 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <fstream>
+#include <limits>
+#include <regex>
 #include <string>
 
 #include "Flags.h"

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -415,7 +415,7 @@ TicksSemantics PerfCounters::default_ticks_semantics() {
 }
 
 uint32_t PerfCounters::skid_size() {
-  init_attributes();
+  DEBUG_ASSERT(attributes_initialized);
   return rr::skid_size;
 }
 

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -32,23 +32,27 @@ namespace rr {
 #define PERF_COUNT_RR 0x72727272L
 
 static bool attributes_initialized;
-// pmu_bug_flags is an architecture dependent flags to determine
-// what bugs need to be checked.
-// Current, this is simply the uarch on x86 and unused on aarch64.
-static int pmu_bug_flags;
 // At some point we might support multiple kinds of ticks for the same CPU arch.
 // At that point this will need to become more complicated.
-static struct perf_event_attr ticks_attr;
-static struct perf_event_attr minus_ticks_attr;
-static struct perf_event_attr cycles_attr;
-static struct perf_event_attr llsc_fail_attr;
-static uint32_t pmu_flags;
-static uint32_t skid_size;
-
-static bool pmu_checked;
-static bool has_ioc_period_bug;
-static bool only_one_counter;
-static bool activate_useless_counter;
+struct perf_event_attrs {
+  // bug_flags is an architecture dependent flags to determine
+  // what bugs need to be checked.
+  // Current, this is simply the uarch on x86 and unused on aarch64.
+  int bug_flags = 0;
+  perf_event_attr ticks{};
+  perf_event_attr minus_ticks{};
+  perf_event_attr cycles{};
+  perf_event_attr llsc_fail{};
+  uint32_t pmu_flags = 0;
+  uint32_t skid_size = 0;
+  bool checked = false;
+  bool has_ioc_period_bug = false;
+  bool only_one_counter = false;
+  bool activate_useless_counter = false;
+};
+// If this contains more than one element, it's indexed by the CPU index.
+static std::vector<perf_event_attrs> perf_attrs;
+static uint32_t pmu_semantics_flags;
 
 /*
  * Find out the cpu model using the cpuid instruction.
@@ -165,6 +169,27 @@ static string lowercase(const string& s) {
   return c;
 }
 
+// The index of the PMU we are using within perf_attrs.
+// This is always 0 if we detected a single PMU type
+// and will be the same as the CPU index if we detected multiple PMU types.
+static int get_pmu_index(int cpu_binding)
+{
+  if (cpu_binding < 0) {
+    if (perf_attrs.size() > 1) {
+      FATAL() << "\nMultiple PMU types detected. Unbinding CPU is not supported.";
+    }
+    return 0;
+  }
+  if (perf_attrs.size() == 1) {
+    // Single PMU type.
+    return 0;
+  }
+  if ((size_t)cpu_binding > perf_attrs.size()) {
+    FATAL() << "\nUnable to find PMU type for CPU " << cpu_binding;
+  }
+  return cpu_binding;
+}
+
 static void init_perf_event_attr(struct perf_event_attr* attr,
                                  perf_type_id type, unsigned config) {
   memset(attr, 0, sizeof(*attr));
@@ -230,9 +255,9 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
   return fd;
 }
 
-static void check_for_ioc_period_bug() {
+static void check_for_ioc_period_bug(perf_event_attrs &perf_attr) {
   // Start a cycles counter
-  struct perf_event_attr attr = rr::ticks_attr;
+  struct perf_event_attr attr = perf_attr.ticks;
   attr.sample_period = 0xffffffff;
   attr.exclude_kernel = 1;
   ScopedFd bug_fd = start_counter(0, -1, &attr);
@@ -245,8 +270,8 @@ static void check_for_ioc_period_bug() {
   struct pollfd poll_bug_fd = {.fd = bug_fd, .events = POLL_IN, .revents = 0 };
   poll(&poll_bug_fd, 1, 0);
 
-  has_ioc_period_bug = poll_bug_fd.revents == 0;
-  LOG(debug) << "has_ioc_period_bug=" << has_ioc_period_bug;
+  perf_attr.has_ioc_period_bug = poll_bug_fd.revents == 0;
+  LOG(debug) << "has_ioc_period_bug=" << perf_attr.has_ioc_period_bug;
 }
 
 static const int NUM_BRANCHES = 500;
@@ -273,11 +298,11 @@ static void do_branches() {
 #error Must define microarchitecture detection code for this architecture
 #endif
 
-static void check_working_counters() {
-  struct perf_event_attr attr = rr::ticks_attr;
+static void check_working_counters(perf_event_attrs &perf_attr) {
+  struct perf_event_attr attr = perf_attr.ticks;
   attr.sample_period = 0;
-  struct perf_event_attr attr2 = rr::cycles_attr;
-  attr.sample_period = 0;
+  struct perf_event_attr attr2 = perf_attr.cycles;
+  attr2.sample_period = 0;
   ScopedFd fd = start_counter(0, -1, &attr);
   ScopedFd fd2 = start_counter(0, -1, &attr2);
   do_branches();
@@ -286,7 +311,8 @@ static void check_working_counters() {
 
   if (events < NUM_BRANCHES) {
     char config[100];
-    sprintf(config, "%llx", (long long)ticks_attr.config);
+    sprintf(config, "%llx", (long long)perf_attr.ticks.config);
+
     FATAL()
         << "\nGot " << events << " branch events, expected at least "
         << NUM_BRANCHES
@@ -303,20 +329,20 @@ static void check_working_counters() {
            "this CPU.";
   }
 
-  only_one_counter = events2 == 0;
-  LOG(debug) << "only_one_counter=" << only_one_counter;
+  perf_attr.only_one_counter = events2 == 0;
+  LOG(debug) << "only_one_counter=" << perf_attr.only_one_counter;
 
-  if (only_one_counter) {
+  if (perf_attr.only_one_counter) {
     arch_check_restricted_counter();
   }
 }
 
-static void check_for_bugs() {
+static void check_for_bugs(perf_event_attrs &perf_attr) {
   DEBUG_ASSERT(!running_under_rr());
 
-  check_for_ioc_period_bug();
-  check_working_counters();
-  check_for_arch_bugs(pmu_bug_flags);
+  check_for_ioc_period_bug(perf_attr);
+  check_working_counters(perf_attr);
+  check_for_arch_bugs(perf_attr);
 }
 
 static CpuMicroarch get_cpu_microarch() {
@@ -351,36 +377,41 @@ static void init_attributes() {
     }
   }
   DEBUG_ASSERT(pmu);
-  pmu_bug_flags = (int)uarch;
 
   if (!(pmu->flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES))) {
     FATAL() << "Microarchitecture `" << pmu->name << "' currently unsupported.";
   }
+  // TODO: multiple PMU
+  perf_attrs.resize(1);
+  perf_attrs[0].bug_flags = (int)uarch;
 
   if (running_under_rr()) {
-    init_perf_event_attr(&ticks_attr, PERF_TYPE_HARDWARE, PERF_COUNT_RR);
-    skid_size = RR_SKID_MAX;
-    pmu_flags = pmu->flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES);
+    init_perf_event_attr(&perf_attrs[0].ticks, PERF_TYPE_HARDWARE, PERF_COUNT_RR);
+    perf_attrs[0].skid_size = RR_SKID_MAX;
+    perf_attrs[0].pmu_flags = pmu->flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES);
+    pmu_semantics_flags = pmu->flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES);
   } else {
-    skid_size = pmu->skid_size;
-    pmu_flags = pmu->flags;
-    init_perf_event_attr(&ticks_attr, PERF_TYPE_RAW, pmu->rcb_cntr_event);
+    perf_attrs[0].skid_size = pmu->skid_size;
+    perf_attrs[0].pmu_flags = pmu->flags;
+    pmu_semantics_flags = pmu->flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES);
+    init_perf_event_attr(&perf_attrs[0].ticks, PERF_TYPE_RAW, pmu->rcb_cntr_event);
     if (pmu->minus_ticks_cntr_event != 0) {
-      init_perf_event_attr(&minus_ticks_attr, PERF_TYPE_RAW,
+      init_perf_event_attr(&perf_attrs[0].minus_ticks, PERF_TYPE_RAW,
                            pmu->minus_ticks_cntr_event);
     }
-    init_perf_event_attr(&cycles_attr, PERF_TYPE_HARDWARE,
+    init_perf_event_attr(&perf_attrs[0].cycles, PERF_TYPE_HARDWARE,
                          PERF_COUNT_HW_CPU_CYCLES);
-    init_perf_event_attr(&llsc_fail_attr, PERF_TYPE_RAW,
+    init_perf_event_attr(&perf_attrs[0].llsc_fail, PERF_TYPE_RAW,
                          pmu->llsc_cntr_event);
   }
 }
 
 static void check_pmu(int pmu_index) {
-  if (pmu_checked) {
+  auto &perf_attr = perf_attrs[pmu_index];
+  if (perf_attr.checked) {
     return;
   }
-  pmu_checked = true;
+  perf_attr.checked = true;
 
   // Under rr we emulate idealized performance counters, so we can assume
   // none of the bugs apply.
@@ -388,7 +419,7 @@ static void check_pmu(int pmu_index) {
     return;
   }
 
-  check_for_bugs();
+  check_for_bugs(perf_attr);
   /*
    * For maintainability, and since it doesn't impact performance when not
    * needed, we always activate this. If it ever turns out to be a problem,
@@ -400,7 +431,7 @@ static void check_pmu(int pmu_index) {
    * coalesce them and tries to schedule the new one on a general purpose PMC.
    * On CPUs with only 2 general PMCs (e.g. KNL), we'd run out.
    */
-  activate_useless_counter = has_ioc_period_bug;
+  perf_attr.activate_useless_counter = perf_attr.has_ioc_period_bug;
 }
 
 bool PerfCounters::is_rr_ticks_attr(const perf_event_attr& attr) {
@@ -411,9 +442,9 @@ bool PerfCounters::supports_ticks_semantics(TicksSemantics ticks_semantics) {
   init_attributes();
   switch (ticks_semantics) {
   case TICKS_RETIRED_CONDITIONAL_BRANCHES:
-    return (pmu_flags & PMU_TICKS_RCB) != 0;
+    return (pmu_semantics_flags & PMU_TICKS_RCB) != 0;
   case TICKS_TAKEN_BRANCHES:
-    return (pmu_flags & PMU_TICKS_TAKEN_BRANCHES) != 0;
+    return (pmu_semantics_flags & PMU_TICKS_TAKEN_BRANCHES) != 0;
   default:
     FATAL() << "Unknown ticks_semantics " << ticks_semantics;
     return false;
@@ -422,10 +453,10 @@ bool PerfCounters::supports_ticks_semantics(TicksSemantics ticks_semantics) {
 
 TicksSemantics PerfCounters::default_ticks_semantics() {
   init_attributes();
-  if (pmu_flags & PMU_TICKS_TAKEN_BRANCHES) {
+  if (pmu_semantics_flags & PMU_TICKS_TAKEN_BRANCHES) {
     return TICKS_TAKEN_BRANCHES;
   }
-  if (pmu_flags & PMU_TICKS_RCB) {
+  if (pmu_semantics_flags & PMU_TICKS_RCB) {
     return TICKS_RETIRED_CONDITIONAL_BRANCHES;
   }
   FATAL() << "Unsupported architecture";
@@ -434,12 +465,13 @@ TicksSemantics PerfCounters::default_ticks_semantics() {
 
 uint32_t PerfCounters::skid_size() {
   DEBUG_ASSERT(attributes_initialized);
-  return rr::skid_size;
+  DEBUG_ASSERT(perf_attrs[pmu_index].checked);
+  return perf_attrs[pmu_index].skid_size;
 }
 
 PerfCounters::PerfCounters(pid_t tid, int cpu_binding,
                            TicksSemantics ticks_semantics)
-    : tid(tid), pmu_index(cpu_binding), ticks_semantics_(ticks_semantics), started(false), counting(false) {
+    : tid(tid), pmu_index(get_pmu_index(cpu_binding)), ticks_semantics_(ticks_semantics), started(false), counting(false) {
   if (!supports_ticks_semantics(ticks_semantics)) {
     FATAL() << "Ticks semantics " << ticks_semantics << " not supported";
   }
@@ -456,7 +488,8 @@ void PerfCounters::reset(Ticks ticks_period) {
   DEBUG_ASSERT(ticks_period >= 0);
   check_pmu(pmu_index);
 
-  if (ticks_period == 0 && !always_recreate_counters()) {
+  auto &perf_attr = perf_attrs[pmu_index];
+  if (ticks_period == 0 && !always_recreate_counters(perf_attr)) {
     // We can't switch a counter between sampling and non-sampling via
     // PERF_EVENT_IOC_PERIOD so just turn 0 into a very big number.
     ticks_period = uint64_t(1) << 60;
@@ -465,22 +498,22 @@ void PerfCounters::reset(Ticks ticks_period) {
   if (!started) {
     LOG(debug) << "Recreating counters with period " << ticks_period;
 
-    struct perf_event_attr attr = rr::ticks_attr;
-    struct perf_event_attr minus_attr = rr::minus_ticks_attr;
+    struct perf_event_attr attr = perf_attr.ticks;
+    struct perf_event_attr minus_attr = perf_attr.minus_ticks;
     attr.sample_period = ticks_period;
     fd_ticks_interrupt = start_counter(tid, -1, &attr);
     if (minus_attr.config != 0) {
       fd_minus_ticks_measure = start_counter(tid, fd_ticks_interrupt, &minus_attr);
     }
 
-    if (!only_one_counter && !running_under_rr()) {
+    if (!perf_attr.only_one_counter && !running_under_rr()) {
       reset_arch_extras<NativeArch>();
     }
 
-    if (activate_useless_counter && !fd_useless_counter.is_open()) {
+    if (perf_attr.activate_useless_counter && !fd_useless_counter.is_open()) {
       // N.B.: This is deliberately not in the same group as the other counters
       // since we want to keep it scheduled at all times.
-      fd_useless_counter = start_counter(tid, -1, &cycles_attr);
+      fd_useless_counter = start_counter(tid, -1, &perf_attr.cycles);
     }
 
     struct f_owner_ex own;
@@ -557,7 +590,7 @@ void PerfCounters::stop_counting() {
     return;
   }
   counting = false;
-  if (always_recreate_counters()) {
+  if (always_recreate_counters(perf_attrs[pmu_index])) {
     stop();
   } else {
     ioctl(fd_ticks_interrupt, PERF_EVENT_IOC_DISABLE, 0);
@@ -574,11 +607,13 @@ void PerfCounters::stop_counting() {
 }
 
 Ticks PerfCounters::ticks_for_unconditional_indirect_branch(Task*) {
-  return (pmu_flags & PMU_TICKS_TAKEN_BRANCHES) ? 1 : 0;
+  DEBUG_ASSERT(attributes_initialized);
+  return (pmu_semantics_flags & PMU_TICKS_TAKEN_BRANCHES) ? 1 : 0;
 }
 
 Ticks PerfCounters::ticks_for_direct_call(Task*) {
-  return (pmu_flags & PMU_TICKS_TAKEN_BRANCHES) ? 1 : 0;
+  DEBUG_ASSERT(attributes_initialized);
+  return (pmu_semantics_flags & PMU_TICKS_TAKEN_BRANCHES) ? 1 : 0;
 }
 
 Ticks PerfCounters::read_ticks(Task* t) {

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -113,14 +113,14 @@ public:
    * When an interrupt is requested, at most this many ticks may elapse before
    * the interrupt is delivered.
    */
-  static uint32_t skid_size();
+  uint32_t skid_size();
 
   /**
    * Use a separate skid_size for recording since we seem to see more skid
    * in practice during recording, in particular during the
    * async_signal_syscalls tests
    */
-  static uint32_t recording_skid_size() { return skid_size() * 5; }
+  uint32_t recording_skid_size() { return skid_size() * 5; }
 
 private:
   // Only valid while 'counting' is true

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -42,7 +42,7 @@ public:
   /**
    * Create performance counters monitoring the given task.
    */
-  PerfCounters(pid_t tid, TicksSemantics ticks_semantics);
+  PerfCounters(pid_t tid, int cpu_binding, TicksSemantics ticks_semantics);
   ~PerfCounters() { stop(); }
 
   void set_tid(pid_t tid);
@@ -126,6 +126,7 @@ private:
   // Only valid while 'counting' is true
   Ticks counting_period;
   pid_t tid;
+  int pmu_index;
   // We use separate fds for counting ticks and for generating interrupts. The
   // former ignores ticks in aborted transactions, and does not support
   // sample_period; the latter does not ignore ticks in aborted transactions,

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -43,7 +43,7 @@ static bool always_recreate_counters() {
   return false;
 }
 
-static void check_for_arch_bugs(__attribute__((unused)) CpuMicroarch uarch) {}
+static void check_for_arch_bugs(__attribute__((unused)) int bug_flags) {}
 
 template <>
 void PerfCounters::reset_arch_extras<ARM64Arch>() {

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -45,6 +45,10 @@ static bool always_recreate_counters(__attribute__((unused)) const perf_event_at
 
 static void check_for_arch_bugs(__attribute__((unused)) perf_event_attrs &perf_attr) {}
 
+static void post_init_pmu_uarchs(std::vector<PmuConfig> &)
+{
+}
+
 template <>
 void PerfCounters::reset_arch_extras<ARM64Arch>() {
   // LL/SC can't be recorded reliably. Start a counter to detect

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -28,6 +28,10 @@ static CpuMicroarch compute_cpu_microarch() {
   return UnknownCpu; // not reached
 }
 
+static std::vector<CpuMicroarch> compute_cpu_microarchs() {
+  return { compute_cpu_microarch() };
+}
+
 static void arch_check_restricted_counter() {
   if (!Flags::get().suppress_environment_warnings) {
     fprintf(stderr,

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -1,35 +1,226 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 // This file is included from PerfCounters.cc
 
-static const char* midr_path =
-    "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
+struct CPUID {
+  uint8_t implementer = 0;
+  uint8_t variant = 0;
+  uint16_t part = 0;
+  operator bool() const
+  {
+    return implementer || variant || part;
+  }
+  // bool operator==(const CPUID&) const = default; // c++20
+  bool operator==(const CPUID &other) const
+  {
+    return implementer == other.implementer &&
+      variant == other.variant && part == other.part;
+  }
+  bool operator!=(const CPUID &other) const
+  {
+    return !(*this == other);
+  }
+};
+static std::ostream &operator<<(std::ostream &stm, const CPUID &cpuid)
+{
+  stm << std::hex << "implementer: 0x" << int(cpuid.implementer)
+      << ", variant: 0x" << int(cpuid.variant) << " part: 0x" << int(cpuid.part);
+  return stm;
+}
 
 /**
  * Return the detected, known microarchitecture of this CPU, or don't
  * return; i.e. never return UnknownCpu.
  */
-static CpuMicroarch compute_cpu_microarch() {
-  FILE *midr_el1 = fopen(midr_path, "r");
-  if (!midr_el1) {
-    CLEAN_FATAL() << "Failed to read midr register from kernel";
-  }
-  uint32_t midir;
-  if (1 != fscanf(midr_el1, "%x", &midir)) {
-    CLEAN_FATAL() << "Failed to read midr register from kernel";
-  }
-  fclose(midr_el1);
-  switch (midir) {
-    case 0x413fd0c1:
+static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
+  switch (cpuid.implementer) {
+  case 0x41: // ARM
+    switch (cpuid.part) {
+    case 0xd0c:
       return ARMNeoverseN1;
-    default:
-      break;
+    }
+    break;
   }
-  CLEAN_FATAL() << "Aarch64 CPU type " << HEX(midir) << " unknown";
+  CLEAN_FATAL() << "Unknown aarch64 CPU type " << cpuid;
   return UnknownCpu; // not reached
 }
 
+static void set_cpuid(std::vector<CPUID> &cpuids, unsigned long cpuidx, CPUID cpuid)
+{
+  if (cpuids.size() <= cpuidx) {
+    cpuids.resize(cpuidx + 1);
+  }
+  if (cpuids[cpuidx]) {
+    CLEAN_FATAL() << "Duplicated CPUID for core " << cpuidx;
+  }
+  cpuids[cpuidx] = cpuid;
+}
+
+/**
+ * The new interface to get ID register values on AArch64
+ * `/sys/devices/system/cpu/cpu([0-9]+)/regs/identification/midr_el1`
+ * The register value is stored in hex.
+ */
+static inline void get_cpuinfo_sysfs(std::vector<CPUID> &res)
+{
+  const std::string cpu_dir = "/sys/devices/system/cpu/";
+  const std::regex cpuname_regex("cpu([0-9]+)");
+  auto dir = opendir(cpu_dir.c_str());
+  if (!dir) {
+    return;
+  }
+  while (auto entry = readdir(dir)) {
+    std::cmatch match;
+    if (entry->d_type != DT_DIR ||
+        !std::regex_match(entry->d_name, match, cpuname_regex)) {
+      continue;
+    }
+    auto cpuidx = std::stoul(match[1].str());
+    std::string name = cpu_dir + entry->d_name + "/regs/identification/midr_el1";
+    std::ifstream file(name);
+    if (!file) {
+      CLEAN_FATAL() << "Failed to read midr register from kernel";
+    }
+    uint64_t val = 0;
+    file >> std::hex >> val;
+    if (!file) {
+      CLEAN_FATAL() << "Failed to read midr register from kernel";
+    }
+    set_cpuid(res, cpuidx, {
+        uint8_t(val >> 24),
+        uint8_t((val >> 20) & 0xf),
+        uint16_t((val >> 4) & 0xfff)
+      });
+  }
+  closedir(dir);
+}
+
+/**
+ * A line we care about in /proc/cpuinfo starts with a prefix followed by
+ * `:` and some white space characters, then followed by the value we care about.
+ * Return true if we've found the prefix. Set `flag` to `false`
+ * if the value parsing failed.
+ *
+ * Use an external template since lambda's can't be templated in C++11
+ */
+template<typename T, typename F>
+static inline bool try_read_procfs_line(const std::string &line,
+                                        const char *prefix, T &out,
+                                        bool &flag, F &&reset)
+{
+  size_t prefix_len = strlen(prefix);
+  if (line.size() < prefix_len) {
+    return false;
+  }
+  if (memcmp(&line[0], prefix, prefix_len) != 0) {
+    return false;
+  }
+  if (flag) {
+    // We've seen this already,
+    // i.e. we didn't see a new line between the processor lines
+    reset();
+  }
+  const char *p = &line[prefix_len];
+  // Skip blank and `:`.
+  while (*p == '\t' || *p == ' ' || *p == ':') {
+    p++;
+  }
+  char *str_end;
+  auto num = std::strtoull(p, &str_end, 0);
+  out = (T)num;
+  if (str_end == p) {
+    flag = false;
+  } else if (num > (unsigned long long)std::numeric_limits<T>::max()) {
+    flag = false;
+  } else {
+    flag = true;
+  }
+  return true;
+}
+
+/**
+ * /proc/cpuinfo reader
+ * The cpuinfo file contains blocks of text for each core.
+ * The blocks are separated by empty lines and it should start with a
+ * `processor : <num>` line followed by lines showing properties of the core.
+ * The three property lines we are looking for starts with
+ * `CPU implementer`, `CPU variant` and `CPU part`.
+ */
+static inline void get_cpuinfo_procfs(std::vector<CPUID> &res)
+{
+  std::ifstream file("/proc/cpuinfo");
+  CPUID cpuid = {0, 0, 0};
+  unsigned cpuidx = 0;
+  bool has_cpuidx = false;
+  bool has_impl = false;
+  bool has_part = false;
+  bool has_var = false;
+  auto reset = [&] () {
+    // Few (none) of the detection code care about the variant number
+    // so we'll accept it if we couldn't read it.
+    if (has_cpuidx && has_impl && has_part) {
+      set_cpuid(res, cpuidx, cpuid);
+    }
+    has_cpuidx = false;
+    has_impl = false;
+    has_part = false;
+    has_var = false;
+    cpuid = {0, 0, 0};
+  };
+  for (std::string line; std::getline(file, line);) {
+    // Empty lines means that we've finished processing of a block
+    if (line.empty()) {
+      reset();
+      continue;
+    }
+    // First find the processor line
+    if (try_read_procfs_line(line, "processor", cpuidx, has_cpuidx, reset)) {
+      continue;
+    }
+    // and ignore the line until we found the processor line.
+    if (!has_cpuidx) {
+      continue;
+    }
+
+    // Try parsing as one of the data lines.
+    // Short circuiting after the first hit.
+    try_read_procfs_line(line, "CPU implementer", cpuid.implementer, has_impl, reset) ||
+      try_read_procfs_line(line, "CPU variant", cpuid.variant, has_var, reset) ||
+      try_read_procfs_line(line, "CPU part", cpuid.part, has_part, reset);
+  }
+  reset();
+}
+
 static std::vector<CpuMicroarch> compute_cpu_microarchs() {
-  return { compute_cpu_microarch() };
+  std::vector<CPUID> cpuids;
+  get_cpuinfo_sysfs(cpuids);
+  if (cpuids.empty()) {
+    LOG(warn) << "Unable to read CPU type from sysfs, trying procfs instead.";
+    get_cpuinfo_procfs(cpuids);
+  }
+  if (cpuids.empty()) {
+    CLEAN_FATAL() << "Failed to read midr register from kernel";
+  }
+  for (auto &cpuid : cpuids) {
+    if (!cpuid) {
+      CLEAN_FATAL() << "Unable to find CPU id for core " << &cpuid - &cpuids[0];
+    }
+  }
+  auto cpuid0 = cpuids[0];
+  bool single_uarch = true;
+  for (auto &cpuid : cpuids) {
+    if (cpuid != cpuid0) {
+      single_uarch = false;
+      break;
+    }
+  }
+  if (single_uarch) {
+    return { compute_cpu_microarch(cpuid0) };
+  }
+  std::vector<CpuMicroarch> uarchs;
+  for (auto &cpuid : cpuids) {
+    uarchs.push_back(compute_cpu_microarch(cpuid));
+  }
+  return uarchs;
 }
 
 static void arch_check_restricted_counter() {

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -39,17 +39,17 @@ static void arch_check_restricted_counter() {
   }
 }
 
-static bool always_recreate_counters() {
+static bool always_recreate_counters(__attribute__((unused)) const perf_event_attrs &perf_attr) {
   return false;
 }
 
-static void check_for_arch_bugs(__attribute__((unused)) int bug_flags) {}
+static void check_for_arch_bugs(__attribute__((unused)) perf_event_attrs &perf_attr) {}
 
 template <>
 void PerfCounters::reset_arch_extras<ARM64Arch>() {
   // LL/SC can't be recorded reliably. Start a counter to detect
   // any usage, such that we can give an intelligent error message.
-  struct perf_event_attr attr = rr::llsc_fail_attr;
+  struct perf_event_attr attr = perf_attrs[pmu_index].llsc_fail;
   attr.sample_period = 0;
   fd_strex_counter = start_counter(tid, fd_ticks_interrupt, &attr);
 }

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -346,7 +346,8 @@ static void check_for_freeze_on_smi() {
   }
 }
 
-static void check_for_arch_bugs(CpuMicroarch uarch) {
+static void check_for_arch_bugs(int bug_flags) {
+  CpuMicroarch uarch = (CpuMicroarch)bug_flags;
   if (uarch >= FirstIntel && uarch <= LastIntel) {
     check_for_kvm_in_txcp_bug();
     check_for_xen_pmi_bug();

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -118,6 +118,10 @@ static CpuMicroarch compute_cpu_microarch() {
   return UnknownCpu; // not reached
 }
 
+static std::vector<CpuMicroarch> compute_cpu_microarchs() {
+  return { compute_cpu_microarch() };
+}
+
 static void check_for_kvm_in_txcp_bug(const perf_event_attrs &perf_attr) {
   int64_t count = 0;
   struct perf_event_attr attr = perf_attr.ticks;

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -362,6 +362,7 @@ static void check_for_arch_bugs(CpuMicroarch uarch) {
 static bool always_recreate_counters() {
   // When we have the KVM IN_TXCP bug, reenabling the TXCP counter after
   // disabling it does not work.
+  DEBUG_ASSERT(pmu_checked);
   return has_ioc_period_bug || has_kvm_in_txcp_bug;
 }
 

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -361,6 +361,14 @@ static void check_for_arch_bugs(perf_event_attrs &perf_attr) {
   }
 }
 
+static void post_init_pmu_uarchs(std::vector<PmuConfig> &pmu_uarchs)
+{
+  if (pmu_uarchs.size() != 1) {
+    CLEAN_FATAL() << "rr only support a single PMU on x86, "
+                  << pmu_uarchs.size() << " specified.";
+  }
+}
+
 static bool always_recreate_counters(const perf_event_attrs &perf_attr) {
   // When we have the KVM IN_TXCP bug, reenabling the TXCP counter after
   // disabling it does not work.

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2369,7 +2369,7 @@ RecordSession::RecordSession(const std::string& exe_path,
   }
 
   trace_out.set_bound_cpu(choose_cpu(bind_cpu, cpu_lock));
-  do_bind_cpu(trace_out);
+  do_bind_cpu();
   ScopedFd error_fd = create_spawn_task_error_pipe();
   RecordTask* t = static_cast<RecordTask*>(
       Task::spawn(*this, error_fd, &tracee_socket_fd(),

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -287,7 +287,7 @@ DiversionSession::shr_ptr ReplaySession::clone_diversion() {
   LOG(debug) << "Deepforking ReplaySession " << this
              << " to DiversionSession...";
 
-  DiversionSession::shr_ptr session(new DiversionSession());
+  DiversionSession::shr_ptr session(new DiversionSession(cpu_binding()));
   session->ticks_semantics_ = ticks_semantics_;
   session->tracee_socket = tracee_socket;
   session->tracee_socket_fd_number = tracee_socket_fd_number;

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -316,7 +316,7 @@ Task* ReplaySession::new_task(pid_t tid, pid_t rec_tid, uint32_t serial,
   vector<string> argv;
   vector<string> env;
 
-  session->do_bind_cpu(session->trace_in);
+  session->do_bind_cpu();
   ScopedFd error_fd = session->create_spawn_task_error_pipe();
   ReplayTask* t = static_cast<ReplayTask*>(
       Task::spawn(*session, error_fd, &session->tracee_socket_fd(),
@@ -329,11 +329,11 @@ Task* ReplaySession::new_task(pid_t tid, pid_t rec_tid, uint32_t serial,
   return session;
 }
 
-int ReplaySession::cpu_binding(TraceStream& trace) const {
+int ReplaySession::cpu_binding() const {
   if (flags_.cpu_unbound) {
     return -1;
   }
-  return Session::cpu_binding(trace);
+  return Session::cpu_binding();
 }
 
 void ReplaySession::advance_to_next_trace_frame() {

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -320,7 +320,7 @@ public:
 
   virtual TraceStream* trace_stream() override { return &trace_in; }
 
-  virtual int cpu_binding(TraceStream& trace) const override;
+  virtual int cpu_binding() const override;
 
   bool has_trace_quirk(TraceReader::TraceQuirks quirk) { return trace_in.quirks() & quirk; }
 

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -713,8 +713,8 @@ bool Session::has_cpuid_faulting() {
   return !Flags::get().disable_cpuid_faulting && cpuid_faulting_works();
 }
 
-int Session::cpu_binding(TraceStream& trace) const {
-  return trace.bound_to_cpu();
+int Session::cpu_binding() const {
+  return const_cast<Session*>(this)->trace_stream()->bound_to_cpu();
 }
 
 // Returns true if we succeeded, false if we failed because the
@@ -734,8 +734,8 @@ static bool set_cpu_affinity(int cpu) {
   return true;
 }
 
-void Session::do_bind_cpu(TraceStream &trace) {
-  int cpu_index = this->cpu_binding(trace);
+void Session::do_bind_cpu() {
+  int cpu_index = this->cpu_binding();
   if (cpu_index >= 0) {
     // Set CPU affinity now, after we've created any helper threads
     // (so they aren't affected), but before we create any
@@ -750,10 +750,10 @@ void Session::do_bind_cpu(TraceStream &trace) {
                   << " even after we re-selected it";
         }
         LOG(warn) << "Bound to CPU " << cpu_index
-                  << "instead of selected " << trace.bound_to_cpu()
+                  << "instead of selected " << trace_stream()->bound_to_cpu()
                   << "because the latter is not available;\n"
                   << "Hoping tracee doesn't use LSL instruction!";
-        trace.set_bound_cpu(cpu_index);
+        trace_stream()->set_bound_cpu(cpu_index);
       } else {
         FATAL() << "Can't bind to requested CPU " << cpu_index
                 << ", and CPUID faulting not available";

--- a/src/Session.h
+++ b/src/Session.h
@@ -365,7 +365,7 @@ public:
   virtual TraceStream* trace_stream() { return nullptr; }
   TicksSemantics ticks_semantics() const { return ticks_semantics_; }
 
-  virtual int cpu_binding(TraceStream& trace) const;
+  virtual int cpu_binding() const;
 
   int syscall_number_for_rrcall_init_preload() const {
     return SYS_rrcall_init_preload - RR_CALL_BASE + rrcall_base_;
@@ -394,7 +394,7 @@ public:
 
   /* Bind the current process to the a CPU as specified in the session options
      or trace */
-  void do_bind_cpu(TraceStream &trace);
+  void do_bind_cpu();
 
   const ThreadGroupMap& thread_group_map() const { return thread_group_map_; }
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -71,7 +71,7 @@ Task::Task(Session& session, pid_t _tid, pid_t _rec_tid, uint32_t serial,
       desched_fd_child(-1),
       // This will be initialized when the syscall buffer is.
       cloned_file_data_fd_child(-1),
-      hpc(_tid, session.ticks_semantics()),
+      hpc(_tid, session.cpu_binding(), session.ticks_semantics()),
       tid(_tid),
       rec_tid(_rec_tid > 0 ? _rec_tid : _tid),
       own_namespace_rec_tid(_rec_tid > 0 ? _rec_tid: _tid),

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3474,7 +3474,7 @@ static void record_ranges(RecordTask* t,
 
 static pid_t do_detach_teleport(RecordTask *t)
 {
-  DiversionSession session;
+  DiversionSession session(t->session().cpu_binding());
   // Use the old task's exe path to make sure that /proc/<pid>/exe looks right
   // for the teleported task.
   std::string exe_path(t->proc_exe_path());


### PR DESCRIPTION
This is a clean up of the non-apple specific part of https://github.com/rr-debugger/rr/pull/3144 and should be applicable to other ARM cores as well. Once this is done, I think #3144 would be basically ready as well. If anyone can test this on a neoverse-n1 machine that'll be much appreciated (since I don't have access to one...). Since this mainly touches the initialization code, just run any rr command with the logging level set to at least warning would be useful enough.

Generally speaking, on aarch64, one has to read from core type specific PMU events. The kernel does not provide any support for consolidating that into a single event. This is generally available under `/sys/bus/event_source/devices/` as documented under dynamic PMU in `perf_event_open` though I cannot find any document on how the PMU name is determined. The current name used for neoverse-n1 is copied from https://github.com/RRZE-HPC/likwid/blob/aee61f19fe78047fc2222be037f586dd46734e23/src/includes/perfmon_neon1_counters.h#L48. The event type read from the sysfs then essentially corresponds to the raw event for that particular core type and all the counters for that core type uses this same type (config in the perf event attr struct). This is the assumption I'm using and it should at least generalize to other ARM systems. Hopefully they don't come up with a completely different model for any other archs that we want to support in the future = = ................

This PR mainly consists of two parts. The first six commits each progressing make the shared code more compatible with having multiple PMUs at the same time. The last 3 commits implements and improves the architecture and PMU detection code for aarch64 with minimum changes to the x86/shared code path.

In addition to improving the PMU type detection. I've also included a tweaked version of the uarch detection code I originally wrote for julia. It's mainly to save myself having to write it again but it should also reduce the reliance on sysfs. Similarly, the PMU type detection also included fallback logic so that if we are on a homogeneous system and couldn't find the PMU type, we can fallback to using the hardware and raw event types.
