### PR TITLE
Use ptrace_if_alive rather than xptrace for PTRACE_SETSIGMASK

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -705,7 +705,7 @@ void RecordTask::did_wait() {
     // state, because we do not allow stashed_signals_blocking_more_signals
     // to hold across syscalls (traced or untraced) that change the signal mask.
     ASSERT(this, !blocked_sigs_dirty);
-    xptrace(PTRACE_SETSIGMASK, remote_ptr<void>(8), &blocked_sigs);
+    ptrace_if_alive(PTRACE_SETSIGMASK, remote_ptr<void>(8), &blocked_sigs);
   } else if (syscallbuf_child) {
     // The syscallbuf struct is only 32 bytes currently so read the whole thing
     // at once to avoid multiple calls to read_mem. Even though this shouldn't


### PR DESCRIPTION
If the process is dead, there's no point trying to set its sigmask. We'll notice the process died next time we try to do something with it, so there's nothing to do here other than to ignore the ptrace failure.

Should address CI failure seen in [1].

[1] https://buildkite.com/julialang/rr/builds/860#018314dd-a7ee-4dd4-a133-109c7ee0ada1