### PR TITLE
Add message to static_assert in Monkeypatcher.cc to fix clang build error

### DIFF
--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -745,8 +745,8 @@ void substitute_replacement_patch<X86SyscallStubRestore>(uint8_t *buffer, uint64
 template <typename ExtendedJumpPatch, typename FakeSyscallExtendedJumpPatch, typename ReplacementPatch>
 static void unpatch_extended_jumps(Monkeypatcher& patcher,
                                    Task* t) {
-  // If these were the same size then the logic below wouldn't work.
-  static_assert(ExtendedJumpPatch::size < FakeSyscallExtendedJumpPatch::size);
+  static_assert(ExtendedJumpPatch::size < FakeSyscallExtendedJumpPatch::size,
+                "If these were the same size then the logic below wouldn't work");
   for (auto patch : patcher.syscallbuf_stubs) {
     const syscall_patch_hook &hook = *patch.second.hook;
     uint8_t bytes[FakeSyscallExtendedJumpPatch::size];


### PR DESCRIPTION
clang 14 gives me this build error for rr trunk:
```
src/Monkeypatcher.cc:749:77: error: 'static_assert' with no message is a C++17 extension [-Werror,-Wc++17-extensions]
  static_assert(ExtendedJumpPatch::size < FakeSyscallExtendedJumpPatch::size);
```

This patch fixes this by promoting the static_assert's code-comment to be its actual assertion-message instead.