### PR TITLE
Fix accidental double-close of fds

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -311,7 +311,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
   {
     ScopedFd page(path.c_str(), O_RDONLY);
     ASSERT(t, page.is_open()) << "Failed to open rrpage library " << path;
-    int child_fd = remote.infallible_send_fd_if_alive(page.get());
+    int child_fd = remote.infallible_send_fd_if_alive(page);
     if (child_fd >= 0) {
       if (t->session().is_recording()) {
         remote.infallible_mmap_syscall_if_alive(rr_page_start() - offset_bytes, offset_bytes, prot, flags,

--- a/src/PackCommand.cc
+++ b/src/PackCommand.cc
@@ -249,7 +249,7 @@ static string copy_into_trace(const string& file_name, const string& trace_dir,
     new_name_buf[sizeof(new_name_buf) - 1] = 0;
     new_name = trace_dir + "/" + new_name_buf;
     ++*name_index;
-    out_fd = open(new_name.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0700);
+    out_fd = ScopedFd(new_name.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0700);
     if (!out_fd.is_open()) {
       if (errno == EEXIST) {
         continue;

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -221,7 +221,7 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
     }
     FATAL() << "Failed to initialize counter";
   }
-  return fd;
+  return ScopedFd(fd);
 }
 
 static void check_for_ioc_period_bug() {

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -471,7 +471,7 @@ template <typename Arch> void RecordTask::init_buffers_arch() {
         session().use_read_cloning()) {
       cloned_file_data_fname = trace_writer().file_data_clone_file_name(tuid());
       ScopedFd clone_file(cloned_file_data_fname.c_str(), O_RDWR | O_CREAT, 0600);
-      int cloned_file_data = remote.infallible_send_fd_if_alive(clone_file.get());
+      int cloned_file_data = remote.infallible_send_fd_if_alive(clone_file);
       if (cloned_file_data >= 0) {
         int free_fd = find_free_file_descriptor(tid);
         cloned_file_data_fd_child =

--- a/src/ScopedFd.h
+++ b/src/ScopedFd.h
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "log.h"
+
 namespace rr {
 
 /**
@@ -17,7 +19,7 @@ namespace rr {
 class ScopedFd {
 public:
   ScopedFd() : fd(-1) {}
-  ScopedFd(int fd) : fd(fd) {}
+  explicit ScopedFd(int fd) : fd(fd) {}
   ScopedFd(const char* pathname, int flags, mode_t mode = 0)
       : fd(open(pathname, flags, mode)) {}
   ScopedFd(ScopedFd&& other) : fd(other.fd) { other.fd = -1; }
@@ -41,7 +43,13 @@ public:
   bool is_open() const { return fd >= 0; }
   void close() {
     if (fd >= 0) {
-      ::close(fd);
+      int err = ::close(fd);
+      // With EINTR/EIO, it is unspecified whether fd will be
+      // closed, but on Linux, it is always removed from the FD
+      // table, so the close was successful for our purposes.
+      if (err != 0 && err != -EINTR && err != -EIO) {
+        FATAL() << "Unexpected error while closing fd " << fd;
+      }
     }
     fd = -1;
   }

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -249,7 +249,7 @@ ScopedFd Session::create_spawn_task_error_pipe() {
   if (0 != pipe2(fds, O_CLOEXEC)) {
     FATAL();
   }
-  spawned_task_error_fd_ = fds[0];
+  spawned_task_error_fd_ = ScopedFd(fds[0]);
   return ScopedFd(fds[1]);
 }
 

--- a/src/ftrace.cc
+++ b/src/ftrace.cc
@@ -29,7 +29,7 @@ static bool tracing = false;
 
 static void open_socket() {
   string s = string(getenv("HOME")) + "/.local/share/rr/ftrace";
-  control_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  control_fd = ScopedFd(socket(AF_UNIX, SOCK_STREAM, 0));
   if (control_fd < 0) {
     FATAL() << "Cannot create socket";
   }

--- a/src/util.cc
+++ b/src/util.cc
@@ -1813,7 +1813,7 @@ TempFile create_temporary_file(const char* pattern) {
   snprintf(buf, sizeof(buf) - 1, "%s/%s", tmp_dir(), pattern);
   buf[sizeof(buf) - 1] = 0;
   TempFile result;
-  result.fd = mkstemp(buf);
+  result.fd = ScopedFd(mkstemp(buf));
   result.name = buf;
   return result;
 }
@@ -1838,7 +1838,7 @@ static ScopedFd create_tmpfs_file(const string &real_name) {
   name = name.substr(0, 255);
 
   ScopedFd fd =
-      open(name.c_str(), O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0700);
+      ScopedFd(name.c_str(), O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0700);
   /* Remove the fs name so that we don't have to worry about
    * cleaning up this segment in error conditions. */
   unlink(name.c_str());


### PR DESCRIPTION
`ScopedFd` has implicit conversions to and from `int`. This is
very dangerous, because patterns like:
```
void f(ScopedFd &fd) {}
void g(int fd) { f(fd); }
void h(ScopedFd &fd) { g(fd); }
```
will compile without complaint, but will actually introduce an
additional `::close` call due to the implicitly constructed
`ScopedFd`. There were a number of instances of this issue
in the codebase. Try to prevent this from happening again
in the future by making the ScopedFd constructor explicit.

Should fix #3038