### PR TITLE
Fixes #2643. PKRU default value is not always set

### DIFF
--- a/src/ExtraRegisters.cc
+++ b/src/ExtraRegisters.cc
@@ -754,7 +754,9 @@ void ExtraRegisters::reset() {
         RegData d = xsave_register_data(arch(), arch() == x86_64 ? DREG_64_PKRU : DREG_PKRU);
         DEBUG_ASSERT(d.xsave_feature_bit == PKRU_FEATURE_BIT);
         DEBUG_ASSERT(d.offset + d.size <= (int)data_.size());
-        *reinterpret_cast<int*>(data_.data() + d.offset) = 0x55555554;
+        // We can't assume PKRU will always be the default Kernel value. For
+        // more take a look in this GH issue: #2643.
+        // *reinterpret_cast<int*>(data_.data() + d.offset) = 0x55555554;
         xinuse |= pkru_bit;
       }
 


### PR DESCRIPTION
We recently detected that replaying from a Skylake processor to a Broadwell is broken with the following error:

```
[ERROR third-party/rr/src/ExtraRegisters.cc:557:set_to_raw_data()] Feature 9 has wrong size 8, expected 0
[FATAL third-party/rr/src/TraceStream.cc:592:read_frame()] Invalid extended register data in trace
```

After some debugging I found that the problem is this specific line [here](https://github.com/rr-debugger/rr/commit/25a6578c8e704ad6b58eac3b213f9fa8a20c1d9f#diff-df077e376f403a72a3cec7ab96035518d8fd9c3a84682f5ae52363875d1a5ec6R666).

Given the discussion in #2643, my understanding is that we can't assume that the default value `0x55555554` is there if PKRU is not set? Please correct me if i'm wrong as my understanding of this subject is quite limited.

Nevertheless, commenting out the line above, makes our traces portable across the 2 CPUs.