### PR TITLE
Handle single step of syscall restart on aarch64

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1522,7 +1522,21 @@ bool RecordSession::signal_state_changed(RecordTask* t, StepState* step_state) {
     case EV_SIGNAL: {
       // This event is used by the replayer to advance to
       // the point of signal delivery.
-      t->record_current_event();
+      if (t->arch() == aarch64 && t->status().is_syscall() &&
+          t->prev_ev() && t->prev_ev()->type() == EV_SYSCALL_INTERRUPTION) {
+        // On aarch64, replaying expects the signal to be delivered before
+        // the syscall instruction but the current pc during recording
+        // is after the syscall instruction with the arg1 clobbered
+        // with the return value (aborted syscall).
+        auto regs = t->regs();
+        auto &syscall_regs = t->prev_ev()->Syscall().regs;
+        regs.set_ip(syscall_regs.ip().decrement_by_syscall_insn_length(t->arch()));
+        regs.set_arg1(syscall_regs.orig_arg1());
+        t->record_event(t->ev(), RecordTask::FLUSH_SYSCALLBUF,
+                        RecordTask::ALLOW_RESET_SYSCALLBUF, &regs);
+      } else {
+        t->record_current_event();
+      }
       t->ev().transform(EV_SIGNAL_DELIVERY);
       ssize_t sigframe_size = 0;
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -3934,6 +3934,12 @@ void Task::move_to_signal_stop()
    * don't want it delivered to the task for real.
    */
   auto old_ip = ip();
+  if (arch() == aarch64 && session().is_recording() && status().is_syscall() &&
+      static_cast<RecordTask*>(this)->at_may_restart_syscall()) {
+    // On aarch64, single step of an aborted syscall
+    // will cause us to move to before the syscall instruction
+    old_ip = old_ip.decrement_by_syscall_insn_length(arch());
+  }
   do {
     resume_execution(RESUME_SINGLESTEP, RESUME_WAIT, RESUME_NO_TICKS);
     ASSERT(this, old_ip == ip())


### PR DESCRIPTION
Single stepping of an aborted syscall will cause us to go back to
right before the syscall instruction on aarch64. Make sure the single step code
can handle this during recording.

Also make sure that the trace records that the signal will also be delivered
before the syscall instruction since the same pc unwinding happens during replay
as well.

I'm 90% sure I understand what's happening in the failed tests that this fixes and I'm reasonably confident that I'm using the right function to check for these conditions.
I'm less sure how this interacts with normal (unpatched) syscalls and what's the best way to fix the issue....
