### PR TITLE
Cherry pick some refactoring for aarch64 syscallbuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ configure_file(
 set(FLAGS_COMMON "-D__USE_LARGEFILE64 -pthread")
 set(supports32bit true)
 set(x86ish false)
+set(has_syscallbuf false)
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
   set(supports32bit false)
   set(FLAGS_COMMON "${FLAGS_COMMON} -march=armv8.3-a -moutline-atomics")
@@ -60,6 +61,7 @@ if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
   set(VDSO_NAME "LINUX_2.6.39")
 else()
   set(x86ish true)
+  set(has_syscallbuf true)
   set(FLAGS_COMMON "${FLAGS_COMMON} -msse2 -D__MMX__ -D__SSE__ -D__SSE2__")
   set(PRELOAD_LIBRARY_PAGE_SIZE 4096)
   set(VDSO_NAME "LINUX_2.6")
@@ -410,7 +412,7 @@ add_custom_command(TARGET rrpage POST_BUILD
 
 # Order matters here! syscall_hook.S must be immediately before syscallbuf.c,
 # raw_syscall.S must be before overrides.c, which must be last.
-if(x86ish)
+if(has_syscallbuf)
   set(PRELOAD_FILES
     syscall_hook.S
     syscallbuf.c

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -63,6 +63,9 @@ public:
    * be replayed.
    */
   bool try_patch_syscall(RecordTask* t, bool entering_syscall = true);
+  bool try_patch_syscall_x86ish(RecordTask* t, bool entering_syscall,
+                                SupportedArch arch);
+  bool try_patch_syscall_aarch64(RecordTask* t, bool entering_syscall);
 
   /**
    * Try to patch the trapping instruction that |t| just trapped on. If this

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -11,6 +11,37 @@
         .hidden _syscallbuf_final_exit_instruction
         .type _syscallbuf_final_exit_instruction, @function
 
+#define DW_OP_CONST4U(val)                      \
+        0x0c, /* DW_OP_const4u */               \
+        /* Individually place bytes */          \
+        (val) & 0xFF,                           \
+        ((val) & (0xFF <<  0x8)) >>  0x8,       \
+        ((val) & (0xFF << 0x10)) >> 0x10,       \
+        ((val) & (0xFF << 0x18)) >> 0x18
+
+#define DW_OP_CONST8U(val)                      \
+        0x0e, /* DW_OP_const8u */               \
+        /* Individually place bytes */          \
+        (val) & 0xFF,                           \
+        ((val) & (0xFF <<  0x8)) >>  0x8,       \
+        ((val) & (0xFF << 0x10)) >> 0x10,       \
+        ((val) & (0xFF << 0x18)) >> 0x18,       \
+        ((val) & (0xFF << 0x20)) >> 0x20,       \
+        ((val) & (0xFF << 0x28)) >> 0x28,       \
+        ((val) & (0xFF << 0x30)) >> 0x30,       \
+        ((val) & (0xFF << 0x38)) >> 0x38
+
+#define REG_AT_ADDR32(reg, addr)                                \
+        .cfi_escape 0x10, /* DW_CFA_expression */               \
+                    reg,                                        \
+                    0x05, /* 5 byte expression follows */       \
+                    DW_OP_CONST4U(addr)
+#define REG_AT_ADDR64(reg, addr)                                \
+        .cfi_escape 0x10, /* DW_CFA_expression */               \
+                    reg,                                        \
+                    0x09, /* 9 byte expression follows */       \
+                    DW_OP_CONST8U(addr)
+
 #if defined(__i386__)
 /**
  * Jump to this hook from |__kernel_vsyscall()|, to buffer syscalls that
@@ -216,15 +247,7 @@ name:                           \
         .cfi_adjust_cfa_offset -4;                              \
         pop %esp;                                               \
         .cfi_same_value %esp;                                   \
-        .cfi_escape 0x10, /* DW_CFA_expression */               \
-                    0x08, /* %eip */                            \
-                    0x05, /* 5 byte expression follows */       \
-                    0x0c, /* DW_OP_const4u */                   \
-                    /* Individually place bytes */              \
-                    stub_scratch_1 & 0xFF,                      \
-                    (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \
-                    (stub_scratch_1 & (0xFF << 0x10)) >> 0x10,  \
-                    (stub_scratch_1 & (0xFF << 0x18)) >> 0x18;  \
+        REG_AT_ADDR32(0x08 /* %eip */, stub_scratch_1);         \
         jmp _syscallbuf_final_exit_instruction;                 \
        .cfi_endproc;                                            \
        .size name, .-name
@@ -455,19 +478,7 @@ name:                              \
 #define SYSCALLHOOK_END(name)                                   \
         pop (stub_scratch_1);                                   \
         CFA_AT_RSP_OFFSET(0)                                    \
-        .cfi_escape 0x10, /* DW_CFA_expression */               \
-                    0x10, /* %rip */                            \
-                    0x09, /* 9 byte expression follows */       \
-                    0x0e, /* DW_OP_const8u */                   \
-                    /* Individually place bytes */              \
-                    stub_scratch_1 & 0xFF,                      \
-                    (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \
-                    (stub_scratch_1 & (0xFF << 0x10)) >> 0x10,  \
-                    (stub_scratch_1 & (0xFF << 0x18)) >> 0x18,  \
-                    (stub_scratch_1 & (0xFF << 0x20)) >> 0x20,  \
-                    (stub_scratch_1 & (0xFF << 0x28)) >> 0x28,  \
-                    (stub_scratch_1 & (0xFF << 0x30)) >> 0x30,  \
-                    (stub_scratch_1 & (0xFF << 0x38)) >> 0x38;  \
+        REG_AT_ADDR32(0x10 /* %rip */, stub_scratch_1);         \
         pop %rsp;                                               \
         .cfi_def_cfa %rsp, 0;                                   \
         jmp _syscallbuf_final_exit_instruction;                 \

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -42,6 +42,19 @@
                     0x09, /* 9 byte expression follows */       \
                     DW_OP_CONST8U(addr)
 
+// 10 bytes LEB128 is enough to encode 64bit integer and we shouldn't
+// really need anything longer than that.
+#define COUNT_LEB128(lebs...)                                   \
+        _COUNT_LEB128(lebs, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+#define _COUNT_LEB128(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+
+#define REG_AT_REG_OFFSET(reg, base, lebs...)                                   \
+        .cfi_escape 0x10, /* DW_CFA_expression */                               \
+                    reg,                                                        \
+                    (COUNT_LEB128(lebs) + 1), /* 1 byte + LEB128 bytes */       \
+                    (0x70 + base), /* DW_OP_breg0 + base */                     \
+                    lebs
+
 #if defined(__i386__)
 /**
  * Jump to this hook from |__kernel_vsyscall()|, to buffer syscalls that
@@ -455,11 +468,7 @@ _syscallbuf_final_exit_instruction:
             0x02, /* 2 bytes follow */\
             0x77, offset; /* DW_OP_breg7, offset */
 
-#define RIP_IS_DEREF_RSP(offset) \
-.cfi_escape 0x10, /* DW_CFA_expression */\
-            0x10, /* %rip */\
-            0x02, /* 2 bytes follow */\
-            0x77, offset; /* DW_OP_breg7, 0 */
+#define RIP_IS_DEREF_RSP(offset) REG_AT_REG_OFFSET(0x10 /* %rip */, 7, offset)
 
 /**
  * On syscallhook entry, the stack has been switched to the end of per-task


### PR DESCRIPTION
The syscallbuf code itself is fine but the signal handling is still bad... In the mean time, this should make it easier to rebase in the future....

Note that I disabled a compile time error on aarch64 that was just added for `rdtsc_recording_only` since it's not used on non-x86.
