### PR TITLE
Fix recording of syscall entry for killed processes on aarch64

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -136,6 +136,13 @@ static bool looks_like_syscall_entry(RecordTask* t) {
     // there.
     return t->regs().original_syscallno() >= 0 &&
            t->regs().syscall_result_signed() == -ENOSYS;
+  } else if (t->arch() == aarch64) {
+    // We recorded when we saw the last syscall entry
+    // so just use that to determine if we've already save it in the trace.
+    if (t->ticks_at_last_syscall_entry == t->tick_count() &&
+        t->ip_at_last_syscall_entry == t->regs().ip()) {
+      return !t->last_syscall_entry_recorded;
+    }
   }
   // Getting a sched event here is better than a spurious syscall event.
   // Syscall entry does not cause visible register modification, so upon

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1870,6 +1870,14 @@ void RecordTask::record_event(const Event& ev, FlushSyscallbuf flush,
   if (ev.is_syscall_event() && ev.Syscall().state == EXITING_SYSCALL) {
     ticks_at_last_recorded_syscall_exit = tick_count();
     ip_at_last_recorded_syscall_exit = registers->ip();
+    if (ticks_at_last_recorded_syscall_exit == ticks_at_last_syscall_entry &&
+        ip_at_last_recorded_syscall_exit == ip_at_last_syscall_entry) {
+      // We've done processing this syscall so we can forget about the entry now
+      // This makes sure that any restarted syscalls would not be treated
+      // as the same entry.
+      ticks_at_last_syscall_entry = 0;
+      ip_at_last_syscall_entry = nullptr;
+    }
   }
 
   remote_code_ptr rseq_new_ip = ip();

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1867,16 +1867,26 @@ void RecordTask::record_event(const Event& ev, FlushSyscallbuf flush,
     }
   }
 
-  if (ev.is_syscall_event() && ev.Syscall().state == EXITING_SYSCALL) {
-    ticks_at_last_recorded_syscall_exit = tick_count();
-    ip_at_last_recorded_syscall_exit = registers->ip();
-    if (ticks_at_last_recorded_syscall_exit == ticks_at_last_syscall_entry &&
-        ip_at_last_recorded_syscall_exit == ip_at_last_syscall_entry) {
-      // We've done processing this syscall so we can forget about the entry now
-      // This makes sure that any restarted syscalls would not be treated
-      // as the same entry.
-      ticks_at_last_syscall_entry = 0;
-      ip_at_last_syscall_entry = nullptr;
+  if (ev.is_syscall_event()) {
+    auto state = ev.Syscall().state;
+    if (state == EXITING_SYSCALL) {
+      ticks_at_last_recorded_syscall_exit = tick_count();
+      ip_at_last_recorded_syscall_exit = registers->ip();
+      if (ticks_at_last_recorded_syscall_exit == ticks_at_last_syscall_entry &&
+          ip_at_last_recorded_syscall_exit == ip_at_last_syscall_entry) {
+        // We've done processing this syscall so we can forget about the entry now
+        // This makes sure that any restarted syscalls would not be treated
+        // as the same entry.
+        ticks_at_last_syscall_entry = 0;
+        ip_at_last_syscall_entry = nullptr;
+        last_syscall_entry_recorded = false;
+      }
+    } else if (state == ENTERING_SYSCALL || state == ENTERING_SYSCALL_PTRACE) {
+      if (tick_count() == ticks_at_last_syscall_entry &&
+          registers->ip() == ip_at_last_syscall_entry) {
+        // Let the process handler know that we've recorded the entry already
+        last_syscall_entry_recorded = true;
+      }
     }
   }
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -78,6 +78,7 @@ Task::Task(Session& session, pid_t _tid, pid_t _rec_tid, uint32_t serial,
       syscallbuf_size(0),
       ticks_at_last_syscall_entry(0),
       ip_at_last_syscall_entry(nullptr),
+      last_syscall_entry_recorded(false),
       serial(serial),
       prname("???"),
       ticks(0),
@@ -3928,6 +3929,7 @@ void Task::apply_syscall_entry_regs()
     // of the ptrace state tracked by that flag.
     ticks_at_last_syscall_entry = tick_count();
     ip_at_last_syscall_entry = registers.ip();
+    last_syscall_entry_recorded = false;
   }
 }
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -76,6 +76,8 @@ Task::Task(Session& session, pid_t _tid, pid_t _rec_tid, uint32_t serial,
       rec_tid(_rec_tid > 0 ? _rec_tid : _tid),
       own_namespace_rec_tid(_rec_tid > 0 ? _rec_tid: _tid),
       syscallbuf_size(0),
+      ticks_at_last_syscall_entry(0),
+      ip_at_last_syscall_entry(nullptr),
       serial(serial),
       prname("???"),
       ticks(0),
@@ -3924,6 +3926,8 @@ void Task::apply_syscall_entry_regs()
     registers.set_orig_arg1(registers.arg1());
     // Don't update registers_dirty here, because these registers are not part
     // of the ptrace state tracked by that flag.
+    ticks_at_last_syscall_entry = tick_count();
+    ip_at_last_syscall_entry = registers.ip();
   }
 }
 

--- a/src/Task.h
+++ b/src/Task.h
@@ -1027,6 +1027,10 @@ public:
   // Used on aarch64 to detect whether we've recorded x0 and x8 on syscall entry
   Ticks ticks_at_last_syscall_entry;
   remote_code_ptr ip_at_last_syscall_entry;
+  // Whether the syscall entry corresponding to `{ticks,ip}_at_last_syscall_entry`
+  // has been recorded in the trace
+  // (used to avoid double recording on unexpected exit)
+  bool last_syscall_entry_recorded;
 
 protected:
   Task(Session& session, pid_t tid, pid_t rec_tid, uint32_t serial,

--- a/src/Task.h
+++ b/src/Task.h
@@ -1024,6 +1024,10 @@ public:
    */
   void forget();
 
+  // Used on aarch64 to detect whether we've recorded x0 and x8 on syscall entry
+  Ticks ticks_at_last_syscall_entry;
+  remote_code_ptr ip_at_last_syscall_entry;
+
 protected:
   Task(Session& session, pid_t tid, pid_t rec_tid, uint32_t serial,
        SupportedArch a);


### PR DESCRIPTION
There are a few related issues being fixed here. Fixing some of these exposes other ones so I'm putting them in the same PR. I've got a few complete test pass on both M1 and Cortex-A77 with this so I think this is reasonably complete. The issues that I've seen includes,

1. Recording of completed untraced syscall.

    We had no way to recover original x0 value AFAICT and the replay isn't happy about this. Fix by just ignoring any untraced syscalls.

2. Getting killed after the syscall is already started but before we got a syscall exit stop.

    Make sure `orig_x0` is always updated and use that for `x0` in the record.

3. In `ptrace_singlestep` test, we were recording two entry of the same syscall, which I assume is related to ptrace/SIGCHLD handling

    Add a check to see if the entry is already recorded and skip it during the process exit.
