### PR TITLE
More robustness for process dying before set_sigmask

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -141,7 +141,8 @@ AutoRemoteSyscalls::AutoRemoteSyscalls(Task* t,
       sigmask_to_restore = rt->get_sigmask();
       sig_set_t all_blocked;
       memset(&all_blocked, 0xff, sizeof(all_blocked));
-      rt->set_sigmask(all_blocked);
+      // Ignore the process dying here - we'll notice later.
+      (void)rt->set_sigmask(all_blocked);
     }
   }
 }

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2052,7 +2052,7 @@ bool RecordSession::prepare_to_inject_signal(RecordTask* t,
     // Our synthesized deterministic SIGSYS (seccomp trap) needs to match the
     // kernel behavior of unblocking the signal and resetting disposition to
     // default.
-    t->unblock_signal(SIGSYS);
+    (void)t->unblock_signal(SIGSYS);
     t->set_sig_handler_default(SIGSYS);
   }
   switch (handle_signal(t, &si.linux_api, sig->deterministic, SIG_UNBLOCKED)) {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -77,7 +77,7 @@ public:
   virtual void post_wait_clone(Task* cloned_from, int flags) override;
   virtual void on_syscall_exit(int syscallno, SupportedArch arch,
                                const Registers& regs) override;
-  virtual void will_resume_execution(ResumeRequest, WaitRequest, TicksRequest,
+  virtual bool will_resume_execution(ResumeRequest, WaitRequest, TicksRequest,
                                      int /*sig*/) override;
   virtual void did_wait() override;
 
@@ -563,8 +563,9 @@ public:
   sig_set_t read_sigmask_from_process();
   /**
    * Unblock the signal for the process.
+   * Returns `false` if the process died underneath us.
    */
-  void unblock_signal(int sig);
+  bool unblock_signal(int sig);
   /**
    * Set the signal handler to default for the process.
    */
@@ -615,7 +616,7 @@ public:
    */
   void send_synthetic_SIGCHLD_if_necessary();
 
-  void set_sigmask(sig_set_t mask);
+  bool set_sigmask(sig_set_t mask);
 
 private:
   /* Retrieve the tid of this task from the tracee and store it */

--- a/src/Task.h
+++ b/src/Task.h
@@ -384,9 +384,11 @@ public:
 
   /**
    * Hook called by `resume_execution`.
+   * Returns `false` if the task is in the process of dying and setup could not
+   * be completed, `true` otherwise.
    */
-  virtual void will_resume_execution(ResumeRequest, WaitRequest, TicksRequest,
-                                     int /*sig*/) {}
+  virtual bool will_resume_execution(ResumeRequest, WaitRequest, TicksRequest,
+                                     int /*sig*/) { return true; }
   /**
    * Hook called by `did_waitpid`.
    */


### PR DESCRIPTION
What appears to be happening in #3312 is that the daemon child is
being killed at the end of the recording session, but we don't
notice until a `set_sigmask` we're performing because the child
has stashed signals. In theory there isn't really anything problematic
with the child dying here, so just improve the robustness of set_sigmask
against this occurrence, which should hopefully fix #3312.