### PR TITLE
Wait for detached nested record to finish before replaying it

### DIFF
--- a/src/test/nested_detach.run
+++ b/src/test/nested_detach.run
@@ -8,5 +8,6 @@ check_record
 # Replay inner
 cd inner
 workdir=$PWD
+wait_for_complete
 replay
 check_replay_token EXIT-SUCCESS

--- a/src/test/nested_detach_kill.run
+++ b/src/test/nested_detach_kill.run
@@ -33,5 +33,6 @@ replay
 # Replay inner
 cd $workdir/inner
 workdir=$PWD
+wait_for_complete
 replay
 check_replay_token $SYNC_TOKEN

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -492,3 +492,11 @@ function checkpoint_test { exe=$1; min=$2; max=$3;
         fi
     done
 }
+
+function wait_for_complete {
+    local record_dir=${1:-"${workdir}/latest-trace"}
+    for ((i = 0; i < TIMEOUT * 10; i++)); do
+        [[ -f "$record_dir/incomplete" ]] || break
+        sleep 0.1
+    done
+}


### PR DESCRIPTION
By waiting for the incomplete file to disappear

This is more likely to happen on asymmetric cores with very different performance.

On my M1 MBA, this happens ~20 times for `nested_detach` in 80 runs of the full test suite. This can also be easily reproduced by adding a sleep in `simple.c` or in `TraceStream.cc` before `incomplete` is renamed to `version`.