### PR TITLE
Rather than guessing where the BSS pages are, use /proc/<pid>/pagemap to see which pages the kernel modified.

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -297,6 +297,12 @@ std::string Task::proc_fd_path(int fd) {
   return path;
 }
 
+std::string Task::proc_pagemap_path() {
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path) - 1, "/proc/%d/pagemap", tid);
+  return path;
+}
+
 std::string Task::proc_stat_path() {
   char path[PATH_MAX];
   snprintf(path, sizeof(path) - 1, "/proc/%d/stat", tid);

--- a/src/Task.h
+++ b/src/Task.h
@@ -205,6 +205,11 @@ public:
   std::string proc_fd_path(int fd);
 
   /**
+   * Return the path of /proc/<pid>/pagemap
+   */
+  std::string proc_pagemap_path();
+
+  /**
    * Return the path of /proc/<pid>/stat
    */
   std::string proc_stat_path();


### PR DESCRIPTION
Fixes #3379