### PR TITLE
Fix madvise fracture during replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1398,6 +1398,7 @@ set(TESTS_WITH_PROGRAM
   jit_proc_mem
   link
   madvise_dontfork
+  madvise_fracture_flags
   main_thread_exit
   many_yields
   mmap_fd_reuse_checkpoint

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1690,6 +1690,8 @@ AddressSpace::AddressSpace(Session* session, const AddressSpace& o,
       mem(o.mem),
       shm_sizes(o.shm_sizes),
       monitored_mem(o.monitored_mem),
+      dont_fork(o.dont_fork),
+      wipe_on_fork(o.wipe_on_fork),
       session_(session),
       vdso_start_addr(o.vdso_start_addr),
       monkeypatch_state(o.monkeypatch_state

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1200,6 +1200,22 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
         case MADV_DONTNEED:
         case MADV_REMOVE:
           break;
+        /* These are not technically required to be passed through, but the
+           syscallbuf code does, so if we don't here, we risk fracturing
+           otherwise coelescable memory regions. Asan in particular triggers
+           a pathological case here that quickly exhausts the total mapping
+           limit by fracturing its shadow region */
+        case MADV_NORMAL:
+        case MADV_RANDOM:
+        case MADV_SEQUENTIAL:
+        case MADV_WILLNEED:
+        case MADV_MERGEABLE:
+        case MADV_UNMERGEABLE:
+        case MADV_HUGEPAGE:
+        case MADV_NOHUGEPAGE:
+        case MADV_DONTDUMP:
+        case MADV_DODUMP:
+          break;
         default:
           return;
       }

--- a/src/test/madvise_fracture_flags.c
+++ b/src/test/madvise_fracture_flags.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+#define FILL_REGION_SIZE 2ULL*1024ULL*1024ULL*1024ULL // 2 GiB
+#define PROBE_REGION_SIZE 200*1024ULL*1024ULL // 200 MiB
+
+int main(__attribute__((unused)) int argc, __attribute__((unused)) char** argv) {
+    FILE *f = fopen("/proc/sys/vm/max_map_count", "r");
+    test_assert(f != NULL);
+
+    size_t max_map_count;
+    int ret = fscanf(f, "%zu", &max_map_count);
+    test_assert(ret == 1);
+
+    if (max_map_count > 100000) {
+        atomic_puts("Skipping test: max_map_count is too high - test would take too long");
+        atomic_puts("EXIT-SUCCESS");
+        return 77;
+    }
+
+    // Prepare the fill region - we will fill this with a number of mappings close to the
+    // maximum. We allow about a 256 mapping gap for rr's and the executable's mappings.
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    size_t target_fill_mappings = max_map_count - 256;
+    size_t fill_region_size = page_size * target_fill_mappings;
+    char *fill_map = mmap(NULL, fill_region_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    test_assert(fill_map != MAP_FAILED);
+    for (size_t off = 0; off < fill_region_size; off += 2*page_size) {
+        // Fracture the fill region into individual page-sized mappings.
+        char *page = fill_map + off;
+        test_assert(mprotect(page, page_size, PROT_READ) == 0);
+    }
+
+    // Now allocate the probe region
+    char *probe_map = mmap(NULL, PROBE_REGION_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    test_assert(probe_map != MAP_FAILED);
+    ret = madvise(probe_map, PROBE_REGION_SIZE, MADV_HUGEPAGE);
+    test_assert(ret == 0);
+    ret = madvise(probe_map, PROBE_REGION_SIZE, MADV_DONTDUMP);
+    test_assert(ret == 0);
+
+    // Now go through and re-map this mapping one page at a time, re-applying
+    // the flags as we go. If rr is inconsistent about applying the flags
+    // during replay, we will exceed the limit on the total number of mappings
+    // and crash during replay.
+    for (size_t off = 0; off < PROBE_REGION_SIZE; off += page_size) {
+        char *map_target = probe_map + off;
+        char *new_map = mmap(map_target, page_size,
+            PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED, -1, 0);
+        test_assert(map_target == new_map);
+        ret = madvise(new_map, page_size, MADV_HUGEPAGE);
+        test_assert(ret == 0);
+        if (off % (2*page_size) == 0) {
+            ret = madvise(new_map, page_size, MADV_DONTDUMP);
+            test_assert(ret == 0);
+        } else {
+            // Simulate a full syscallbuf - perform an unbuffered syscall
+            ret = unbufferable_syscall(SYS_madvise, (uintptr_t)map_target,
+                page_size, MADV_DONTDUMP);
+            test_assert(ret == 0);
+        }
+    }
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+}

--- a/src/test/madvise_fracture_flags.run
+++ b/src/test/madvise_fracture_flags.run
@@ -1,0 +1,3 @@
+NO_CHECK_CACHED_MMAP=1
+source `dirname $0`/util.sh
+compare_test EXIT-SUCCESS

--- a/src/test/syscall_bp.c
+++ b/src/test/syscall_bp.c
@@ -12,40 +12,6 @@ char breakpoint_instruction[] = { 0x0, 0x0, 0x20, 0xd4 };
 
 #define RR_PAGE_ADDR 0x70000000
 
-static uintptr_t my_syscall(uintptr_t syscall, uintptr_t arg1, uintptr_t arg2,
-                            uintptr_t arg3) {
-  uintptr_t ret;
-#ifdef __x86_64__
-  __asm__ volatile("syscall\n\t"
-                   /* Make sure we don't patch this syscall for syscall buffering */
-                   "cmp $0x77,%%rax\n\t"
-                   : "=a"(ret)
-                   : "a"(syscall), "D"(arg1), "S"(arg2), "d"(arg3)
-                   : "flags");
-#elif defined(__i386__)
-  __asm__ volatile("xchg %%esi,%%edi\n\t"
-                   "int $0x80\n\t"
-                   "xchg %%esi,%%edi\n\t"
-                   : "=a"(ret)
-                   : "a"(syscall), "b"(arg1), "c"(arg2), "d"(arg3));
-#elif defined(__aarch64__)
-  register long x8 __asm__("x8") = syscall;
-  register long x0 __asm__("x0") = (long)arg1;
-  register long x1 __asm__("x1") = (long)arg2;
-  register long x2 __asm__("x2") = (long)arg3;
-  __asm__ volatile("b 1f\n\t"
-                   "mov x8, 0xdc\n"
-                   "1:\n\t"
-                   "svc #0\n\t"
-                   : "+r"(x0)
-                   : "r"(x1), "r"(x2), "r"(x8));
-  ret = x0;
-#else
-#error define syscall here
-#endif
-  return ret;
-}
-
 int main(void) {
   uint8_t* syscall_addr = (uint8_t*)RR_PAGE_ADDR;
   uintptr_t current_brk = (uintptr_t)sbrk(0);
@@ -64,9 +30,9 @@ int main(void) {
   // Now make a syscall that we know rr will want to use a remote syscall
   // for. Don't use the glibc wrapper to make absolutely sure we don't hit
   // our own breakpoint.
-  my_syscall(SYS_brk, current_brk + 0x100000, 0, 0);
-  my_syscall(SYS_write, STDOUT_FILENO, (uintptr_t) "EXIT-SUCCESS", 14);
+  unbufferable_syscall(SYS_brk, current_brk + 0x100000, 0, 0);
+  unbufferable_syscall(SYS_write, STDOUT_FILENO, (uintptr_t) "EXIT-SUCCESS", 14);
   // Exit directly.
-  my_syscall(SYS_exit, 0x0, 0, 0);
+  unbufferable_syscall(SYS_exit, 0x0, 0, 0);
   return 1;
 }

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -388,6 +388,43 @@ inline static SyscallWrapper get_spurious_desched_syscall(void) {
       (SyscallWrapper)dlsym(RTLD_DEFAULT, "spurious_desched_syscall");
   return ret ? ret : default_syscall_wrapper;
 }
+
+static inline uintptr_t unbufferable_syscall(uintptr_t syscall, uintptr_t arg1,
+                                             uintptr_t arg2,
+                                             uintptr_t arg3) {
+  uintptr_t ret;
+#ifdef __x86_64__
+  __asm__ volatile("syscall\n\t"
+                   /* Make sure we don't patch this syscall for syscall buffering */
+                   "cmp $0x77,%%rax\n\t"
+                   : "=a"(ret)
+                   : "a"(syscall), "D"(arg1), "S"(arg2), "d"(arg3)
+                   : "flags");
+#elif defined(__i386__)
+  __asm__ volatile("xchg %%esi,%%edi\n\t"
+                   "int $0x80\n\t"
+                   "xchg %%esi,%%edi\n\t"
+                   : "=a"(ret)
+                   : "a"(syscall), "b"(arg1), "c"(arg2), "d"(arg3));
+#elif defined(__aarch64__)
+  register long x8 __asm__("x8") = syscall;
+  register long x0 __asm__("x0") = (long)arg1;
+  register long x1 __asm__("x1") = (long)arg2;
+  register long x2 __asm__("x2") = (long)arg3;
+  __asm__ volatile("b 1f\n\t"
+                   "mov x8, 0xdc\n"
+                   "1:\n\t"
+                   "svc #0\n\t"
+                   : "+r"(x0)
+                   : "r"(x1), "r"(x2), "r"(x8));
+  ret = x0;
+#else
+#error define syscall here
+#endif
+  return ret;
+}
+
+
 /* Old systems don't have these functions, re-define using the syscall */
 #define tgkill(tgid, tid, sig) \
   syscall(SYS_tgkill, (int)(tgid), (int)(tid), (int)(sig))

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -97,7 +97,10 @@ function usage {
     echo Usage: "util.sh TESTNAME [LIB_ARG] [OBJDIR]"
 }
 
-GLOBAL_OPTIONS="--suppress-environment-warnings --check-cached-mmaps --fatal-errors"
+GLOBAL_OPTIONS="--suppress-environment-warnings --fatal-errors"
+if [[ "$NO_CHECK_CACHED_MMAP" == "" ]]; then
+    GLOBAL_OPTIONS="${GLOBAL_OPTIONS} --check-cached-mmaps"
+fi
 
 SRCDIR=`dirname ${BASH_SOURCE[0]}`/../..
 SRCDIR=`realpath $SRCDIR`


### PR DESCRIPTION
This is an incomplete PR, because although the test case passes as included (with replay -a), it does not pass when running from the debugger prompt. I do not know what the difference between the two scenarios is. rr's logs are identical, there are no spurious debugger traps or anything. I did trace the kernel and there is a minor difference, but it is not particularly helpful. Anyway, I'll look at this some more, but if anybody has bright ideas what difference running with GDB attached vs not makes, I'm all ears.

The core issue I'm trying to fix here is the following, when replaying the included test case, which emulates some (questionably sound) asan behavior:
```
[FATAL src/AutoRemoteSyscalls.cc:734:check_syscall_result()] 
 (task 1144611 (rec:1088200) at time 1206)
 -> Assertion `false' failed to hold. Syscall mmap failed with errno ENOMEM
Tail of trace dump:
```
What happens is that the program exceeds the total number of allowed mappings, because the kernel refuses to coalesce the mappings back after the second madvise, for unknown reasons. The coalescing does happen without rr, during record, as well as during `replay -a`. At first I thought this was a syscallbuf vs non-syscallbuf behavior difference, and indeed I believe that was a problem as well (which is fixed in this PR), but the mentioned behavior persists even with this patch applied.

I'll look at this some more, but I'm somewhat stumped.

<details><summary>Kernel function tracing results</summary>

Good:
```
15)               |  do_syscall_64() {
15)               |    __x64_sys_madvise() {
15)               |      down_write_killable() {
15)               |        _cond_resched() {
15)   0.210 us    |          rcu_all_qs();
15)   0.620 us    |        }
15)   1.020 us    |      }
15)               |      find_vma_prev() {
15)               |        find_vma() {
15)   0.280 us    |          vmacache_find();
15)   0.230 us    |          vmacache_update();
15)   1.540 us    |        }
15)   1.930 us    |      }
15)   0.230 us    |      blk_start_plug();
15)               |      hugepage_madvise() {
15)               |        khugepaged_enter_vma_merge() {
15)   0.240 us    |          hugepage_vma_check();
15)   0.790 us    |        }
15)   1.370 us    |      }
15)   0.370 us    |      vma_merge();
15)               |      blk_finish_plug() {
15)   0.250 us    |        blk_flush_plug_list();
15)   0.820 us    |      }
15)   0.200 us    |      up_write();
15)   8.150 us    |    }
15)   0.210 us    |    fpregs_assert_state_consistent();
15)   9.280 us    |  }
15)               |  do_syscall_64() {
15)               |    __x64_sys_madvise() {
15)               |      down_write_killable() {
15)               |        _cond_resched() {
15)   0.210 us    |          rcu_all_qs();
15)   0.610 us    |        }
15)   1.010 us    |      }
15)               |      find_vma_prev() {
15)               |        find_vma() {
15)   0.240 us    |          vmacache_find();
15)   0.630 us    |        }
15)   1.020 us    |      }
15)   0.230 us    |      blk_start_plug();
15)               |      vma_merge() {
15)   0.260 us    |        can_vma_merge_before.part.0();
15)               |        __vma_adjust() {
15)   0.250 us    |          vma_adjust_trans_huge();
15)   0.460 us    |          __vma_rb_erase();
15)               |          vm_area_free() {
15)   0.360 us    |            kmem_cache_free();
15)   0.790 us    |          }
15)   3.150 us    |        }
15)               |        khugepaged_enter_vma_merge() {
15)   0.230 us    |          hugepage_vma_check();
15)   0.620 us    |        }
15)   4.930 us    |      }
15)               |      blk_finish_plug() {
15)   0.230 us    |        blk_flush_plug_list();
15)   0.650 us    |      }
15)   0.210 us    |      up_write();
15)   9.500 us    |    }
15)   0.200 us    |    fpregs_assert_state_consistent();
15) + 10.330 us   |  }
```
Bad:
```
15)               |  do_syscall_64() {
15)               |    __x64_sys_madvise() {
15)               |      down_write_killable() {
15)               |        _cond_resched() {
15)   0.210 us    |          rcu_all_qs();
15)   0.660 us    |        }
15)   1.070 us    |      }
15)               |      find_vma_prev() {
15)               |        find_vma() {
15)   0.300 us    |          vmacache_find();
15)   0.280 us    |          vmacache_update();
15)   1.340 us    |        }
15)   1.730 us    |      }
15)   0.240 us    |      blk_start_plug();
15)               |      hugepage_madvise() {
15)               |        khugepaged_enter_vma_merge() {
15)               |          hugepage_vma_check() {
15)   0.230 us    |            is_vma_temporary_stack();
15)   0.790 us    |          }
15)   1.400 us    |        }
15)   1.980 us    |      }
15)   0.360 us    |      vma_merge();
15)               |      blk_finish_plug() {
15)   0.250 us    |        blk_flush_plug_list();
15)   0.730 us    |      }
15)   0.220 us    |      up_write();
15)   8.530 us    |    }
15)   0.210 us    |    fpregs_assert_state_consistent();
15) + 10.050 us   |  }
15)               |  do_syscall_64() {
15)               |    __x64_sys_madvise() {
15)               |      down_write_killable() {
15)               |        _cond_resched() {
15)   0.210 us    |          rcu_all_qs();
15)   0.620 us    |        }
15)   1.040 us    |      }
15)               |      find_vma_prev() {
15)               |        find_vma() {
15)   0.240 us    |          vmacache_find();
15)   0.630 us    |        }
15)   1.010 us    |      }
15)   0.220 us    |      blk_start_plug();
15)               |      vma_merge() {
15)   0.230 us    |        can_vma_merge_before.part.0();
15)   0.710 us    |      }
15)               |      blk_finish_plug() {
15)   0.240 us    |        blk_flush_plug_list();
15)   0.650 us    |      }
15)   0.210 us    |      up_write();
15)   5.320 us    |    }
15)   0.200 us    |    fpregs_assert_state_consistent();
15)   6.140 us    |  }
```
</details>
