### PR TITLE
Disable various glibc integrations at build time if we're not being built with glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,13 @@ else()
   message(AUTHOR_WARNING "execinfo.h not present. Automatic backtraces for failures in rr are disabled.")
 endif()
 
+find_path(PROC_SERVICE_H NAMES "proc_service.h")
+if(PROC_SERVICE_H)
+  add_definitions(-DPROC_SERVICE_H=1)
+else()
+  message(AUTHOR_WARNING "proc_service.h not present. Support for libthread_db.so is disabled.")
+endif()
+
 include(CheckSymbolExists)
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_symbol_exists(LAV_CURRENT "link.h" RTLD_AUDIT)
@@ -550,7 +557,6 @@ set(RR_SOURCES
   src/SysCpuMonitor.cc
   src/Task.cc
   src/ThreadGroup.cc
-  src/ThreadDb.cc
   src/TraceFrame.cc
   src/TraceInfoCommand.cc
   src/TraceStream.cc
@@ -560,6 +566,10 @@ set(RR_SOURCES
   ${CMAKE_CURRENT_BINARY_DIR}/rr_trace.capnp.c++
   ${BLAKE_ARCH_DIR}/blake2b.c
 )
+
+if(PROC_SERVICE_H)
+  set(RR_SOURCES ${RR_SOURCES} src/ThreadDb.cc)
+endif()
 
 if (x86ish)
   set(RR_SOURCES ${RR_SOURCES} src/test/x86/cpuid_loop.S)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,13 @@ if(NOT SECCOMP)
   message(FATAL_ERROR "Couldn't find linux/seccomp.h. You may need to upgrade your kernel.")
 endif()
 
+find_path(EXECINFO_H NAMES "execinfo.h")
+if(EXECINFO_H)
+  add_definitions(-DEXECINFO_H=1)
+else()
+  message(AUTHOR_WARNING "execinfo.h not present. Automatic backtraces for failures in rr are disabled.")
+endif()
+
 set(Python_ADDITIONAL_VERSIONS 3 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
 find_package(PythonInterp 3 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,14 @@ else()
   message(AUTHOR_WARNING "execinfo.h not present. Automatic backtraces for failures in rr are disabled.")
 endif()
 
+include(CheckSymbolExists)
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(LAV_CURRENT "link.h" RTLD_AUDIT)
+if(NOT RTLD_AUDIT)
+  message(AUTHOR_WARNING "Couldn't find rtld-audit support. librraudit skipped.")
+endif()
+list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+
 set(Python_ADDITIONAL_VERSIONS 3 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
 find_package(PythonInterp 3 REQUIRED)
 
@@ -405,25 +413,27 @@ endforeach(file)
 set_target_properties(rrpreload PROPERTIES LINK_FLAGS "-nostartfiles ${LINKER_FLAGS}")
 set_target_properties(rrpreload PROPERTIES INSTALL_RPATH "\$ORIGIN")
 
-set(AUDIT_FILES
-  rtld-audit.c
-  stap-note-iter.c
-  ../preload/raw_syscall.S
-)
-set(AUDIT_SOURCE_FILES
-  ${AUDIT_FILES}
-  rtld-audit.h
-  stap-note-iter.h
-  ../preload/preload_interface.h
-  ../preload/rrcalls.h
-)
-add_library(rraudit)
-foreach(file ${AUDIT_FILES})
-  target_sources(rraudit PUBLIC "${CMAKE_SOURCE_DIR}/src/audit/${file}")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/src/audit/${file}"
-                              PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
-endforeach(file)
-set_target_properties(rraudit PROPERTIES LINK_FLAGS "-nostartfiles -ldl ${LINKER_FLAGS}")
+if(RTLD_AUDIT)
+  set(AUDIT_FILES
+    rtld-audit.c
+    stap-note-iter.c
+    ../preload/raw_syscall.S
+  )
+  set(AUDIT_SOURCE_FILES
+    ${AUDIT_FILES}
+    rtld-audit.h
+    stap-note-iter.h
+    ../preload/preload_interface.h
+    ../preload/rrcalls.h
+  )
+  add_library(rraudit)
+  foreach(file ${AUDIT_FILES})
+    target_sources(rraudit PUBLIC "${CMAKE_SOURCE_DIR}/src/audit/${file}")
+    set_source_files_properties("${CMAKE_SOURCE_DIR}/src/audit/${file}"
+                                PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
+  endforeach(file)
+  set_target_properties(rraudit PROPERTIES LINK_FLAGS "-nostartfiles -ldl ${LINKER_FLAGS}")
+endif()
 
 # Ensure that CMake knows about our generated files.
 #
@@ -690,8 +700,10 @@ install(PROGRAMS scripts/signal-rr-recording.sh
 install(PROGRAMS scripts/rr_completion
   DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions RENAME rr)
 
-set(RR_INSTALL_LIBS rrpage rraudit rr_exec_stub)
-set(RR_INSTALL_LIBS rrpreload ${RR_INSTALL_LIBS})
+set(RR_INSTALL_LIBS rrpreload rrpage rr_exec_stub)
+if(RTLD_AUDIT)
+  set(RR_INSTALL_LIBS ${RR_INSTALL_LIBS} rraudit)
+endif()
 install(TARGETS ${RR_BIN} ${RR_INSTALL_LIBS}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr
@@ -703,6 +715,7 @@ install(TARGETS ${RR_BIN} ${RR_INSTALL_LIBS}
 # This sucks but I can't find a better way to get CMake to build
 # the same source file in two different ways.
 if(rr_32BIT AND rr_64BIT)
+  set(RR_INSTALL_LIBS_32 rrpreload_32 rrpage_32 rr_exec_stub_32)
   add_library(rrpage_32)
 
   foreach(file ${RR_PAGE_SOURCE_FILES})
@@ -746,24 +759,28 @@ if(rr_32BIT AND rr_64BIT)
     ${CMAKE_DL_LIBS}
   )
 
-  add_library(rraudit_32)
+  if(RTLD_AUDIT)
+    add_library(rraudit_32)
 
-  foreach(file ${AUDIT_SOURCE_FILES})
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/audit/${file}"
-                   "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
-                   COPYONLY)
-  endforeach(file)
+    foreach(file ${AUDIT_SOURCE_FILES})
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/audit/${file}"
+                     "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
+                     COPYONLY)
+    endforeach(file)
 
-  foreach(file ${AUDIT_FILES})
-    target_sources(rraudit_32 PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}")
-    set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
-                                PROPERTIES COMPILE_FLAGS "-m32 ${PRELOAD_COMPILE_FLAGS}")
-  endforeach(file)
+    foreach(file ${AUDIT_FILES})
+      target_sources(rraudit_32 PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}")
+      set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
+                                  PROPERTIES COMPILE_FLAGS "-m32 ${PRELOAD_COMPILE_FLAGS}")
+    endforeach(file)
 
-  set_target_properties(rraudit_32 PROPERTIES LINK_FLAGS "-m32 -nostartfiles ${LINKER_FLAGS}")
-  target_link_libraries(rraudit_32
-    ${CMAKE_DL_LIBS}
-  )
+    set_target_properties(rraudit_32 PROPERTIES LINK_FLAGS "-m32 -nostartfiles ${LINKER_FLAGS}")
+    target_link_libraries(rraudit_32
+      ${CMAKE_DL_LIBS}
+    )
+
+    set(RR_INSTALL_LIBS_32 ${RR_INSTALL_LIBS_32} rraudit_32)
+  endif()
 
   foreach(file exec_stub.c)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/${file}"
@@ -778,7 +795,7 @@ if(rr_32BIT AND rr_64BIT)
   set_target_properties(rr_exec_stub_32
                         PROPERTIES LINK_FLAGS "-static -nostartfiles -nodefaultlibs -m32 ${LINKER_FLAGS}")
 
-  install(TARGETS rrpreload_32 rrpage_32 rraudit_32 rr_exec_stub_32
+  install(TARGETS ${RR_INSTALL_LIBS_32}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr)

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -747,6 +747,7 @@ void GdbServer::dispatch_debugger_request(Session& session,
       dbg->reply_rr_cmd(
           GdbCommandHandler::process_command(*this, target, req.text()));
       return;
+#ifdef PROC_SERVICE_H
     case DREQ_QSYMBOL: {
       // When gdb sends "qSymbol::", it means that gdb is ready to
       // respond to symbol requests.  This can be sent multiple times
@@ -800,6 +801,7 @@ void GdbServer::dispatch_debugger_request(Session& session,
       dbg->reply_tls_addr(ok, address);
       return;
     }
+#endif
     default:
       FATAL() << "Unknown debugger request " << req.type;
   }

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -12,7 +12,9 @@
 #include "ReplaySession.h"
 #include "ReplayTimeline.h"
 #include "ScopedFd.h"
+#ifdef PROC_SERVICE_H
 #include "ThreadDb.h"
+#endif
 #include "TraceFrame.h"
 
 namespace rr {
@@ -220,7 +222,9 @@ private:
   // support switching gdb between debuggee processes.
   ThreadGroupUid debuggee_tguid;
   // ThreadDb for debuggee ThreadGroup
+#ifdef PROC_SERVICE_H
   std::unique_ptr<ThreadDb> thread_db;
+#endif
   // The TaskUid of the last continued task.
   TaskUid last_continue_tuid;
   // The TaskUid of the last queried task.

--- a/src/util.cc
+++ b/src/util.cc
@@ -5,7 +5,9 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <elf.h>
+#ifdef EXECINFO_H
 #include <execinfo.h>
+#endif
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -1734,9 +1736,14 @@ void notifying_abort() {
 void dump_rr_stack() {
   static const char msg[] = "=== Start rr backtrace:\n";
   write_all(STDERR_FILENO, msg, sizeof(msg) - 1);
+#if EXECINFO_H
   void* buffer[1024];
   int count = backtrace(buffer, 1024);
   backtrace_symbols_fd(buffer, count, STDERR_FILENO);
+#else
+  static const char msg_fallback[] = "<rr backtraces not available on this system>\n";
+  write_all(STDERR_FILENO, msg_fallback, sizeof(msg_fallback) - 1);
+#endif
   static const char msg2[] = "=== End rr backtrace\n";
   write_all(STDERR_FILENO, msg2, sizeof(msg2) - 1);
 }


### PR DESCRIPTION
rr uses/integrates with three glibc specific features

1. execinfo.h's backtrace is used to dump rr's stack during assertions
2. rr supports rtld-audit (I don't actually know what this does, but it doesn't matter)
3. rr supports glibc/gdb's libthread_db.so

Bionic doesn't support any of these, so check for them at build time and disable the relevant features if necessary.