### PR TITLE
Make the artifact storage location configurable.

### DIFF
--- a/.android/cloudbuild.yaml
+++ b/.android/cloudbuild.yaml
@@ -5,5 +5,7 @@ steps:
 timeout: 3600s
 artifacts:
   objects:
-    location: 'gs://rr-android-testing_artifacts/rr'
+    # Configure _ARTIFACT_BUCKET in you cloud build trigger
+    # https://cloud.google.com/build/docs/automating-builds/github/build-repos-from-github#creating_a_github_trigger.
+    location: 'gs://$_ARTIFACT_BUCKET/$PROJECT_ID/$BUILD_ID'
     paths: ["obj/dist/rr-5.5.0-Android-x86_64.tar.gz"]


### PR DESCRIPTION
Forks shouldn't be attempting to push their artifacts to the upstream bucket. Make this location configurable in the cloud build config so each repository can have their own storage location.

This does also change the storage layout to avoid clobbering stored artifacts with each build. The output path as well as the bucket name could probably be made configurable instead if that behavior should be kept.