### PR TITLE
Use the correct arg1 when checking for syscall restart

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1477,7 +1477,7 @@ bool RecordTask::is_syscall_restart() {
 
   {
     const Registers& old_regs = ev().Syscall().regs;
-    if (!(old_regs.arg1() == regs().arg1() &&
+    if (!(old_regs.orig_arg1() == regs().arg1() &&
           old_regs.arg2() == regs().arg2() &&
           old_regs.arg3() == regs().arg3() &&
           old_regs.arg4() == regs().arg4() &&


### PR DESCRIPTION
Similar to the use of original_syscallno for x86, the arg1 may also be overwrites
at this point when the syscall got interrupted.