### PR TITLE
Fix seeking to ticks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1548,6 +1548,8 @@ set(TESTS_WITHOUT_PROGRAM
   subprocess_exit_ends_session
   switch_processes
   syscallbuf_timeslice_250
+  tick0
+  tick0_less
   trace_version
   term_trace_cpu
   trace_events
@@ -1617,6 +1619,18 @@ if(BUILD_TESTS)
               DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr/testsuite/obj/bin)
     endif(INSTALL_TESTSUITE)
   endforeach(test)
+
+  add_executable(tick0 src/test/tick0.c)
+  post_build_executable(tick0)
+  set_target_properties(tick0
+    PROPERTIES LINK_FLAGS "-static -nostdlib -nodefaultlibs"
+    COMPILE_FLAGS "-static -nostdlib -nodefaultlibs -O3 -g2 -DHAS_TICK0=1")
+
+  add_executable(tick0_less src/test/tick0.c)
+  post_build_executable(tick0_less)
+  set_target_properties(tick0_less
+    PROPERTIES LINK_FLAGS "-static -nostdlib -nodefaultlibs"
+    COMPILE_FLAGS "-static -nostdlib -nodefaultlibs -O3 -g2")
 
   # Test disabled because it requires libuvc to be built and installed, and a
   # working USB camera
@@ -1732,7 +1746,7 @@ if(BUILD_TESTS)
                     COPYONLY)
     endforeach(header)
 
-    foreach(test ${BASIC_TESTS} ${TESTS_WITH_PROGRAM} x86/cpuid test_lib)
+    foreach(test ${BASIC_TESTS} ${TESTS_WITH_PROGRAM} x86/cpuid test_lib tick0)
       configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/${test}.c"
                      "${CMAKE_CURRENT_BINARY_DIR}/32/${test}.c"
                      COPYONLY)
@@ -1777,6 +1791,18 @@ if(BUILD_TESTS)
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr/testsuite/obj/bin)
       endif (INSTALL_TESTSUITE)
     endforeach(test)
+
+    add_executable(tick0_32 "${CMAKE_CURRENT_BINARY_DIR}/32/tick0.c")
+    post_build_executable(tick0_32)
+    set_target_properties(tick0_32
+      PROPERTIES LINK_FLAGS "-m32 -static -nostdlib -nodefaultlibs"
+      COMPILE_FLAGS "-m32 -static -nostdlib -nodefaultlibs -O3 -g2 -DHAS_TICK0=1")
+
+    add_executable(tick0_less_32 "${CMAKE_CURRENT_BINARY_DIR}/32/tick0.c")
+    post_build_executable(tick0_less_32)
+    set_target_properties(tick0_less_32
+      PROPERTIES LINK_FLAGS "-m32 -static -nostdlib -nodefaultlibs"
+      COMPILE_FLAGS "-m32 -static -nostdlib -nodefaultlibs -O3 -g2")
 
     add_library(test_lib_32
       "${CMAKE_CURRENT_BINARY_DIR}/32/test_lib.c"

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1599,12 +1599,12 @@ void GdbServer::restart_session(const GdbRequest& req) {
         return;
       }
       TraceFrame frame = tmp_reader.read_frame();
-      if (frame.tid() == task->tuid().tid() && frame.ticks() > target) {
+      if (frame.tid() == task->tuid().tid() && frame.ticks() >= target) {
         break;
       }
       last_time = frame.time();
     }
-    timeline.seek_to_ticks(last_time, target);
+    timeline.seek_to_ticks(last_time + 1, target);
   }
 
   interrupt_pending = true;

