### PR TITLE
Add a command line option to override interactivity detection

### DIFF
--- a/src/Flags.h
+++ b/src/Flags.h
@@ -40,6 +40,11 @@ struct Flags {
   // doesn't seem to be a tty.
   bool force_things;
 
+  // Force rr to assume that the terminal is non-interactive, disabling e.g.
+  // the interactive emergency debugger. If used with --force-things, this
+  // option prevails.
+  bool non_interactive;
+
   /* Mark the trace global time along with tracee writes to
    * stdio. */
   bool mark_stdio;

--- a/src/main.cc
+++ b/src/main.cc
@@ -127,6 +127,7 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 1, "disable-ptrace-exit-events", NO_PARAMETER },
     { 2, "resource-path", HAS_PARAMETER },
     { 3, "log", HAS_PARAMETER },
+    { 4, "non-interactive", NO_PARAMETER },
     { 'A', "microarch", HAS_PARAMETER },
     { 'C', "checksum", HAS_PARAMETER },
     { 'D', "dump-on", HAS_PARAMETER },
@@ -161,6 +162,9 @@ bool parse_global_option(std::vector<std::string>& args) {
       break;
     case 3:
       apply_log_spec(opt.value.c_str());
+      break;
+    case 4:
+      flags.non_interactive = true;
       break;
     case 'A':
       flags.forced_uarch = opt.value;

--- a/src/util.cc
+++ b/src/util.cc
@@ -196,6 +196,9 @@ static bool is_start_of_scratch_region(Task* t, remote_ptr<void> start_addr) {
 }
 
 bool probably_not_interactive(int fd) {
+  if (Flags::get().non_interactive) {
+    return true;
+  }
   /* Eminently tunable heuristic, but this is guaranteed to be
    * true during rr unit tests, where we care most about this
    * check (to a first degree).  A failing test shouldn't


### PR DESCRIPTION
This was requested by the Julia CI team for situations where rr
itself crashes on Julia CI. The CI system uses a pty, so rr thinks
the terminal is interactive, but in reality it isn't, so this causes
the build to time our rather than triggering the usual failure handling.

cc @staticfloat @DilumAluthge 