### PR TITLE
Include ctime explicitly

### DIFF
--- a/src/test-monitor/test-monitor.cc
+++ b/src/test-monitor/test-monitor.cc
@@ -11,6 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <ctime>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
In GCC 12, ctime is no longer included indirectly, and needs to be
included explicitly (for time()).

See https://www.gnu.org/software/gcc/gcc-12/porting_to.html for
details.

Signed-off-by: Stephen Kitt <steve@sk2.org>