### PR TITLE
Print orig_arg1 value on aarch64

### DIFF
--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -723,8 +723,12 @@ bool Registers::syscall_may_restart() const {
 ostream& operator<<(ostream& stream, const Registers& r) {
   stream << "{ ip:" << HEX(r.ip().register_value()) << " args:(" << HEX(r.arg1()) << "," << HEX(r.arg2()) << ","
          << HEX(r.arg3()) << "," << HEX(r.arg4()) << "," << HEX(r.arg5()) << ","
-         << r.arg6() << ") orig_syscall: " << r.original_syscallno() <<
-         " syscallno: " << r.syscallno() << " }";
+         << r.arg6() << ") orig_syscall: " << r.original_syscallno()
+         << " syscallno: " << r.syscallno();
+  if (r.arch() == aarch64) {
+    stream << " orig_arg1: " << HEX(r.orig_arg1());
+  }
+  stream << " }";
   return stream;
 }
 


### PR DESCRIPTION
On x86 this is exactly the same as arg1 but this is not the case on aarch64

I swear that failing to update orig_arg1 accounts for at least half of the test failures that I've seen so far on aarch64......
