### PR TITLE
add glibc 2.36 release bug workaround

### DIFF
--- a/src/test-monitor/test-monitor.cc
+++ b/src/test-monitor/test-monitor.cc
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <ctime>


### PR DESCRIPTION
This should be reverted, once there are no distros with the affected
release.
The last release was 2022-08-01 and "It has been fixed upstream and
backported to 2.36 release branch.", but there is still no announcement
for the bug fix release.

Further more, "Not a blocker. We can review in 2.37." hints there might
be none.

Due to this bug, rr does not build on Arch Linux as of 2022-09-06.

All credits go to @wcohen for the patch.

Closes #3356.