### PR TITLE
Increase timeout for record_replay test

### DIFF
--- a/src/test/record_replay.run
+++ b/src/test/record_replay.run
@@ -1,5 +1,5 @@
 source `dirname $0`/util.sh
-if [ $TIMEOUT -lt 300 ]; then TIMEOUT=300; fi
+if [ $TIMEOUT -lt 600 ]; then TIMEOUT=600; fi
 record record_replay_subject$bitness
 just_record rr "--suppress-environment-warnings replay -a $workdir/*-0"
 replay


### PR DESCRIPTION
This is getting very close to timeout on the M1 E core (>250s)
when running alone and sometimes actually time out in parallel test run.