--- a/src/test/tick0.c
+++ b/src/test/tick0.c
@@ -1,0 +1,70 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+// This is not linked to anything, not even the dynamic linker.
+
+volatile int nloop = 100000;
+const char exit_msg[] = "EXIT-SUCCESS\n";
+
+#ifdef __x86_64__
+#define SYS_write 1
+#define SYS_exit 60
+#define SYS_getpid 39
+#elif defined(__i386__)
+#define SYS_write 4
+#define SYS_exit 1
+#define SYS_getpid 20
+#elif defined(__aarch64__)
+#define SYS_write 64
+#define SYS_exit 93
+#define SYS_getpid 172
+#else
+#error define syscall numbers here
+#endif
+
+
+static inline __attribute__((always_inline))
+unsigned long my_syscall(unsigned long syscall, unsigned long arg1,
+                         unsigned long arg2, unsigned long arg3) {
+  unsigned long ret;
+#ifdef __x86_64__
+  __asm__ volatile("syscall\n\t"
+                   : "=a"(ret)
+                   : "a"(syscall), "D"(arg1), "S"(arg2), "d"(arg3)
+                   : "flags");
+#elif defined(__i386__)
+  __asm__ volatile("xchg %%esi,%%edi\n\t"
+                   "int $0x80\n\t"
+                   "xchg %%esi,%%edi\n\t"
+                   : "=a"(ret)
+                   : "a"(syscall), "b"(arg1), "c"(arg2), "d"(arg3));
+#elif defined(__aarch64__)
+  register unsigned long x8 __asm__("x8") = syscall;
+  register unsigned long x0 __asm__("x0") = arg1;
+  register unsigned long x1 __asm__("x1") = arg2;
+  register unsigned long x2 __asm__("x2") = arg3;
+  __asm__ volatile("svc #0\n\t"
+                   : "+r"(x0)
+                   : "r"(x1), "r"(x2), "r"(x8));
+  ret = x0;
+#else
+#error define syscall here
+#endif
+  return ret;
+}
+
+void _start(void) {
+#ifdef HAS_TICK0
+  my_syscall(SYS_getpid, 0, 0, 0);
+#endif
+  // Do some branches to make sure the very first event on this program
+  // happens at ticks != 0
+  for (int i = 0; i < nloop; i++) {
+    asm volatile ("" : "+r"(i) :: "memory");
+  }
+
+  unsigned long nchar = sizeof(exit_msg) - 1; // remove terminal NUL byte
+
+  my_syscall(SYS_write, 1, (unsigned long)exit_msg, nchar);
+  my_syscall(SYS_exit, 0, 0, 0);
+  __builtin_unreachable();
+}

--- a/src/test/tick0.py
+++ b/src/test/tick0.py
@@ -1,0 +1,38 @@
+from util import *
+import re
+
+send_gdb('handle SIGKILL stop')
+
+send_gdb('when')
+expect_gdb(re.compile(r'Current event: (\d+)'))
+event = eval(last_match().group(1));
+
+send_gdb('when-ticks')
+expect_gdb(re.compile(r'Current tick: (\d+)'))
+ticks = eval(last_match().group(1));
+if ticks != 0:
+    failed('ERROR in first "when-ticks"')
+
+send_gdb('c')
+
+send_gdb('when-ticks')
+expect_gdb(re.compile(r'Current tick: (\d+)'))
+ticks2 = eval(last_match().group(1));
+if ticks2 < 99999:
+    failed('ERROR in second "when-ticks"')
+
+send_gdb("seek-ticks %d" % ticks)
+expect_gdb("Program stopped.")
+send_gdb('when-ticks')
+expect_gdb(re.compile(r'Current tick: (\d+)'))
+ticks3 = eval(last_match().group(1));
+if ticks3 != ticks:
+    failed('ERROR: Failed to seek back to ticks')
+
+send_gdb('when')
+expect_gdb(re.compile(r'Current event: (\d+)'))
+event2 = eval(last_match().group(1));
+if event2 != event:
+    failed('ERROR: Failed to seek back to ticks')
+
+ok()

--- a/src/test/tick0.run
+++ b/src/test/tick0.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record tick0$bitness
+debug tick0

--- a/src/test/tick0_less.run
+++ b/src/test/tick0_less.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record tick0_less$bitness
+debug tick0


### PR DESCRIPTION
* Make sure we execute the first event that is at the desired tick

  Previously, we stop before the last event that's no later than the tick.
  This causes us to undershot which is especially bad when seeking to beginning
  past the ticks reset.

* Also add explicit test for seeking to tick 0
  when the first event happens at ticks > 0 and ticks == 0

Fix #3252

The document for `seek_to_ticks` says "during event `time`" but I'm not 100% sure if the period between frame times counts as part of the event before or after it.... The current behavior seems to be that we are seeking to the period before the event, which agrees with what `when` command says so I'm keeping it this way. As such, the frame time passed in right now should be that of the event right after where we want to seek to.
