### PR TITLE
Raise the skid count on Alder Lake slightly.

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -154,7 +154,7 @@ struct PmuConfig {
 // See Intel 64 and IA32 Architectures Performance Monitoring Events.
 // See check_events from libpfm4.
 static const PmuConfig pmu_configs[] = {
-  { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },
+  { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRocketlake, "Intel Rocketlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },
   { IntelTigerlake, "Intel Tigerlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },
   { IntelIcelake, "Intel Icelake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },


### PR DESCRIPTION
Empirical testing shows this is necessary on an i9-12900K.