### PR TITLE
fix compile with old glibc

### DIFF
--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -4,9 +4,6 @@
 
 static int num_signals_caught;
 
-#define tgkill(tgid, tid, sig) \
-  syscall(SYS_tgkill, (int)(tgid), (int)(tid), (int)(sig))
-
 static void sighandler(int sig) {
   atomic_printf("Task %d got signal %d\n", sys_gettid(), sig);
   ++num_signals_caught;

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -388,6 +388,9 @@ inline static SyscallWrapper get_spurious_desched_syscall(void) {
       (SyscallWrapper)dlsym(RTLD_DEFAULT, "spurious_desched_syscall");
   return ret ? ret : default_syscall_wrapper;
 }
+/* Old systems don't have these functions, re-define using the syscall */
+#define tgkill(tgid, tid, sig) \
+  syscall(SYS_tgkill, (int)(tgid), (int)(tid), (int)(sig))
 
 #define ALLOCATE_GUARD(p, v) p = allocate_guard(sizeof(*p), v)
 #define VERIFY_GUARD(p) verify_guard(sizeof(*p), p)


### PR DESCRIPTION
applying 7044c5c6a8e64c737ba3cdb97187ff5c406e5162 to this file to not call the system function which is only available in newer glibc, but to always use the syscall instead

that file did not compile with

> g++ (GCC) 8.3.1 20191121 (Red Hat 8.3.1-5)
> GNU C Library (GNU libc) stable release version 2.28.

bailing out with

~~~
./rr/src/test/futex_restart_clone.c: In function 'child':
./rr/src/test/futex_restart_clone.c:23:3: error: implicit declaration of function 'tgkill'; did you mean 'kill'? [-Werror=implicit-function-declaration]
   tgkill(parent_tid, parent_tid, SIGUSR1);
   ^~~~~~
   kill
~~~

before, but does afterwards.