### PR TITLE
Try fixing early_error test

### DIFF
--- a/src/test/early_error.c
+++ b/src/test/early_error.c
@@ -11,17 +11,17 @@ int main(int argc, char *argv[]) {
     { BPF_JMP | BPF_JEQ | BPF_K, 0, 4, AUDIT_ARCH_I386 },
     // i386
     { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, nr) },
-    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 172 /* __NR32_prctl */ },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 37 /* __NR32_kill */ },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_TRAP },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_ALLOW },
     // x86_64
     { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, nr) },
-    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 157 /* __NR_prctl */ },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 62 /* __NR_kill */ },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_TRAP },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_ALLOW }
 #else
     { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, nr) },
-    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, SYS_prctl },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, SYS_kill },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_TRAP },
     { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_ALLOW }
 #endif


### PR DESCRIPTION
On x86, the syscall we expect to veto here is the prctl that sets
PR_SET_TSC (and thus happens before the SIGSTOP that indicates
completion of the intial setup code). However, on aarch64 this
prctl doesn't exist. Depending on ordering of events, we
somtimes see the subsequent prctl which sets up the seccomp
filter and that happens to make the test work, but this is
unreliable and can lead to a weird situation where that prctl
got veto'd and thus rr's usual seccomp filter never got installed,
confusing rr down the line.

Fix all of that by switching the veto'd syscall to be the kill(SIGSTOP)
instead, which is present on all architectures.