### PR TITLE
rm unused globals.pretend_num_cores

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -394,11 +394,6 @@ template <typename Arch> static void do_preload_init_arch(RecordTask* t) {
   t->write_mem(in_chaos_ptr, in_chaos);
   t->record_local(in_chaos_ptr, &in_chaos);
 
-  int cores = t->session().scheduler().pretend_num_cores();
-  auto cores_ptr = REMOTE_PTR_FIELD(params.globals.rptr(), pretend_num_cores);
-  t->write_mem(cores_ptr, cores);
-  t->record_local(cores_ptr, &cores);
-
   auto desched_sig = t->session().syscallbuf_desched_sig();
   auto desched_sig_ptr = REMOTE_PTR_FIELD(params.globals.rptr(), desched_sig);
   t->write_mem(desched_sig_ptr, desched_sig);

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -245,9 +245,8 @@ struct preload_globals {
   unsigned char in_chaos;
   /* The signal to use for desched events */
   unsigned char desched_sig;
-  /* Number of cores to pretend we have. 0 means 1. rr sets this when
-   * the preload library is initialized. */
-  int pretend_num_cores;
+  /* RESERVED */
+  int reserved;
   /**
    * Set by rr.
    * For each fd, indicate a class that is valid for all fds with the given


### PR DESCRIPTION
This used to be used in the interception of _SC_NPROCESSORS_{CONF, ONLN}.
However, we are no longer intercepting these queries. Instead, we are
emulating the underlying OS featuers that glibc reads these values from.
As a result, the `globals.pretend_num_cores` field is no longer used.
Remove it for cleanup. Note that there is no corresponding replay
code for this field, so no compatibility code is required.