### PR TITLE
Add support for a few more consumer ARM cores

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -92,6 +92,13 @@ enum CpuMicroarch {
   LastAMD = AMDZen,
   FirstARM,
   ARMNeoverseN1 = FirstARM,
+  ARMNeoverseE1,
+  ARMCortexA55,
+  ARMCortexA75,
+  ARMCortexA76,
+  ARMCortexA77,
+  ARMCortexA78,
+  ARMCortexX1,
   AppleM1Icestorm,
   AppleM1Firestorm,
   LastARM = AppleM1Firestorm,
@@ -167,11 +174,34 @@ static const PmuConfig pmu_configs[] = {
   // 0x2c == INTERRUPT_TAKEN - Counts the number of interrupts taken
   // Both counters are available on Zen, Zen+ and Zen2.
   { AMDZen, "AMD Zen", 0x5100d1, 0, 0, 10000, PMU_TICKS_RCB },
+  // Performance cores from ARM from cortex-a76 on (including neoverse-n1)
+  // have the following counters that are reliable enough for us.
   // 0x21 == BR_RETIRED - Architecturally retired taken branches
   // 0x6F == STREX_SPEC - Speculatively executed strex instructions
   // 0x11 == CPU_CYCLES - Cycle
   { ARMNeoverseN1, "ARM Neoverse N1", 0x21, 0, 0x6F, 1000, PMU_TICKS_TAKEN_BRANCHES,
     "armv8_pmuv3_0", 0x11, -1, -1 },
+  { ARMCortexA76, "ARM Cortex A76", 0x21, 0, 0x6F, 10000, PMU_TICKS_TAKEN_BRANCHES,
+    "armv8_pmuv3", 0x11, -1, -1 },
+  { ARMCortexA77, "ARM Cortex A77", 0x21, 0, 0x6F, 10000, PMU_TICKS_TAKEN_BRANCHES,
+    "armv8_pmuv3", 0x11, -1, -1 },
+  { ARMCortexA78, "ARM Cortex A78", 0x21, 0, 0x6F, 10000, PMU_TICKS_TAKEN_BRANCHES,
+    "armv8_pmuv3", 0x11, -1, -1 },
+  { ARMCortexX1, "ARM Cortex X1", 0x21, 0, 0x6F, 10000, PMU_TICKS_TAKEN_BRANCHES,
+    "armv8_pmuv3", 0x11, -1, -1 },
+  // cortex-a55, cortex-a75 and neoverse-e1 counts uarch ISB
+  // as retired branches so the BR_RETIRED counter is not reliable.
+  // There are some counters that are somewhat more reliable than
+  // the total branch count (0x21) including
+  // 0x0D (BR_IMMED_RETIRED) 0x0E (BR_RETURN_RETIRED)
+  // 0xCD (BR_INDIRECT_ADDR_PRED) 0x76 (PC_WRITE_SPEC)
+  // 0x78 (BR_IMMED_SPEC), 0xC9 (BR_COND_PRED)
+  // 0xCD (BR_INDIRECT_ADDR_PRED)
+  // but according to tests on the LITTLE core on a snapdragon 865
+  // none of them (including the sums) seems to be useful/reliable enough.
+  { ARMNeoverseE1, "ARM Neoverse E1", 0, 0, 0, 0, 0 },
+  { ARMCortexA55, "ARM Cortex A55", 0, 0, 0, 0, 0 },
+  { ARMCortexA75, "ARM Cortex A75", 0, 0, 0, 0, 0 },
   { AppleM1Icestorm, "Apple M1 Icestorm", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
     "apple_icestorm_pmu", 0x8c, -1, -1 },
   { AppleM1Firestorm, "Apple M1 Firestorm", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -84,6 +84,11 @@ public:
   static Ticks ticks_for_direct_call(Task*);
 
   /**
+   * Whether PMU on core i is supported.
+   */
+  static bool support_cpu(int cpu);
+
+  /**
    * Read the current value of the ticks counter.
    * `t` is used for debugging purposes.
    */

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -35,8 +35,34 @@ static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
   switch (cpuid.implementer) {
   case 0x41: // ARM
     switch (cpuid.part) {
+    case 0xd05:
+      return ARMCortexA55;
+    case 0xd0a:
+      return ARMCortexA75;
+    case 0xd0b:
+      return ARMCortexA76;
     case 0xd0c:
       return ARMNeoverseN1;
+    case 0xd0d:
+      return ARMCortexA77;
+    case 0xd41:
+      return ARMCortexA78;
+    case 0xd44:
+      return ARMCortexX1;
+    case 0xd4a:
+      return ARMNeoverseE1;
+    }
+    break;
+  case 0x51: // Qualcomm
+    switch (cpuid.part) {
+    case 0x802:
+      return ARMCortexA75;
+    case 0x803:
+      return ARMCortexA55;
+    case 0x804:
+      return ARMCortexA76;
+    case 0x805:
+      return ARMCortexA55;
     }
     break;
   case 0x61: // Apple

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -319,9 +319,27 @@ static void post_init_pmu_uarchs(std::vector<PmuConfig> &pmu_uarchs)
     }
   }
   if (pmu_types.size() == 1 && !has_unknown) {
-    // Single PMU type
-    pmu_uarchs.resize(1);
-  } else if (pmu_type_failed) {
+    bool single_type = true;
+    auto &pmu_uarch0 = pmu_uarchs[0];
+    // Apparently the same PMU type doesn't actually mean the same PMU events...
+    for (auto &pmu_uarch: pmu_uarchs) {
+      if (&pmu_uarch == &pmu_uarch0) {
+        // Skip first
+        continue;
+      }
+      if (pmu_uarch.rcb_cntr_event != pmu_uarch0.rcb_cntr_event ||
+          pmu_uarch.minus_ticks_cntr_event != pmu_uarch0.minus_ticks_cntr_event ||
+          pmu_uarch.llsc_cntr_event != pmu_uarch0.llsc_cntr_event) {
+        single_type = false;
+        break;
+      }
+    }
+    if (single_type) {
+      // Single PMU type
+      pmu_uarchs.resize(1);
+    }
+  }
+  if (pmu_uarchs.size() != 0 && pmu_type_failed) {
     // If reading PMU type failed, we only allow a single PMU type to be sure
     // that we get what we want from the kernel events.
     CLEAN_FATAL() << "Unable to read PMU event types";

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -271,8 +271,13 @@ static void post_init_pmu_uarchs(std::vector<PmuConfig> &pmu_uarchs)
       pmu_uarch.event_type = type;
     }
   };
+  bool has_unknown = false;
   for (size_t i = 0; i < npmus; i++) {
     auto &pmu_uarch = pmu_uarchs[i];
+    if (!(pmu_uarch.flags & (PMU_TICKS_RCB | PMU_TICKS_TAKEN_BRANCHES))) {
+      has_unknown = true;
+      continue;
+    }
     if (!pmu_uarch.pmu_name) {
       CLEAN_FATAL() << "Unknown PMU name for core " << i;
       continue;
@@ -313,7 +318,7 @@ static void post_init_pmu_uarchs(std::vector<PmuConfig> &pmu_uarchs)
       pmu_type = val;
     }
   }
-  if (pmu_types.size() == 1) {
+  if (pmu_types.size() == 1 && !has_unknown) {
     // Single PMU type
     pmu_uarchs.resize(1);
   } else if (pmu_type_failed) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -2007,7 +2007,7 @@ int choose_cpu(BindCPU bind_cpu, ScopedFd &cpu_lock_fd_out) {
   }
   std::vector<int> cpus;
   for (int i = 0; i < CPU_SETSIZE; ++i) {
-    if (CPU_ISSET(i, &affinity_mask)) {
+    if (CPU_ISSET(i, &affinity_mask) && PerfCounters::support_cpu(i)) {
       cpus.push_back(i);
     }
   }


### PR DESCRIPTION
Hardware tested is a snapdragon 865 with cortex-a77 and cortex-a55 (do note that the linaro rb5 kernel has CONFIG_CHECKPOINT_RESTORE disabled so a custom kernel is needed). Other cores added are based on the technical reference manual.

As noted in the comment, I don't think cortex-a55 contains any usable counters so when running on a big.LITTLE system with cortex-a55, we'll only run on the big cores. This shouldn't be a problem from cortex-a510 on anymore (SVE would be a problem though....)

The skid size is based on observation in the test (I saw up to ~3-4000 so I give it twice that to be safe...)

This almost reaches test passing parity as an M1 system. @Keno, do you have your patch for interrupt on the LL/SC counter available somewhere? I'm seeing related failure from the sysconf_conf test here and I assume that might help with debugging...
