### PR TITLE
Disable gdb debuginfod in test

### DIFF
--- a/src/test/test_setup.gdb
+++ b/src/test/test_setup.gdb
@@ -3,3 +3,5 @@ handle SIGSEGV stop
 handle SIGKILL nostop
 # This fails in gdb < 8.3
 set style enabled off
+# gdb >= 10
+set debuginfod enabled off


### PR DESCRIPTION
Otherwise gdb may ask about whether it should be enabled during the test and hang forever.

This starts to happen on ArchLinux recently and is causing the debug tests to timeout.
