### PR TITLE
Fix unwind info of syscall hook end on x86

### DIFF
--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -208,7 +208,7 @@ name:                           \
         .cfi_escape 0x10, /* DW_CFA_expression */               \
                     0x08, /* %eip */                            \
                     0x05, /* 5 byte expression follows */       \
-                    0x03, /* DW_OP_addr */                      \
+                    0x0c, /* DW_OP_const4u */                   \
                     /* Individually place bytes */              \
                     stub_scratch_1 & 0xFF,                      \
                     (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \
@@ -434,7 +434,7 @@ name:                              \
         .cfi_escape 0x10, /* DW_CFA_expression */               \
                     0x10, /* %rip */                            \
                     0x09, /* 9 byte expression follows */       \
-                    0x03, /* DW_OP_addr */                      \
+                    0x0e, /* DW_OP_const8u */                   \
                     /* Individually place bytes */              \
                     stub_scratch_1 & 0xFF,                      \
                     (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \


### PR DESCRIPTION
DW_OP_addr actually specifies an address that requires relocation. Quote from DWARF5, 7.3.1

> A DWARF expression may contain a DW_OP_addr (see Section 2.5.1.1 on
> page 26) which contains a location within the virtual address space of the
> program, and require relocation.

What we need here is a constant instead.

@Keno, it turns out that DW_OP_addr does require relocation. Ref https://sourceware.org/pipermail/gdb/2022-May/050099.html