### PR TITLE
Fix syscallbuf for getsockopt

### DIFF
--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -3238,14 +3238,14 @@ static long sys_getsockopt(struct syscall_info* call) {
 
   assert(syscallno == call->no);
 
+  if (!start_commit_buffered_syscall(syscallno, ptr, MAY_BLOCK)) {
+    return traced_raw_syscall(call);
+  }
+
   memcpy_input_parameter(optlen2, optlen, sizeof(*optlen2));
   // Some variance of getsockopt does use the initial content of *optval
   // (e.g. SOL_IP + IPT_SO_GET_INFO) so we need to copy it.
   memcpy_input_parameter(optval2, optval, *optlen);
-
-  if (!start_commit_buffered_syscall(syscallno, ptr, MAY_BLOCK)) {
-    return traced_raw_syscall(call);
-  }
 
   // We may need to manually restart this syscall due to kernel bug
   // returning a EFAULT when interrupted by signal and we won't have

--- a/src/test/sock_names_opts.c
+++ b/src/test/sock_names_opts.c
@@ -74,6 +74,13 @@ int main(void) {
 
   unlink(addr.sun_path);
 
+  // Make sure the syscallbuf doesn't crash on an invalid fd
+  int procfd = open("/proc/self/mem", O_RDONLY);
+  test_assert(procfd >= 0);
+  test_assert(-1 == getsockopt(procfd, SOL_SOCKET, SO_PASSCRED, &got_opt,
+                               &got_opt_len));
+  test_assert(errno == ENOTSOCK);
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }


### PR DESCRIPTION
The syscallbuf would crash if `ptr` was NULL, e.g. because the fd
was traced by a file monitor. Fix that by moving the input memcpy
to the correct place and add a simple test.