### PR TITLE
Stop using random_shuffle.

### DIFF
--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -98,6 +98,8 @@ Scheduler::Scheduler(RecordSession& session)
       enable_poll(false),
       last_reschedule_in_high_priority_only_interval(false),
       unlimited_ticks_mode(false) {
+  std::random_device rd;
+  random.seed(rd());
   regenerate_affinity_mask();
 }
 
@@ -144,7 +146,7 @@ void Scheduler::regenerate_affinity_mask() {
       other_cpus.push_back(i);
     }
   }
-  random_shuffle(other_cpus.begin(), other_cpus.end());
+  shuffle(other_cpus.begin(), other_cpus.end(), random);
   CPU_ZERO(&pretend_affinity_mask_);
   CPU_SET(cpu, &pretend_affinity_mask_);
   for (int i = 0; i < pretend_num_cores_ - 1; ++i) {
@@ -336,7 +338,7 @@ RecordTask* Scheduler::find_next_runnable_task(RecordTask* t, bool* by_waitpid,
       for (auto it = same_priority_start; it != same_priority_end; ++it) {
         tasks.push_back(it->second);
       }
-      random_shuffle(tasks.begin(), tasks.end());
+      shuffle(tasks.begin(), tasks.end(), random);
       for (RecordTask* next : tasks) {
         if (is_task_runnable(next, by_waitpid)) {
           return next;

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -6,6 +6,7 @@
 #include <sched.h>
 
 #include <deque>
+#include <random>
 #include <set>
 
 #include "Ticks.h"
@@ -182,6 +183,7 @@ private:
   // Tasks sorted by priority.
   typedef std::set<std::pair<int, RecordTask*>> TaskPrioritySet;
   typedef std::deque<RecordTask*> TaskQueue;
+  typedef std::default_random_engine Random;
 
   /**
    * Pull a task from the round-robin queue if available. Otherwise,
@@ -213,6 +215,8 @@ private:
   bool is_task_runnable(RecordTask* t, bool* by_waitpid);
   void validate_scheduled_task();
   void regenerate_affinity_mask();
+
+  Random random;
 
   RecordSession& session;
 


### PR DESCRIPTION
It was removed from C++17. Now you have to pass a random number generator into
shuffle. This initializes a PRNG (default_random_engine) with an actual entropy
source (random_device, which should be either RDRAND or /dev/urandom) and then
passes that into each shuffle call.