### PR TITLE
Manually make the tgkill syscall in test on aarch64

### DIFF
--- a/src/test/sigrt.c
+++ b/src/test/sigrt.c
@@ -17,7 +17,12 @@ static void handle_sigrt(int sig) {
 
 static void __attribute__((noinline)) my_raise(int sig) {
 /* Don't call raise() directly, since that can go through our syscall hooks
-   which mess up gdb's reverse-finish slightly. */
+   which mess up gdb's reverse-finish slightly.
+   Also, glibc's raise calls __pthread_kill_internal to make the syscall.
+   If the symbol for this cannot be found (as is the case on ArchLinux)
+   gdb's reverse-finish will keep reverse-continuing and hit the signal
+   when we reverse-finishing out of the signal handler.
+*/
 #ifdef __i386__
   int tid = getpid();
   /* Use a special instruction after the syscall to make sure we don't patch
@@ -33,6 +38,15 @@ static void __attribute__((noinline)) my_raise(int sig) {
   __asm__ __volatile__("syscall\n\t"
                        "xchg %%rdx,%%rdx\n\t" ::"a"(SYS_tgkill),
                        "D"(tid), "S"(tid), "d"(sig));
+#elif defined(__aarch64__)
+  int tid = getpid();
+  register long x8 __asm__("x8") = SYS_tgkill;
+  register long x0 __asm__("x0") = (long)tid;
+  register long x1 __asm__("x1") = (long)tid;
+  register long x2 __asm__("x2") = (long)sig;
+  __asm__ volatile("svc #0\n\t"
+                   : "+r"(x0)
+                   : "r"(x1), "r"(x2), "r"(x8));
 #else
   raise(sig);
 #endif


### PR DESCRIPTION
To make sure that the GDB reverse-finish stops properly.

This fixes the reverse_step_signal test.

Wasted an hour tracing through gdb before realizing that the hint is right in the test itself ....................
