### PR TITLE
Use break_status rather than replay event in stop filter

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1379,15 +1379,14 @@ GdbServer::ContinueOrStop GdbServer::debug_one_step(
     // if tids get reused.
     RunCommand command = compute_run_command_for_reverse_exec(
         timeline.current_session(), debuggee_tguid, req, allowed_tasks);
-    auto stop_filter = [&](ReplayTask* t) -> bool {
+    auto stop_filter = [&](ReplayTask* t, const BreakStatus &break_status) -> bool {
       if (t->thread_group()->tguid() != debuggee_tguid) {
         return false;
       }
 
       // don't stop for a signal that has been specified by QPassSignal
-      Event const& stop_event = t->current_trace_frame().event();
-      if (stop_event.is_signal_event() && dbg->is_pass_signal(stop_event.Signal().siginfo.si_signo)) {
-        LOG(debug) << "Filtering out event for signal " << stop_event.Signal().siginfo;
+      if (break_status.signal && dbg->is_pass_signal(break_status.signal->si_signo)) {
+        LOG(debug) << "Filtering out event for signal " << break_status.signal->si_signo;
         return false;
       }
 

--- a/src/ReplayTimeline.h
+++ b/src/ReplayTimeline.h
@@ -212,11 +212,11 @@ public:
   ReplayResult replay_step_forward(RunCommand command);
 
   ReplayResult reverse_continue(
-      const std::function<bool(ReplayTask* t)>& stop_filter,
+      const std::function<bool(ReplayTask* t, const BreakStatus &)>& stop_filter,
       const std::function<bool()>& interrupt_check);
   ReplayResult reverse_singlestep(
       const TaskUid& tuid, Ticks tuid_ticks,
-      const std::function<bool(ReplayTask* t)>& stop_filter,
+      const std::function<bool(ReplayTask* t, const BreakStatus &)>& stop_filter,
       const std::function<bool()>& interrupt_check);
 
   /**
@@ -425,7 +425,7 @@ private:
                                       const ReplayResult& result);
   ReplayResult reverse_singlestep(
       const Mark& origin, const TaskUid& step_tuid, Ticks step_ticks,
-      const std::function<bool(ReplayTask* t)>& stop_filter,
+      const std::function<bool(ReplayTask* t, const BreakStatus &)>& stop_filter,
       const std::function<bool()>& interrupt_check);
 
   // Reasonably fast since it just relies on checking the mark map.


### PR DESCRIPTION
The current event might be a syscallbuf reset if the syscallbuf
is enabled. What we're really interested in is what kind of signal
we're about to report to GDB, which can be found in break_status,
so pass that to stop_filter instead.

Fixes gdb_qpasssignals on aarch64 CI.