### PR TITLE
Add a fallback implementation of pidof for the aarch64 CI

### DIFF
--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -20,6 +20,12 @@
 # scheduler, don't use it for anything else.
 #
 
+if ! which pidof &> /dev/null; then
+    pidof() {
+        ps ax -o 'pid= exe=' | grep ' \(\|.*/\)'"$1"'$' | awk '{print $1}'
+    }
+fi
+
 #  delay_kill <sig> <delay_secs> <proc>
 #
 # Deliver the signal |sig|, after waiting |delay_secs| seconds, to the


### PR DESCRIPTION
From a quick test https://buildkite.com/julialang/rr/builds/724#0181ad32-977e-4124-b5df-5eb17b7c122a/362-368 it seems that the file `pidof` is available on the file system and it is in the PATH. It is in fact a symlink to `/sbin/killall5` which agrees with the content of the package I downloaded and is probably just a arg0 trick. However, it seems that `/sbin` does not contain `killall5` which is why the command cannot be found.

This can probably be fixed properly on the CI. In the mean time, this version should work well enough to get the relevant tests to pass.
