### PR TITLE
Update the orig_* registers when we enter an assist syscall

### DIFF
--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -739,6 +739,7 @@ Completion ReplaySession::continue_or_step(ReplayTask* t,
       // Detect replay assist but handle it later in flush_syscallbuf
       auto type = AddressSpace::rr_page_syscall_from_exit_point(t->arch(), t->ip());
       if (type && type->enabled == AddressSpace::REPLAY_ASSIST) {
+        t->apply_syscall_entry_regs();
         return INCOMPLETE;
       }
     } else if (handle_unrecorded_cpuid_fault(t, constraints)) {


### PR DESCRIPTION
This simulate an actual syscall entry which is what later code expects.
Without this, we'll get the wrong syscall argument when we try to replay
the side-effect of this call.