### PR TITLE
Add std:: prefix to all move() invocations, to address clang -Wunqualified-std-cast-call build warning

### DIFF
--- a/src/Dwarf.cc
+++ b/src/Dwarf.cc
@@ -198,7 +198,7 @@ DwarfAbbrev* DwarfAbbrevSet::lookup(uint64_t code) {
       LOG(warn) << "Invalid DWARF abbrev table!";
       return nullptr;
     }
-    abbrevs.insert(make_pair(abbrev_code, move(abbrev)));
+    abbrevs.insert(make_pair(abbrev_code, std::move(abbrev)));
     if (code == abbrev_code) {
       return abbrev_raw;
     }
@@ -215,7 +215,7 @@ DwarfAbbrevSet& DwarfAbbrevs::lookup(uint64_t offset) {
 
   unique_ptr<DwarfAbbrevSet> set(new DwarfAbbrevSet(debug_abbrev.subspan(offset)));
   auto set_raw = set.get();
-  abbrevs.insert(make_pair(offset, move(set)));
+  abbrevs.insert(make_pair(offset, std::move(set)));
   return *set_raw;
 }
 

--- a/src/ExportImportCheckpoints.cc
+++ b/src/ExportImportCheckpoints.cc
@@ -234,16 +234,16 @@ CommandForCheckpoint export_checkpoints(ReplaySession::shr_ptr session, int coun
     if (!child) {
       set_title(args);
       session->forget_tasks();
-      command_for_checkpoint.args = move(args);
-      command_for_checkpoint.session = move(checkpoint);
+      command_for_checkpoint.args = std::move(args);
+      command_for_checkpoint.session = std::move(checkpoint);
       setup_child_fds(fds_data, command_for_checkpoint);
       char ch;
       ret = read(parent_to_child_read, &ch, 1);
       if (ret != 1) {
         FATAL() << "Failed to read parent notification";
       }
-      command_for_checkpoint.session->reattach_tasks(move(new_tracee_socket),
-        move(new_tracee_socket_receiver));
+      command_for_checkpoint.session->reattach_tasks(std::move(new_tracee_socket),
+        std::move(new_tracee_socket_receiver));
       return command_for_checkpoint;
     }
     children.push_back(child);

--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -953,7 +953,7 @@ bool GdbConnection::process_vpacket(char* payload) {
     }
     req = GdbRequest(DREQ_CONT);
     req.cont().run_direction = RUN_FORWARD;
-    req.cont().actions = move(actions);
+    req.cont().actions = std::move(actions);
     return true;
   }
 
@@ -1274,7 +1274,7 @@ bool GdbConnection::process_packet() {
             parser_assert('\0' == *payload);
             payload[0] = tmp;
           }
-          req.watch().conditions.push_back(move(bytes));
+          req.watch().conditions.push_back(std::move(bytes));
         }
       }
       parser_assert('\0' == *payload);

--- a/src/GdbExpression.cc
+++ b/src/GdbExpression.cc
@@ -400,21 +400,21 @@ GdbExpression::GdbExpression(const uint8_t* data, size_t size) {
         if (bits > 8) {
           vector<uint8_t> v = b;
           v[i + 1] = 8;
-          variants.push_back(move(v));
+          variants.push_back(std::move(v));
         }
         if (bits > 16) {
           vector<uint8_t> v = b;
           v[i + 1] = 16;
-          variants.push_back(move(v));
+          variants.push_back(std::move(v));
         }
         if (bits > 32) {
           vector<uint8_t> v = b;
           v[i + 1] = 32;
-          variants.push_back(move(v));
+          variants.push_back(std::move(v));
         }
-        variants.push_back(move(b));
+        variants.push_back(std::move(b));
       }
-      bytecode_variants = move(variants);
+      bytecode_variants = std::move(variants);
     }
   }
 }

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -2036,7 +2036,7 @@ static ScopedFd generate_fake_proc_maps(Task* t) {
     FATAL() << "Can't write";
   }
 
