### PR TITLE
Add support for Rembrandt (Zen 3+)

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -102,6 +102,7 @@ static CpuMicroarch compute_cpu_microarch() {
       break;
     case 0x20f10: // Vermeer (Zen 3)
     case 0x50f00: // Cezanne (Zen 3)
+    case 0x40f40: // Rembrandt (Zen 3+)
       if (ext_family == 0xa) {
         return AMDZen;
       }


### PR DESCRIPTION
This small PR allows me to run `rr` on a very new Ryzen 6000 series Laptop -- specifically Ryzen 6800U.  

I, of course, needed to follow [tips](https://github.com/rr-debugger/rr/wiki/Zen) in the wiki to disable the SpecLockMap interfering optimization. FYI I had 27 test failures. I'll open a separate issue on those.

BTW, I've assumed that `cpu_type == 0x40f40` represents Rembrandt in the PR. It's quite possible there are other `cpu_types` which also represent Rembrandt -- in which case future PRs can correct the C++ comment that I added. 