### PR TITLE
Wait for detached processes again

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2459,7 +2459,7 @@ RecordSession::RecordSession(const std::string& exe_path,
 RecordSession::RecordResult RecordSession::record_step() {
   RecordResult result;
 
-  if (task_map.size() == detached_task_map.size()) {
+  if (task_map.empty()) {
     result.status = STEP_EXITED;
     result.exit_status = initial_thread_group->exit_status;
     return result;


### PR DESCRIPTION
I changed this in #3019, but I'm not sure why. The commit message doesn't make a mention of it
and the test passes without. I also don't see why the new code would have affected the task_map,
so this is definitely just a behavior change. Let's undo this and if something breaks downstream,
let's make sure to add a test for it, but in the meantime, this fixes #3310 (I believe).