### PR TITLE
Fix PMU count check

### DIFF
--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -365,7 +365,7 @@ static void post_init_pmu_uarchs(std::vector<PmuConfig> &pmu_uarchs)
       pmu_uarchs.resize(1);
     }
   }
-  if (pmu_uarchs.size() != 0 && pmu_type_failed) {
+  if (pmu_uarchs.size() != 1 && pmu_type_failed) {
     // If reading PMU type failed, we only allow a single PMU type to be sure
     // that we get what we want from the kernel events.
     CLEAN_FATAL() << "Unable to read PMU event types";


### PR DESCRIPTION
Allow **single** PMU type to use RAW event, not **zero** PMU types...

Typo from #3265

This is related to the current CI failure on aarch64 since it broke the PMU detection on neoverse-n1 when there's no sysfs.

@DilumAluthge @Keno It seems that sysfs isn't available/accessible on CI. I added a command that print out the warning and it seems that the reading of sysfs for CPUID and PMU types both failed. https://buildkite.com/julialang/rr/builds/674#0181787e-8097-44f0-ba1d-349522b98b87/395-2280
