### PR TITLE
Fix check for existance of memory maps

### DIFF
--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -792,8 +792,9 @@ static void __attribute__((constructor)) init_process(void) {
 
   // Check if the rr page is mapped. We avoid a syscall if it looks like
   // rr places librrpage as the vdso
+  // Use 1 as size since linux implementation of msync round it up to page size
   if ((!getauxval || (getauxval(AT_SYSINFO_EHDR) != RR_PAGE_ADDR - 3*PRELOAD_LIBRARY_PAGE_SIZE)) &&
-      msync((void*)RR_PAGE_ADDR, PRELOAD_LIBRARY_PAGE_SIZE, MS_ASYNC) != 0) {
+      msync((void*)RR_PAGE_ADDR, 1, MS_ASYNC) != 0) {
     // The RR page is not mapped - this process is not rr traced.
     buffer_enabled = 0;
     return;
@@ -840,7 +841,8 @@ static void __attribute__((constructor)) init_process(void) {
     // preloaded without rr listening, which is allowed (e.g. after detach).
     // Otherwise give an intelligent error message indicating that our connection
     // to rr is broken.
-    if (msync((void*)RR_PAGE_ADDR + PRELOAD_LIBRARY_PAGE_SIZE, PRELOAD_LIBRARY_PAGE_SIZE, MS_ASYNC) == 0) {
+    // Use 1 as size since linux implementation of msync round it up to page size
+    if (msync((void*)RR_PAGE_ADDR + PRELOAD_LIBRARY_PAGE_SIZE, 1, MS_ASYNC) == 0) {
       fatal("Failed to communicated with rr tracer.\n"
             "Perhaps a restrictive seccomp filter is in effect (e.g. docker?)?\n"
             "Adjust the seccomp filter to allow syscalls above 1000, disable it,\n"


### PR DESCRIPTION
We should not use the preload page size here since if the page size is smaller it's possible that only part of the preload page is actually mapped.

On linux, the msync implementation rounds the length argument up to page size so simply using a length of 1 works.

If people have other preferences, getting the actual page size, or just use 4096, or using `mincore` may also work. It seems that this should be the simplest fix though.