### PR TITLE
Implement syscall buffering for RDTSC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1108,6 +1108,7 @@ set(BASIC_TESTS
   # pivot_root ... disabled because it fails when run as root and does nothing otherwise
   quotactl
   x86/rdtsc
+  x86/rdtsc_flags
   read_nothing
   readdir
   read_large

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1376,6 +1376,7 @@ set(TESTS_WITH_PROGRAM
   x86/patch_40_80_f6_81
   priority
   ptrace_remote_unmap
+  x86/rdtsc_loop
   read_big_struct
   remove_latest_trace
   restart_abnormal_exit

--- a/src/Event.h
+++ b/src/Event.h
@@ -108,12 +108,15 @@ struct DeschedEvent {
 };
 
 struct PatchSyscallEvent {
-  PatchSyscallEvent() : patch_after_syscall(false) {}
+  PatchSyscallEvent() : patch_trapping_instruction(false),
+    patch_after_syscall(false), patch_vsyscall(false) {}
+  // If true, this patch is for a trapping instruction, not a real syscall
+  bool patch_trapping_instruction;
   // If true, this patch event comes after a syscall (whereas usually they
   // come before). We assume the trace has put us in the correct place
   // and don't try to execute any code to reach this event.
   bool patch_after_syscall;
-  // It true, this patch is for the caller of a vsyscall entry point
+  // If true, this patch is for the caller of a vsyscall entry point
   bool patch_vsyscall;
 };
 
@@ -387,6 +390,7 @@ struct Event {
     auto ev = Event(EV_PATCH_SYSCALL);
     ev.PatchSyscall().patch_after_syscall = false;
     ev.PatchSyscall().patch_vsyscall = false;
+    ev.PatchSyscall().patch_trapping_instruction = false;
     return ev;
   }
   static Event sched() {

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -360,7 +360,6 @@ public:
   bool set_cx(uintptr_t value) { return RR_SET_REG_X86(ecx, rcx, value); }
 
   uintptr_t ax() const { return RR_GET_REG_X86(eax, rax); }
-  bool set_ax(uintptr_t value) { return RR_SET_REG_X86(eax, rax, value); }
 
   uintptr_t dx() const { return RR_GET_REG_X86(edx, rdx); }
   bool set_dx(uintptr_t value) { return RR_SET_REG_X86(edx, rdx, value); }

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -360,6 +360,11 @@ public:
   bool set_cx(uintptr_t value) { return RR_SET_REG_X86(ecx, rcx, value); }
 
   uintptr_t ax() const { return RR_GET_REG_X86(eax, rax); }
+  bool set_ax(uintptr_t value) { return RR_SET_REG_X86(eax, rax, value); }
+
+  uintptr_t dx() const { return RR_GET_REG_X86(edx, rdx); }
+  bool set_dx(uintptr_t value) { return RR_SET_REG_X86(edx, rdx, value); }
+
   uintptr_t bp() const { return RR_GET_REG_X86(ebp, rbp); }
 
   uintptr_t flags() const { return RR_GET_REG_X86(eflags, eflags); };

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -65,8 +65,8 @@ enum ReplayTraceStepType {
   /* Replay until we exit the next syscall, then patch it. */
   TSTEP_PATCH_AFTER_SYSCALL,
 
-  /* Replay until we hit the ip recorded in the event, then patch the vsyscall caller. */
-  TSTEP_PATCH_VSYSCALL,
+  /* Replay until we hit the ip recorded in the event, then patch the site. */
+  TSTEP_PATCH_IP,
 
   /* Exit the task */
   TSTEP_EXIT_TASK,
@@ -385,7 +385,8 @@ private:
   Completion patch_next_syscall(ReplayTask* t,
                                 const StepConstraints& constraints,
                                 bool before_syscall);
-  Completion patch_vsyscall(ReplayTask* t, const StepConstraints& constraints);
+  Completion patch_ip(ReplayTask* t, const StepConstraints& constraints);
+  void apply_patch_data(ReplayTask* t);
   void check_approaching_ticks_target(ReplayTask* t,
                                       const StepConstraints& constraints,
                                       BreakStatus& break_status);

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -149,6 +149,8 @@ void ReplayTask::set_return_value_from_trace() {
   // (to -1 in that case).
   r.set_original_syscallno(current_trace_frame().regs().original_syscallno());
   if (r.original_syscallno() == session().syscall_number_for_rrcall_rdtsc()) {
+    ASSERT(this, is_x86ish(arch()));
+    // EAX has been set via set_syscall_result above
     r.set_dx(current_trace_frame().regs().dx());
   }
   set_regs(r);

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -148,6 +148,9 @@ void ReplayTask::set_return_value_from_trace() {
   // seccomp filters) we need to emulate a change to the original_syscallno
   // (to -1 in that case).
   r.set_original_syscallno(current_trace_frame().regs().original_syscallno());
+  if (r.original_syscallno() == session().syscall_number_for_rrcall_rdtsc()) {
+    r.set_dx(current_trace_frame().regs().dx());
+  }
   set_regs(r);
 }
 

--- a/src/Session.h
+++ b/src/Session.h
@@ -391,6 +391,9 @@ public:
   int syscall_number_for_rrcall_notify_stap_semaphore_removed() const {
     return SYS_rrcall_notify_stap_semaphore_removed - RR_CALL_BASE + rrcall_base_;
   }
+  int syscall_number_for_rrcall_rdtsc() const {
+    return SYS_rrcall_rdtsc - RR_CALL_BASE + rrcall_base_;
+  }
 
   /* Bind the current process to the a CPU as specified in the session options
      or trace */

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -440,7 +440,9 @@ void TraceWriter::write_frame(RecordTask* t, const Event& ev,
       event.setInstructionTrap(Void());
       break;
     case EV_PATCH_SYSCALL:
-      if (ev.PatchSyscall().patch_vsyscall) {
+      if (ev.PatchSyscall().patch_trapping_instruction) {
+        event.setPatchTrappingInstruction(Void());
+      } else if (ev.PatchSyscall().patch_vsyscall) {
         event.setPatchVsyscall(Void());
       } else if (ev.PatchSyscall().patch_after_syscall) {
         event.setPatchAfterSyscall(Void());
@@ -602,6 +604,10 @@ TraceFrame TraceReader::read_frame() {
       break;
     case trace::Frame::Event::PATCH_SYSCALL:
       ret.ev = Event::patch_syscall();
+      break;
+    case trace::Frame::Event::PATCH_TRAPPING_INSTRUCTION:
+      ret.ev = Event::patch_syscall();
+      ret.ev.PatchSyscall().patch_trapping_instruction = true;
       break;
     case trace::Frame::Event::PATCH_VSYSCALL:
       ret.ev = Event::patch_syscall();

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -87,6 +87,9 @@ templates = {
     'X86SyscallStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         RawBytes(0x89, 0x25, 0x08, 0x10, 0x00, 0x70), # movl %esp,(stub_scratch_1)
+        RawBytes(0xBC, 0x12, 0x10, 0x00, 0x70),                   # mov $saved_flags+2,%esp
+        RawBytes(0x66, 0x9c),                                     # pushfw
+        RawBytes(0x8b, 0x25, 0x08, 0x10, 0x00, 0x70),             # movq (stub_scratch_1),%esp
         RawBytes(0xFF, 0x05, 0x0c, 0x10, 0x00, 0x70), # incl (alt_stack_nesting_level)
         RawBytes(0x83, 0x3c, 0x25, 0x0c, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
         RawBytes(0x75, 0x06),                                     # jne dont_switch
@@ -101,6 +104,9 @@ templates = {
     'X86TrapInstructionStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         RawBytes(0x89, 0x25, 0x08, 0x10, 0x00, 0x70), # movl %esp,(stub_scratch_1)
+        RawBytes(0xBC, 0x12, 0x10, 0x00, 0x70),                   # mov $saved_flags+2,%esp
+        RawBytes(0x66, 0x9c),                                     # pushfw
+        RawBytes(0x8b, 0x25, 0x08, 0x10, 0x00, 0x70),             # movq (stub_scratch_1),%esp
         RawBytes(0xFF, 0x05, 0x0c, 0x10, 0x00, 0x70), # incl (alt_stack_nesting_level)
         RawBytes(0x83, 0x3c, 0x25, 0x0c, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
         RawBytes(0x75, 0x06),                                     # jne dont_switch
@@ -129,6 +135,9 @@ templates = {
     'X64SyscallStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         RawBytes(0x48, 0x89, 0x24, 0x25, 0x10, 0x10, 0x00, 0x70), # movq %rsp,(stub_scratch_1)
+        RawBytes(0xBC, 0x1e, 0x10, 0x00, 0x70),                   # mov $saved_flags+2,%esp
+        RawBytes(0x66, 0x9c),                                     # pushfw
+        RawBytes(0x48, 0x8b, 0x24, 0x25, 0x10, 0x10, 0x00, 0x70), # movq (stub_scratch_1),%rsp
         RawBytes(0xFF, 0x04, 0x25, 0x18, 0x10, 0x00, 0x70),       # incl (alt_stack_nesting_level)
         RawBytes(0x83, 0x3c, 0x25, 0x18, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
         RawBytes(0x75, 0x0a),                                     # jne dont_switch
@@ -149,6 +158,9 @@ templates = {
     'X64TrapInstructionStubExtendedJump': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         RawBytes(0x48, 0x89, 0x24, 0x25, 0x10, 0x10, 0x00, 0x70), # movq %rsp,(stub_scratch_1)
+        RawBytes(0xBC, 0x1e, 0x10, 0x00, 0x70),                   # mov $saved_flags+2,%esp
+        RawBytes(0x66, 0x9c),                                     # pushfw
+        RawBytes(0x48, 0x8b, 0x24, 0x25, 0x10, 0x10, 0x00, 0x70), # movq (stub_scratch_1),%rsp
         RawBytes(0xFF, 0x04, 0x25, 0x18, 0x10, 0x00, 0x70),       # incl (alt_stack_nesting_level)
         RawBytes(0x83, 0x3c, 0x25, 0x18, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
         RawBytes(0x75, 0x0a),                                     # jne dont_switch

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -98,6 +98,22 @@ templates = {
         RawBytes(0xe9),                               # jmp $trampoline_relative_addr
         Field('trampoline_relative_addr', 4)
     ),
+    'X86TrapInstructionStubExtendedJump': AssemblyTemplate(
+        # This code must match the stubs in syscall_hook.S.
+        RawBytes(0x89, 0x25, 0x08, 0x10, 0x00, 0x70), # movl %esp,(stub_scratch_1)
+        RawBytes(0xFF, 0x05, 0x0c, 0x10, 0x00, 0x70), # incl (alt_stack_nesting_level)
+        RawBytes(0x83, 0x3c, 0x25, 0x0c, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
+        RawBytes(0x75, 0x06),                                     # jne dont_switch
+        RawBytes(0x8b, 0x25, 0x00, 0x10, 0x00, 0x70), # movl (syscallbuf_stub_alt_stack),%esp
+        # dont_switch:
+        RawBytes(0xff, 0x35, 0x08, 0x10, 0x00, 0x70), # pushl (stub_scratch_1)
+        RawBytes(0x68),                               # pushl $return_addr
+        Field('return_addr', 4),
+        RawBytes(0xb8),                               # movl $fake_syscall_no,%eax
+        Field('fake_syscall_no', 4),
+        RawBytes(0xe9),                               # jmp $trampoline_relative_addr
+        Field('trampoline_relative_addr', 4)
+    ),
     'X86SyscallStubRestore': AssemblyTemplate(
         RawBytes(0xe9),                               # jmp $trampoline_relative_addr
         Field('trampoline_relative_addr', 4)
@@ -122,11 +138,33 @@ templates = {
         RawBytes(0x48, 0x81, 0xec, 0x00, 0x01, 0x00, 0x00), # subq $256, %rsp
         # after adjust
         RawBytes(0xff, 0x34, 0x25, 0x10, 0x10, 0x00, 0x70), # pushq (stub_scratch_1)
-        RawBytes(0x50),                                     # pushq rax
+        RawBytes(0x50),                                     # pushq rax (just to make space for the next 2 instructions)
         RawBytes(0xc7, 0x04, 0x24),                         # movl $return_addr_lo,(%rsp)
         Field('return_addr_lo', 4),
         RawBytes(0xc7, 0x44, 0x24, 0x04),                   # movl $return_addr_hi,(%rsp+4)
         Field('return_addr_hi', 4),
+        RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00),       # jmp *0(%rip)
+        Field('jump_target', 8),
+    ),
+    'X64TrapInstructionStubExtendedJump': AssemblyTemplate(
+        # This code must match the stubs in syscall_hook.S.
+        RawBytes(0x48, 0x89, 0x24, 0x25, 0x10, 0x10, 0x00, 0x70), # movq %rsp,(stub_scratch_1)
+        RawBytes(0xFF, 0x04, 0x25, 0x18, 0x10, 0x00, 0x70),       # incl (alt_stack_nesting_level)
+        RawBytes(0x83, 0x3c, 0x25, 0x18, 0x10, 0x00, 0x70, 0x01), # cmpl 1,(alt_stack_nesting_level)
+        RawBytes(0x75, 0x0a),                                     # jne dont_switch
+        RawBytes(0x48, 0x8b, 0x24, 0x25, 0x00, 0x10, 0x00, 0x70), # movq (syscallbuf_stub_alt_stack),%rsp
+        RawBytes(0xeb, 0x07),                                     # jmp after_adjust
+        # dont_switch:
+        RawBytes(0x48, 0x81, 0xec, 0x00, 0x01, 0x00, 0x00), # subq $256, %rsp
+        # after adjust
+        RawBytes(0xff, 0x34, 0x25, 0x10, 0x10, 0x00, 0x70), # pushq (stub_scratch_1)
+        RawBytes(0x50),                                     # pushq rax (just to make space for the next 2 instructions)
+        RawBytes(0xc7, 0x04, 0x24),                         # movl $return_addr_lo,(%rsp)
+        Field('return_addr_lo', 4),
+        RawBytes(0xc7, 0x44, 0x24, 0x04),                   # movl $return_addr_hi,(%rsp+4)
+        Field('return_addr_hi', 4),
+        RawBytes(0xb8),                                     # movl $fake_syscall_no,%eax
+        Field('fake_syscall_no', 4),
         RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00),       # jmp *0(%rip)
         Field('jump_target', 8),
     ),

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -307,11 +307,9 @@ struct preload_thread_locals {
   /* The offset of this field MUST NOT CHANGE, it is part of the preload ABI
    * rr depends on.
    */
-  int alt_stack_nesting_level;
-  /**
-   * We could use this later.
-   */
-  int unused_padding;
+  int32_t alt_stack_nesting_level;
+  /* Syscall hook saved flags (bottom 16 bits only) */
+  int32_t saved_flags;
   /* The offset of this field MUST NOT CHANGE, it is part of the preload ABI
    * rr depends on. It contains the parameters to the patched syscall, or
    * zero if we're not processing a buffered syscall. Do not depend on this

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -394,6 +394,8 @@ enum syscallbuf_fd_classes {
 /**
  * Packs up the parameters passed to |SYS_rrcall_init_preload|.
  * We use this struct because it's a little cleaner.
+ * When evolving this struct, add new fields at the end and don't
+ * depend on them during replay.
  */
 TEMPLATE_ARCH
 struct rrcall_init_preload_params {

--- a/src/preload/rrcalls.h
+++ b/src/preload/rrcalls.h
@@ -95,3 +95,9 @@
  * behavior is unaffected. Used for testing Scheduler-sensitive scenarios.
  */
 #define SYS_rrcall_freeze_tid (RR_CALL_BASE + 11)
+/**
+ * Requests a simulated (buffered) RDTSC.
+ * The RDTSC value is returned as a 64-bit value stored in the
+ * memory location given by the first argument. RAX returns 0.
+ */
+#define SYS_rrcall_rdtsc (RR_CALL_BASE + 12)

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -312,9 +312,18 @@ _syscall_hook_trampoline:
         movdqa %xmm6,0x60(%rsp)
         movdqa %xmm7,0x70(%rsp)
 
+        /* Save registers that aren't callee-saves preserved by syscall_hook,
+           and that we aren't already restoring from the syscall args */
+        push %rcx
+        push %r11
+        /* stack is 16-byte aligned again for entry to C */
+
         /* Call our hook. */
         mov %rbx,%rdi
         callq syscall_hook
+
+        pop %r11
+        pop %rcx
 
         /* Restore XMM registers */
         movdqa (%rsp),%xmm0
@@ -330,8 +339,7 @@ _syscall_hook_trampoline:
         .cfi_def_cfa_register %rsp
 
         /* On entrance, we pushed the %rax, the syscall number. But we don't
-           want to |pop %rax|, as that will overwrite our return value. Pop
-           into %r11 instead. */
+           want to |pop %rax|, as that will overwrite our return value. Skip over it. */
         pop %r11
         .cfi_adjust_cfa_offset -8
 
@@ -571,6 +579,11 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_49_89_ca)
 	mov %rcx, %r10
 	call __morestack
 SYSCALLHOOK_END(_syscall_hook_trampoline_49_89_ca)
+
+SYSCALLHOOK_START(_syscall_hook_trampoline_48_89_c1)
+        callq __morestack
+        mov %rax, %rcx
+SYSCALLHOOK_END(_syscall_hook_trampoline_48_89_c1)
 
 #endif /* __x86_64__ */
 

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -30,6 +30,7 @@
         .set syscallbuf_stub_alt_stack, preload_thread_locals
         .set stub_scratch_1, preload_thread_locals + 8
         .set alt_stack_nesting_level, preload_thread_locals + 12
+        .set saved_flags, preload_thread_locals + 16
 
         .p2align 4
 _syscallbuf_code_start:
@@ -77,8 +78,14 @@ _switch_stack_vsyscall:
 
         /* Pop previous EIP */
         lea 4(%esp),%esp
-        /* Restore previous ESP */
-        subl $4,(%esp)
+
+        /* Restore previous ESP ... without modifying flags */
+        mov %eax,(stub_scratch_1)
+        mov (%esp),%eax
+        lea -4(%eax),%eax
+        mov %eax,(%esp)
+        mov (stub_scratch_1),%eax
+
         pop %esp
         ret
         .cfi_endproc
@@ -152,13 +159,17 @@ _syscall_hook_trampoline:
         movdqa 0x70(%esp),%xmm6
         movdqa 0x80(%esp),%xmm7
 
+        pushw (saved_flags)
+        popfw
+        /* From here on, non-application flag changes are not allowed */
+
         /* Restore ESP */
         mov %ebp, %esp
         .cfi_def_cfa_register %esp
 
         /* $eax is now the syscall return value.  Erase |info.no| from the
          * stack so that we can restore the other registers we saved. */
-        addl $4,%esp
+        lea 4(%esp),%esp
         .cfi_adjust_cfa_offset -4
 
         /* Contract of __kernel_vsyscall() and real syscalls is that even
@@ -261,6 +272,7 @@ _get_pc_thunks_end:
 
         .set stub_scratch_1, preload_thread_locals + 16
         .set alt_stack_nesting_level, preload_thread_locals + 24
+        .set saved_flags, preload_thread_locals + 28
 
         .p2align 4
 _syscallbuf_code_start:
@@ -334,6 +346,10 @@ _syscall_hook_trampoline:
         movdqa 0x50(%rsp),%xmm5
         movdqa 0x60(%rsp),%xmm6
         movdqa 0x70(%rsp),%xmm7
+
+        pushw (saved_flags)
+        popfw
+        /* From here on, non-application flag changes are not allowed */
 
         mov %rbx,%rsp
         .cfi_def_cfa_register %rsp

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -334,5 +334,6 @@ struct Frame {
     }
     patchAfterSyscall @26: Void;
     patchVsyscall @27: Void;
+    patchTrappingInstruction @31: Void;
   }
 }

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1755,6 +1755,9 @@ rrcall_notify_stap_semaphore_added = IrregularEmulatedSyscall(x86=1006, x64=1006
 rrcall_notify_stap_semaphore_removed = IrregularEmulatedSyscall(x86=1007, x64=1007, generic=1007)
 rrcall_check_presence = IrregularEmulatedSyscall(x86=1008, x64=1008, generic=1008)
 rrcall_detach_teleport = IrregularEmulatedSyscall(x86=1009, x64=1009, generic=1009)
+rrcall_arm_time_slice = IrregularEmulatedSyscall(x86=1010, x64=1010, generic=1010)
+rrcall_freeze_tid = IrregularEmulatedSyscall(x86=1011, x64=1011, generic=1011)
+rrcall_rdtsc = IrregularEmulatedSyscall(x86=1012, x64=1012, generic=1012)
 
 # These syscalls also appear under `socketcall` on x86.
 socket = EmulatedSyscall(x86=359, x64=41, generic=198)

--- a/src/test/x86/rdtsc_flags.c
+++ b/src/test/x86/rdtsc_flags.c
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+#ifdef __x86_64__
+  char zero_ok;
+  char nonzero_ok;
+
+  /* Check that ZF=0 holds across buffered RDTSC */
+  asm volatile ("xor %%eax,%%eax\n\t"
+                "rdtsc\n\t"
+                "mov %%rax,%%rcx\n\t" /* make it bufferable */
+                "sete %0\n\t"
+                : "=m"(zero_ok) :: "eax", "edx", "rcx");
+  test_assert(zero_ok);
+
+  /* Check that ZF=1 holds across buffered RDTSC */
+  asm volatile ("xor %%eax,%%eax\n\t"
+                "cmp $1,%%eax\n\t"
+                "rdtsc\n\t"
+                "mov %%rax,%%rcx\n\t" /* make it bufferable */
+                "setne %0\n\t"
+                : "=m"(nonzero_ok) :: "eax", "edx", "rcx");
+  test_assert(nonzero_ok);
+#endif
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}
+

--- a/src/test/x86/rdtsc_loop.c
+++ b/src/test/x86/rdtsc_loop.c
@@ -1,0 +1,25 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+#ifdef __x86_64__
+  int i;
+
+  uint64_t prev_tsc;
+  for (i = 0; i < 5000000; ++i) {
+    uint32_t out;
+    uint32_t out_hi;
+    asm volatile ("rdtsc\n\t"
+                  "mov %%rax,%%rcx\n\t"
+                  : "=c"(out), "=d"(out_hi)
+                  :: "rax");
+    uint64_t tsc = ((uint64_t)out_hi << 32) + out;
+    test_assert(prev_tsc < tsc || tsc < 1000000000);
+    prev_tsc = tsc;
+  }
+#endif
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/x86/rdtsc_loop.run
+++ b/src/test/x86/rdtsc_loop.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+skip_if_no_syscall_buf
+compare_test EXIT-SUCCESS

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,10 @@
 #include <string>
 #include <vector>
 
+#if defined(__i386__) || defined(__x86_64__)
+#include <x86intrin.h>
+#endif
+
 #include "ScopedFd.h"
 #include "TraceFrame.h"
 #include "remote_ptr.h"
@@ -568,6 +572,15 @@ bool coredumping_signal_takes_down_entire_vm();
 
 /* Parse tid from the proc file system path /proc/<pid>/<property> or /proc/<pid>/task/<tid>/<property> */
 int parse_tid_from_proc_path(const std::string& pathname, const std::string& property);
+
+inline unsigned long long rdtsc(void) {
+#if defined(__i386__) || defined(__x86_64__)
+  return __rdtsc();
+#else
+  FATAL() << "Reached x86-only code path on non-x86 architecture";
+  return 0;
+#endif
+}
 
 } // namespace rr
 


### PR DESCRIPTION
Before:
[roc@localhost rr]$ time rr record ~/rr/obj/bin/rdtsc_loop
rr: Saving execution to trace directory `/home/roc/.local/share/rr/rdtsc_loop-19'.
EXIT-SUCCESS
real    8m15.591s
user    5m9.203s
sys     3m10.668s

After:
[roc@localhost rr]$ time rr record ~/rr/obj/bin/rdtsc_loop
rr: Saving execution to trace directory `/home/roc/.local/share/rr/rdtsc_loop-18'.
EXIT-SUCCESS
real    0m7.757s
user    0m12.862s
sys     0m3.769s

FYI, without rr:
[roc@localhost rr]$ time ~/rr/obj/bin/rdtsc_loop
EXIT-SUCCESS
real    0m0.063s
user    0m0.060s
sys     0m0.003s