### PR TITLE
Remove StepConstraints::stop_at_time

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1363,7 +1363,7 @@ GdbServer::ContinueOrStop GdbServer::debug_one_step(
       RunCommand command = compute_run_command_from_actions(
           timeline.current_session().current_task(), req, &signal_to_deliver);
       // Ignore gdb's |signal_to_deliver|; we just have to follow the replay.
-      result = timeline.replay_step_forward(command, target.event);
+      result = timeline.replay_step_forward(command);
     }
     if (result.status == REPLAY_EXITED) {
       return handle_exited_state(last_resume_request);
@@ -1633,7 +1633,7 @@ void GdbServer::restart_session(const GdbRequest& req) {
     timeline.seek_to_before_event(target.event);
     ReplayResult result;
     do {
-      result = timeline.replay_step_forward(RUN_CONTINUE, target.event);
+      result = timeline.replay_step_forward(RUN_CONTINUE);
       // We should never reach the end of the trace without hitting the stop
       // condition below.
       DEBUG_ASSERT(result.status != REPLAY_EXITED);
@@ -1773,7 +1773,7 @@ static void print_debugger_launch_command(Task* t, const string& host,
 void GdbServer::serve_replay(const ConnectionFlags& flags) {
   ReplayResult result;
   do {
-    result = timeline.replay_step_forward(RUN_CONTINUE, target.event);
+    result = timeline.replay_step_forward(RUN_CONTINUE);
     if (result.status == REPLAY_EXITED) {
       LOG(info) << "Debugger was not launched before end of trace";
       return;

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -258,9 +258,8 @@ public:
 
   struct StepConstraints {
     explicit StepConstraints(RunCommand command)
-        : command(command), stop_at_time(0), ticks_target(0) {}
+        : command(command), ticks_target(0) {}
     RunCommand command;
-    FrameTime stop_at_time;
     Ticks ticks_target;
     // When the RunCommand is RUN_SINGLESTEP_FAST_FORWARD, stop if the next
     // singlestep would enter one of the register states in this list.
@@ -275,16 +274,11 @@ public:
   };
   /**
    * Take a single replay step.
-   * Ensure we stop at event stop_at_time. If this is not specified,
-   * optimizations may cause a replay_step to pass straight through
-   * stop_at_time.
    * Outside of replay_step, no internal breakpoints will be set for any
    * task in this session.
-   * Stop when the current event reaches stop_at_time (i.e. this event has
-   * is the next event to be replayed).
    * If ticks_target is nonzero, stop before the current task's ticks
-   * reaches ticks_target (but not too far before, unless we hit a breakpoint
-   * or stop_at_time). Only useful for RUN_CONTINUE.
+   * reaches ticks_target (but not too far before, unless we hit a breakpoint).
+   * Only useful for RUN_CONTINUE.
    * Always stops on a switch to a new task.
    */
   ReplayResult replay_step(const StepConstraints& constraints);

--- a/src/ReplayTimeline.h
+++ b/src/ReplayTimeline.h
@@ -209,7 +209,7 @@ public:
    * replay_step_forward only does one replay step. That means we'll only
    * execute code in current_session().current_task().
    */
-  ReplayResult replay_step_forward(RunCommand command, FrameTime stop_at_time);
+  ReplayResult replay_step_forward(RunCommand command);
 
   ReplayResult reverse_continue(
       const std::function<bool(ReplayTask* t)>& stop_filter,


### PR DESCRIPTION
This is now completely unused.

Noticed when debugging https://github.com/rr-debugger/rr/issues/3252. Not sure if this is expected / correct but AFAICT this is simply making the code confusing to read at this point...
Therefore, I think this should either be removed (this PR) or something should actually be using it....
