### PR TITLE
Use the kernel termios struct, not the glibc one.

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -627,12 +627,12 @@ struct BaseArch : public wordsize,
     tcflag_t c_cflag;
     tcflag_t c_lflag;
     cc_t c_line;
-    cc_t c_cc[32];
-    char _padding[3];
-    speed_t c_ispeed;
-    speed_t c_ospeed;
+    cc_t c_cc[19];
   };
-  RR_VERIFY_TYPE(termios);
+  /* We don't verify termios because the kernel and glibc don't agree on its
+   * layout and ensuring that we only have the kernel termios visible here is
+   * a pain.
+   */
 
   struct termio {
     unsigned_short c_iflag;


### PR DESCRIPTION
There are two different versions of this struct (the glibc one being larger).
We have to include the kernel headers directly to get at the correct one
and make sure that we don't include the conflicting glibc headers. The result
is a little gross but I don't see a better way to do this.