-  return move(file.fd);
+  return std::move(file.fd);
 }
 
 static bool is_ld_mapping(string map_name) {
@@ -2190,7 +2190,7 @@ int GdbServer::open_file(Session& session, Task* continue_task, const std::strin
   while (files.find(ret_fd) != files.end()) {
     ++ret_fd;
   }
-  files.insert(make_pair(ret_fd, move(contents)));
+  files.insert(make_pair(ret_fd, std::move(contents)));
   return ret_fd;
 }
 

--- a/src/MonitoredSharedMemory.cc
+++ b/src/MonitoredSharedMemory.cc
@@ -44,7 +44,7 @@ void MonitoredSharedMemory::maybe_monitor(RecordTask* t,
       new MonitoredSharedMemory(real_mem, m.map.size()));
 
   const AddressSpace::Mapping& shared =
-      Session::steal_mapping(remote, m, move(result));
+      Session::steal_mapping(remote, m, std::move(result));
   // m may be invalid now
   if (!shared.local_addr) {
     // tracee died
@@ -80,7 +80,7 @@ void MonitoredSharedMemory::check_for_changes(RecordTask* t,
     AutoRemoteSyscalls remote(t);
     auto msm = m.monitored_shared_memory;
     m = Session::recreate_shared_mmap(remote, m, Session::DISCARD_CONTENTS,
-                                      move(msm));
+                                      std::move(msm));
     if (!m.local_addr) {
       // Tracee died.
       return;

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -2075,8 +2075,8 @@ void ReplaySession::detach_tasks(pid_t new_ptracer, ScopedFd& new_tracee_socket_
 }
 
 void ReplaySession::reattach_tasks(ScopedFd new_tracee_socket, ScopedFd new_tracee_socket_receiver) {
-  tracee_socket = make_shared<ScopedFd>(move(new_tracee_socket));
-  tracee_socket_receiver = make_shared<ScopedFd>(move(new_tracee_socket_receiver));
+  tracee_socket = make_shared<ScopedFd>(std::move(new_tracee_socket));
+  tracee_socket_receiver = make_shared<ScopedFd>(std::move(new_tracee_socket_receiver));
   // Seize all tasks.
   for (auto& entry : task_map) {
     Task* t = entry.second;

--- a/src/ReplayTimeline.cc
+++ b/src/ReplayTimeline.cc
@@ -666,7 +666,7 @@ bool ReplayTimeline::add_breakpoint(
   if (!t->vm()->add_breakpoint(addr, BKPT_USER)) {
     return false;
   }
-  breakpoints.insert(make_tuple(t->vm()->uid(), addr, move(condition)));
+  breakpoints.insert(make_tuple(t->vm()->uid(), addr, std::move(condition)));
   return true;
 }
 
@@ -699,7 +699,7 @@ bool ReplayTimeline::add_watchpoint(ReplayTask* t, remote_ptr<void> addr,
     return false;
   }
   watchpoints.insert(
-      make_tuple(t->vm()->uid(), addr, num_bytes, type, move(condition)));
+      make_tuple(t->vm()->uid(), addr, num_bytes, type, std::move(condition)));
   no_watchpoints_hit_interval_start = no_watchpoints_hit_interval_end =
       Mark();
   return true;
@@ -903,7 +903,7 @@ bool ReplayTimeline::run_forward_to_intermediate_point(const Mark& end,
     ReplayResult result = current->replay_step(constraints);
     if (at_mark(end)) {
       DEBUG_ASSERT(tmp_session);
-      current = move(tmp_session);
+      current = std::move(tmp_session);
       LOG(debug) << "Singlestepping arrived at |end|, restoring session";
     } else if (!m.equal_states(*current)) {
       LOG(debug) << "Did fast-singlestep forward to " << current_mark_key();
@@ -976,7 +976,7 @@ ReplayResult ReplayTimeline::reverse_continue(
         seek_to_mark(seek);
         LOG(debug) << "Seeked directly backward from " << start << " to "
                    << seek;
-        start = move(seek);
+        start = std::move(seek);
       }
     } else {
       checkpoint_at_first_break = false;

--- a/src/RerunCommand.cc
+++ b/src/RerunCommand.cc
@@ -635,7 +635,7 @@ static int rerun(const string& trace_dir, const RerunFlags& flags, CommandForChe
   // exporter's child process.
   if (flags.export_checkpoints_event) {
     if (command_for_checkpoint.session) {
-      export_checkpoints_socket = move(command_for_checkpoint.fds.front());
+      export_checkpoints_socket = std::move(command_for_checkpoint.fds.front());
     } else {
       export_checkpoints_socket = bind_export_checkpoints_socket(flags.export_checkpoints_count, flags.export_checkpoints_socket);
     }
@@ -643,7 +643,7 @@ static int rerun(const string& trace_dir, const RerunFlags& flags, CommandForChe
 
   ReplaySession::shr_ptr replay_session;
   if (command_for_checkpoint.session) {
-    replay_session = move(command_for_checkpoint.session);
+    replay_session = std::move(command_for_checkpoint.session);
   } else if (flags.import_checkpoint_socket.empty()) {
     replay_session = ReplaySession::create(trace_dir, session_flags(flags));
     // Now that we've spawned the replay, raise our resource limits if
@@ -652,9 +652,9 @@ static int rerun(const string& trace_dir, const RerunFlags& flags, CommandForChe
   } else {
     vector<ScopedFd> fds;
     if (export_checkpoints_socket.is_open()) {
-      fds.push_back(move(export_checkpoints_socket));
+      fds.push_back(std::move(export_checkpoints_socket));
     }
-    return invoke_checkpoint_command(flags.import_checkpoint_socket, command_for_checkpoint.args, move(fds));
+    return invoke_checkpoint_command(flags.import_checkpoint_socket, command_for_checkpoint.args, std::move(fds));
   }
 
   uint64_t instruction_count_within_event = 0;
@@ -743,7 +743,8 @@ static int rerun(const string& trace_dir, const RerunFlags& flags, CommandForChe
     }
 
     if (after_time == flags.export_checkpoints_event) {
-      command_for_checkpoint = export_checkpoints(move(replay_session), flags.export_checkpoints_count,
+      command_for_checkpoint = export_checkpoints(std::move(replay_session),
+          flags.export_checkpoints_count,
           export_checkpoints_socket, flags.export_checkpoints_socket);
       return 0;
     }
@@ -792,9 +793,9 @@ int RerunCommand::run_internal(CommandForCheckpoint& command_for_checkpoint) {
 
 int RerunCommand::run(vector<string>& args) {
   CommandForCheckpoint command_for_checkpoint;
-  command_for_checkpoint.args = move(args);
+  command_for_checkpoint.args = std::move(args);
   while (true) {
-    ScopedFd exit_notification_fd = move(command_for_checkpoint.exit_notification_fd);
+    ScopedFd exit_notification_fd = std::move(command_for_checkpoint.exit_notification_fd);
     int ret = run_internal(command_for_checkpoint);
     if (!command_for_checkpoint.session) {
       if (exit_notification_fd.is_open()) {

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -705,7 +705,7 @@ void Session::copy_state_to(Session& dest, EmuFs& emu_fs, EmuFs& dest_emu_fs) {
 
     group.clone_leader_state = group_leader->capture_state();
   }
-  dest.clone_completion = move(completion);
+  dest.clone_completion = std::move(completion);
 
   DEBUG_ASSERT(dest.vms().size() > 0);
 }

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -304,7 +304,7 @@ static bool process_compilation_units(ElfFileReader& reader,
           if (comp_dir) {
             c = comp_dir;
           }
-          dwos->push_back({ dwo_name, trace_relative_name, move(c), full_name, dwo_id });
+          dwos->push_back({ dwo_name, trace_relative_name, std::move(c), full_name, dwo_id });
         } else {
           FATAL() << "DWO missing due to relative path " << full_name;
         }
@@ -698,7 +698,7 @@ static string resolve_symlinks(const string& path,
       if (!base_is_file) {
         check_vcs_root(resolved, vcs_dirs);
         // Cache the result of the readlink operation
-        resolved_dirs->insert(make_pair(move(resolved_base), resolved));
+        resolved_dirs->insert(make_pair(std::move(resolved_base), resolved));
         // And cache based on the original `base`.
         resolved_dirs->insert(make_pair(base, resolved));
       }
@@ -828,7 +828,7 @@ static int sources(const map<string, string>& binary_file_names, const map<strin
     }
 
     if (has_source_files) {
-      relevant_binary_names.push_back(move(trace_relative_name));
+      relevant_binary_names.push_back(std::move(trace_relative_name));
     } else {
       LOG(info) << "No debuginfo found";
     }
@@ -1007,7 +1007,7 @@ int SourcesCommand::run(vector<string>& args) {
       break;
     }
     if (data.source == TraceReader::SOURCE_FILE) {
-      binary_file_names.insert(make_pair(move(data.file_name), km.fsname()));
+      binary_file_names.insert(make_pair(std::move(data.file_name), km.fsname()));
     }
   }
 
@@ -1043,7 +1043,7 @@ int ExplicitSourcesCommand::run(vector<string>& args) {
       LOG(warn) << "No build-id for `" << arg << "`";
       continue;
     }
-    binary_file_names.insert(make_pair(move(buildid), arg));
+    binary_file_names.insert(make_pair(std::move(buildid), arg));
   }
 
   return sources(binary_file_names, comp_dir_substitutions, true);

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2433,7 +2433,7 @@ Task* Task::os_fork_into(Session* session, FdTable::shr_ptr new_fds) {
                // be copied by fork()ing the address
                // space.
                SIGCHLD,
-               move(new_fds));
+               std::move(new_fds));
   // When we forked ourselves, the child inherited the setup we
   // did to make the clone() call.  So we have to "finish" the
   // remote calls (i.e. undo fudged state) in the child too,
@@ -2466,7 +2466,7 @@ Task* Task::os_clone_into(const CapturedState& state,
                   (CLONE_VM | CLONE_FS | CLONE_SIGHAND |
                    CLONE_SYSVSEM),
                   fdtable_entry->second,
-                  move(new_tg),
+                  std::move(new_tg),
                   state.top_of_stack);
 }
 
@@ -2699,7 +2699,7 @@ bool Task::open_mem_fd() {
     LOG(info) << "Can't retrieve mem fd for " << tid << "; process no longer exists?";
     return false;
   }
-  as->set_mem_fd(move(fd));
+  as->set_mem_fd(std::move(fd));
   return true;
 }
 
@@ -3197,8 +3197,8 @@ static long perform_remote_clone(AutoRemoteSyscalls& remote,
 
   Task* child = remote.task()->clone(
       reason, clone_flags_to_task_flags(base_flags), stack, tls, ctid,
-      remote.new_tid(), rec_child_tid, new_serial, session, move(new_fds),
-      move(new_tg));
+      remote.new_tid(), rec_child_tid, new_serial, session, std::move(new_fds),
+      std::move(new_tg));
   return child;
 }
 

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -1252,7 +1252,7 @@ bool TraceReader::read_raw_data_for_frame_with_holes(RawDataWithHoles& d) {
   auto& rec = raw_recs[raw_recs.size() - 1];
   d.rec_tid = rec.rec_tid;
   d.addr = rec.addr;
-  d.holes = move(rec.holes);
+  d.holes = std::move(rec.holes);
   size_t data_size = rec.size;
   for (auto& h : d.holes) {
     data_size -= h.size;


### PR DESCRIPTION
This fixes #3386.

In a few cases this patch also rewraps the affected line, aiming to roughly preserve the prior line length and optimize for readability.