### PR TITLE
Be more robust against unexpected exit

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1224,6 +1224,10 @@ sig_set_t RecordTask::read_sigmask_from_process() {
   }
 
   auto results = read_proc_status_fields(tid, "SigBlk");
+  if (results.empty()) {
+    // Read failed, process probably died
+    return 0;
+  }
   ASSERT(this, results.size() == 1);
   return strtoull(results[0].c_str(), NULL, 16);
 }
@@ -1294,6 +1298,10 @@ void RecordTask::verify_signal_states() {
   }
 
   auto results = read_proc_status_fields(tid, "SigBlk", "SigIgn", "SigCgt");
+  if (results.empty()) {
+    // Read failed, process probably died
+    return;
+  }
   ASSERT(this, results.size() == 3);
   sig_set_t blocked = strtoull(results[0].c_str(), NULL, 16);
   sig_set_t ignored = strtoull(results[1].c_str(), NULL, 16);

--- a/src/Task.h
+++ b/src/Task.h
@@ -404,8 +404,10 @@ public:
    * We're currently in user-space with registers set up to perform a system
    * call. Continue into the kernel and stop where we can modify the syscall
    * state.
+   * Return `true` if the syscall entry succeeded.
+   * Return `false` if the tracee exited unexpectedly.
    */
-  void enter_syscall();
+  bool enter_syscall(bool allow_exit=false);
 
   /**
    * We have observed entry to a syscall (either by PTRACE_EVENT_SECCOMP or


### PR DESCRIPTION
Especially in the verifier.

This fixes the intermittent test failure in `unexpected_exit_pid_ns` on aarch64 where previously an unexpected exit is first noticed by the verifier and subsequently asserts in `enter_syscall` since it can't handle exited process. The signal status verifier was also not able to handle this after the memory verification passed.

I didn't check if any the other callers should receive the same treatment but for now I've made this optional and the return value is consistent with that of `exit_syscall`.
