### PR TITLE
Minor change to error if the expected share/rr/*.xml file is missing.

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -416,7 +416,9 @@ static string read_target_desc(const char* file_name) {
   string path = resource_path() + share_path + string(file_name);
   stringstream ss;
   FILE* f = fopen(path.c_str(), "r");
-  DEBUG_ASSERT(f);
+  if (f == NULL) {
+      FATAL() << "Failed to load target description file: " << file_name;
+  }
   while (true) {
     int ch = getc(f);
     if (ch == EOF) {


### PR DESCRIPTION
Without this, we were a bit surprised to find rr segfaulting when we started building/installing it in a new way (and bungled the placement of those xml files).  The DEBUG_ASSERT check only happens in debug builds of course, so it cannot catch this mis-installation issue.