### PR TITLE
Use the explicit variant, because statx is also known as function name.

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1700,7 +1700,7 @@ struct BaseArch : public wordsize,
     uint64_t __spare2[14];
   } statx;
   // statx not yet widely available in system headers
-  // RR_VERIFY_TYPE(statx);
+  // RR_VERIFY_TYPE_EXPLICIT(struct ::statx, statx);
 
   struct sg_io_hdr {
     int interface_id;


### PR DESCRIPTION
Got this error (when uncommented):
```
src/kernel_abi.cc:68:55: error: type/value mismatch at argument 2 in template parameter list for ‘template<rr::SupportedArch a, class system_type, class rr_type> struct rr::Verifier’
src/kernel_abi.cc:68:55: note:   expected a type, got ‘statx’
```