### PR TITLE
Fix compiler-dependent failure of step_rdtsc test

### DIFF
--- a/src/test/x86/rdtsc.c
+++ b/src/test/x86/rdtsc.c
@@ -11,7 +11,7 @@ static uint64_t my_rdtsc(void) {
   uint32_t low;
   uint32_t high;
   /* Make sure this doesn't get buffered */
-  asm ("rdtsc; xchg %%edx,%%edx" : "=a"(low), "=d"(high));
+  asm ("rdtsc_instruction: rdtsc; xchg %%edx,%%edx" : "=a"(low), "=d"(high));
   return ((uint64_t)high << 32) + low;
 }
 

--- a/src/test/x86/step_rdtsc.py
+++ b/src/test/x86/step_rdtsc.py
@@ -1,8 +1,8 @@
 import re
 from util import *
 
-send_gdb('b my_rdtsc')
-expect_gdb('Breakpoint 1')
+send_gdb('hbreak *rdtsc_instruction')
+expect_gdb('breakpoint 1')
 
 send_gdb('c')
 expect_gdb('Breakpoint 1')


### PR DESCRIPTION
The test was depending on gdb setting the breakpoint for the my_rdtsc
function at the first non-prologue instruction (and expecting that to
be the rdtsc). However, some compilers emit DWARF info that causes
gdb to set a breakpoint at the first instruction of the prologue
instead. Work around that by setting a label in the place we want
and using that for the breakpoints.

Fixes a locally observed failure.