### PR TITLE
Fix build on older libcs

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -270,7 +270,6 @@ struct WordSize32Defs {
     uint32_t ch_size;
     uint32_t ch_addralign;
   } ElfChdr;
-  RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf32_Chdr, ElfChdr);
   typedef struct {
     uint32_t st_name;
     uint32_t st_value;
@@ -367,7 +366,6 @@ struct WordSize64Defs {
     uint64_t ch_size;
     uint64_t ch_addralign;
   } ElfChdr;
-  RR_VERIFY_TYPE_ARCH(RR_NATIVE_ARCH, ::Elf64_Chdr, ElfChdr);
   typedef struct {
     uint32_t st_name;
     uint8_t st_info;

--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -478,6 +478,17 @@ enum {
 #define PR_SET_VMA_ANON_NAME 0
 #endif
 
+// Technically not "kernel" constants, exactly, since these are defined
+// in libc, but required for compat with older libcs like the rest of
+// this file.
+#ifndef SHF_COMPRESSED
+#define SHF_COMPRESSED (1 << 11)
+#endif
+
+#ifndef ELFCOMPRESS_ZLIB
+#define ELFCOMPRESS_ZLIB 1
+#endif
+
 } // namespace rr
 
 // We can't include libc's ptrace.h, so declare this here.


### PR DESCRIPTION
Older libcs may lack references to compressed ELF sections. Add
the requisite constants and skip verification for structs that
may not be defined.