### PR TITLE
Add an assertion to make sure we never try to patch syscall from rrpage

### DIFF
--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -582,6 +582,12 @@ bool Monkeypatcher::try_patch_syscall(RecordTask* t, bool entering_syscall) {
 
   Registers r = t->regs();
   remote_code_ptr ip = r.ip();
+  // We should not get here for untraced syscalls or anything else from the rr page.
+  // These should be normally prevented by our seccomp filter
+  // and in the case of syscalls interrupted by signals,
+  // the check for the syscall restart should prevent us from reaching here.
+  DEBUG_ASSERT(ip.to_data_ptr<void>() < AddressSpace::rr_page_start() ||
+               ip.to_data_ptr<void>() >= AddressSpace::rr_page_end());
   if (tried_to_patch_syscall_addresses.count(ip)) {
     return false;
   }


### PR DESCRIPTION
This is cherry-picked from #3235 and this is actually more of a request for clarification than useful patch.

I do not see a check for this elsewhere, the closest is the `t->is_in_traced_syscall()` above but that only cover 2 of the many syscall sites in the rr page. On AArch64 with syscallbuf and a broken syscall restart detection (i.e. https://github.com/yuyichao/rr/commit/5f6e008ec7f671dc4acf021cbc233a1b00ca27e9) I am seeing code reaching here with a rrpage address and fixing the syscall restart logic fixes it. I did the fix, which I still need to convince myself whether it's correct/complete or not, only because I see the x86 version diverges with the aarch64 from here but I don't really know what is the invariant that should prevent this from happening.

That said, I do think an explicit check here, either in the branch condition or as an assertion, would be useful since currently if we actually enter this function with a rr page address, the pattern mismatch would still prevent it from being patched on x86 but not on aarch64. An explicit check here would make the behavior more consistent between archs.