### PR TITLE
Tweak syscall PC check on aarch64 in signal stop

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -342,7 +342,14 @@ public:
    * instruction.
    */
   bool is_in_untraced_syscall() {
-    auto t = AddressSpace::rr_page_syscall_from_exit_point(arch(), ip());
+    const AddressSpace::SyscallType *t;
+    if (arch() == aarch64 && stop_sig() > 0) {
+      // On aarch64 we can't distinguish untraced syscall entry and exit
+      // when a signal happened
+      t = AddressSpace::rr_page_syscall_from_entry_point(arch(), ip());
+    } else {
+      t = AddressSpace::rr_page_syscall_from_exit_point(arch(), ip());
+    }
     return t && t->traced == AddressSpace::UNTRACED;
   }
 


### PR DESCRIPTION
Also add comment about the slightly different logic used on aarch64 in is_safe_to_deliver_signal.

Went back and forth on the correct check for this a few time and the final version is actually quite clean... With the test pass after #3293 I'm fairly confident about this logic now.