### PR TITLE
Force enable TSan support with a flag

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -97,6 +97,8 @@ RecordCommand RecordCommand::singleton(
     "  --stap-sdt                 Enables the use of SystemTap statically-\n"
     "                             defined tracepoints\n"
     "  --asan                     Override heuristics and always enable ASAN\n"
+    "                             compatibility.\n"
+    "  --tsan                     Override heuristics and always enable TSAN\n"
     "                             compatibility.\n");
 
 struct RecordFlags {
@@ -174,6 +176,9 @@ struct RecordFlags {
   /* True if we should always enable ASAN compatibility. */
   bool asan;
 
+  /* True if we should always enable TSAN compatibility. */
+  bool tsan;
+
   RecordFlags()
       : max_ticks(Scheduler::DEFAULT_MAX_TICKS),
         ignore_sig(0),
@@ -196,7 +201,8 @@ struct RecordFlags {
         syscallbuf_desched_sig(SYSCALLBUF_DEFAULT_DESCHED_SIGNAL),
         stap_sdt(false),
         unmap_vdso(false),
-        asan(false) {}
+        asan(false),
+        tsan(false) {}
 };
 
 static void parse_signal_name(ParsedOption& opt) {
@@ -257,6 +263,7 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
     { 15, "unmap-vdso", NO_PARAMETER },
     { 16, "disable-avx-512", NO_PARAMETER },
     { 17, "asan", NO_PARAMETER },
+    { 18, "tsan", NO_PARAMETER },
     { 'c', "num-cpu-ticks", HAS_PARAMETER },
     { 'h', "chaos", NO_PARAMETER },
     { 'i', "ignore-signal", HAS_PARAMETER },
@@ -467,6 +474,9 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
     case 17:
       flags.asan = true;
       break;
+    case 18:
+      flags.tsan = true;
+      break;
     case 's':
       flags.always_switch = true;
       break;
@@ -646,7 +656,7 @@ static WaitStatus record(const vector<string>& args, const RecordFlags& flags) {
       flags.use_syscall_buffer, flags.syscallbuf_desched_sig,
       flags.bind_cpu, flags.output_trace_dir,
       flags.trace_id.get(),
-      flags.stap_sdt, flags.unmap_vdso, flags.asan);
+      flags.stap_sdt, flags.unmap_vdso, flags.asan, flags.tsan);
   setup_session_from_flags(*session, flags);
 
   static_session = session.get();

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2274,7 +2274,8 @@ static string lookup_by_path(const string& name) {
     const TraceUuid* trace_id,
     bool use_audit,
     bool unmap_vdso,
-    bool force_asan_active) {
+    bool force_asan_active,
+    bool force_tsan_active) {
   // The syscallbuf library interposes some critical
   // external symbols like XShmQueryExtension(), so we
   // preload it whether or not syscallbuf is enabled. Indicate here whether
@@ -2330,8 +2331,12 @@ static string lookup_by_path(const string& name) {
     CLEAN_FATAL() << "Provided tracee '" << argv[0] << "' is a directory, not an executable";
   }
   ExeInfo exe_info = read_exe_info(full_path);
-  if (force_asan_active && exe_info.sanitizer_exclude_memory_ranges.empty()) {
-    exe_info.setup_asan_memory_ranges();
+  if (exe_info.sanitizer_exclude_memory_ranges.empty()) {
+    if (force_asan_active) {
+      exe_info.setup_asan_memory_ranges();
+    } else if (force_tsan_active) {
+      exe_info.setup_tsan_memory_ranges();
+    }
   }
 
   // Strip any LD_PRELOAD that an outer rr may have inserted

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -70,7 +70,8 @@ public:
       const TraceUuid* trace_id = nullptr,
       bool use_audit = false,
       bool unmap_vdso = false,
-      bool force_asan_active = false);
+      bool force_asan_active = false,
+      bool force_tsan_active = false);
 
   const DisableCPUIDFeatures& disable_cpuid_features() const {
     return disable_cpuid_features_;


### PR DESCRIPTION
Following up the discussion from #3296, this is a less intrusive approach to force enable TSan.