### PR TITLE
Fix a couple struct layouts

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2067,8 +2067,11 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     uint64_t magic;
     char u_comm[32];
     uint64_t u_debugreg[8];
+    uint64_t error_code;
+    uint64_t fault_address;
   };
-  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86_64, ::user, user);
+  // Can't verify this one because glibc leaves out the last two members and the
+  // kernel header isn't available to userspace.
 
   struct stat {
     dev_t st_dev;

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1219,17 +1219,11 @@ struct BaseArch : public wordsize,
   };
   RR_VERIFY_TYPE(__sysctl_args);
 
+  // libc reserves some space in the user facing structures for future
+  // extensibility, so we are careful to use the kernel definition here.
   typedef struct {
     unsigned_long __val[64 / (8 * sizeof(unsigned_long))];
   } kernel_sigset_t;
-
-  // libc reserves some space in the user facing structures for future
-  // extensibility.
-  typedef struct {
-    unsigned_long __val[1024 / (8 * sizeof(unsigned_long))];
-  } __sigset_t;
-  typedef __sigset_t sigset_t;
-  RR_VERIFY_TYPE(sigset_t);
 
   typedef struct {
     ptr<const kernel_sigset_t> ss;
@@ -2462,8 +2456,8 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
     unsigned long	uc_flags;
     ptr<ucontext> uc_link;
     stack_t		  uc_stack;
-    sigset_t	  uc_sigmask;
-    uint8_t __unused1[1024 / 8 - sizeof(sigset_t)];
+    kernel_sigset_t	  uc_sigmask;
+    uint8_t __unused1[1024 / 8 - sizeof(kernel_sigset_t)];
     struct sigcontext uc_mcontext;
   };
 

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2463,7 +2463,7 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
     ptr<ucontext> uc_link;
     stack_t		  uc_stack;
     sigset_t	  uc_sigmask;
-    uint8_t __unused[1024 / 8 - sizeof(sigset_t)];
+    uint8_t __unused1[1024 / 8 - sizeof(sigset_t)];
     struct sigcontext uc_mcontext;
   };
 

--- a/src/test/x86/ptrace.c
+++ b/src/test/x86/ptrace.c
@@ -267,6 +267,12 @@ int main(void) {
   test_assert(0 == ptrace(PTRACE_POKEUSER, child,
                           (void*)offsetof(struct user, u_debugreg[0]),
                           (void*)0));
+#ifdef __x86_64__
+  // On x86-64 the user struct also includes error_code and fault_address at the
+  // end. This is not in glibc's copy of user.
+  test_assert(0 == ptrace(PTRACE_PEEKUSER, child,
+                          (void*)offsetof(struct user, u_debugreg[9]), NULL));
+#endif
 
   /* Test invalid signal in continue */
   test_assert(-1 == ptrace(PTRACE_CONT, child, NULL, -1) && errno == EIO);


### PR DESCRIPTION
I discovered these because the glibc definitions don't match the bionic definitions, and it turns out our existing definitions are wrong. The test I added does fail before this change.