### PR TITLE
Fix build failure on Android

### DIFF
--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -418,7 +418,7 @@ struct rrcall_init_preload_params {
   int syscallbuf_enabled;
   int syscall_patch_hook_count;
   PTR(struct syscall_patch_hook) syscall_patch_hooks;
-  PTR(void) __unused;
+  PTR(void) unused;
   PTR(void) syscallbuf_code_start;
   PTR(void) syscallbuf_code_end;
   PTR(void) get_pc_thunks_start;


### PR DESCRIPTION
The Android NDK contains `#define __unused __attribute__((__unused__))`
in `sys/cdefs.h`, so it can't be used as an identifier.