### PR TITLE
Use PT_INTERP to find the dynamic linker/program interpreter and record that information in the trace, for later use by --serve-files.

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -359,6 +359,12 @@ public:
    */
   const std::string& exe_image() const { return exe; }
 
+  const std::string& interp_name() const { return interp_name_; }
+  void set_interp_name(std::string name) { interp_name_ = name; }
+
+  remote_ptr<void> interp_base() const { return interp_base_; }
+  void set_interp_base(remote_ptr<void> base) { interp_base_ = base; }
+
   /**
    * Assuming the last retired instruction has raised a SIGTRAP
    * and might be a breakpoint trap instruction, return the type
@@ -1080,6 +1086,10 @@ private:
   /* Path of the real executable image this address space was
    * exec()'d with. */
   std::string exe;
+  /* Path of the intepreter, if any, of exe. */
+  std::string interp_name_;
+  /* Base address of the interpeter (might be null!) */
+  remote_ptr<void> interp_base_;
   /* Pid of first task for this address space */
   pid_t leader_tid_;
   /* Serial number of first task for this address space */

--- a/src/ElfReader.h
+++ b/src/ElfReader.h
@@ -101,6 +101,7 @@ public:
   Debuglink read_debuglink();
   Debugaltlink read_debugaltlink();
   std::string read_buildid();
+  std::string read_interp();
   // Returns true and sets file |offset| if ELF address |addr| is mapped from
   // a section in the ELF file.  Returns false if no section maps to
   // |addr|.  |addr| is an address indicated by the ELF file, not its

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -742,6 +742,8 @@ void TraceWriter::write_task_event(const TraceTaskEvent& event) {
         cmd_line.set(i, str_to_data(event_cmd_line[i]));
       }
       exec.setExeBase(event.exe_base().as_int());
+      exec.setInterpBase(event.interp_base().as_int());
+      exec.setInterpName(str_to_data(event.interp_name()));;
       break;
     }
     case TraceTaskEvent::EXIT:
@@ -802,6 +804,8 @@ TraceTaskEvent TraceReader::read_task_event(FrameTime* time) {
         r.cmd_line_[i] = data_to_str(cmd_line[i]);
       }
       r.exe_base_ = exec.getExeBase();
+      r.interp_base_ = exec.getInterpBase();
+      r.interp_name_ = data_to_str(exec.getInterpName());
       break;
     }
     case trace::TaskEvent::Which::EXIT:

--- a/src/TraceTaskEvent.h
+++ b/src/TraceTaskEvent.h
@@ -88,6 +88,23 @@ public:
     DEBUG_ASSERT(type() == EXEC);
     exe_base_ = ptr;
   }
+  // May be zero at any time.
+  remote_ptr<void> interp_base() const {
+    DEBUG_ASSERT(type() == EXEC);
+    return interp_base_;
+  }
+  void set_interp_base(remote_ptr<void> ptr) {
+    DEBUG_ASSERT(type() == EXEC);
+    interp_base_ = ptr;
+  }
+  const std::string& interp_name() const {
+    DEBUG_ASSERT(type() == EXEC);
+    return interp_name_;
+  }
+  void set_interp_name(std::string name) {
+    DEBUG_ASSERT(type() == EXEC);
+    interp_name_ = name;
+  }
   WaitStatus exit_status() const {
     DEBUG_ASSERT(type() == EXIT);
     return exit_status_;
@@ -105,6 +122,8 @@ private:
   std::string file_name_;             // EXEC only
   std::vector<std::string> cmd_line_; // EXEC only
   remote_ptr<void> exe_base_;         // EXEC only
+  remote_ptr<void> interp_base_;      // EXEC only
+  std::string interp_name_;           // EXEC only
   WaitStatus exit_status_;            // EXIT only
 };
 

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -241,6 +241,18 @@ struct WordSize32Defs {
     uint16_t e_shstrndx;
   } ElfEhdr;
   RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf32_Ehdr, ElfEhdr);
+  typedef struct
+  {
+    uint32_t p_type;
+    uint32_t p_offset;
+    uint32_t p_vaddr;
+    uint32_t p_paddr;
+    uint32_t p_filesz;
+    uint32_t p_memsz;
+    uint32_t p_flags;
+    uint32_t p_align;
+  } ElfPhdr;
+  RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf32_Phdr, ElfPhdr);
   typedef struct {
     uint32_t sh_name;
     uint32_t sh_type;
@@ -326,6 +338,18 @@ struct WordSize64Defs {
     uint16_t e_shstrndx;
   } ElfEhdr;
   RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf64_Ehdr, ElfEhdr);
+  typedef struct
+  {
+    uint32_t p_type;
+    uint32_t p_flags;
+    uint64_t p_offset;
+    uint64_t p_vaddr;
+    uint64_t p_paddr;
+    uint64_t p_filesz;
+    uint64_t p_memsz;
+    uint64_t p_align;
+  } ElfPhdr;
+  RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf64_Phdr, ElfPhdr);
   typedef struct {
     uint32_t sh_name;
     uint32_t sh_type;

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -448,6 +448,8 @@ static void process_execve(ReplayTask* t, const TraceFrame& trace_frame,
                                ? kms[exe_km].fsname()
                                : datas[exe_km].file_name;
   t->post_exec_syscall(exe_name, kms[exe_km].fsname());
+  t->vm()->set_interp_base(tte.interp_base());
+  t->vm()->set_interp_name(tte.interp_name());
 
   t->fd_table()->close_after_exec(
       t, t->current_trace_frame().event().Syscall().exec_fds_to_close);

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -196,6 +196,9 @@ struct TaskEvent {
       # Never null (in traces that support the field)
       # Added after 5.0.0
       exeBase @8 :RemotePtr;
+      interpBase @10 :RemotePtr;
+      # Not a Path since it is only meaningful during recording
+      interpName @11 :CString;
     }
     # Most frame 'exit' events generate one of these, but these are not
     # generated if rr ends abnormally so the tasks did not in fact exit during


### PR DESCRIPTION
bionic doesn't use the glibc linker and it doesn't follow the same naming convention. This seemed like a good opportunity to bite the bullet and use PT_INTERP here. This is complicated slightly by the fact that the GdbServer can also be invoked during _recording_ by the emergency debugger if rr asserts. In practice the emergency debugger won't use --serve-files so it shouldn't matter, but it's easy enough to put the interpreter name/base address on AddressSpace, which is the natural place to smuggle this information from the task exec event to GdbServer, in both recording and replay.