### PR TITLE
Add the IntelRaptorLake CpuMicroarch

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -85,7 +85,8 @@ enum CpuMicroarch {
   IntelTigerlake,
   IntelRocketlake,
   IntelAlderlake,
-  LastIntel = IntelAlderlake,
+  IntelRaptorlake,
+  LastIntel = IntelRaptorlake,
   FirstAMD,
   AMDF15R30 = FirstAMD,
   AMDZen,
@@ -154,6 +155,7 @@ struct PmuConfig {
 // See Intel 64 and IA32 Architectures Performance Monitoring Events.
 // See check_events from libpfm4.
 static const PmuConfig pmu_configs[] = {
+  { IntelRaptorlake, "Intel Raptorlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRocketlake, "Intel Rocketlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },
   { IntelTigerlake, "Intel Tigerlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -82,6 +82,8 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x90670:
     case 0x906a0:
       return IntelAlderlake;
+    case 0xb0670:
+      return IntelRaptorlake;
     case 0x30f00:
       return AMDF15R30;
     case 0x00f10: // Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen), Milan (Zen 3) (UNTESTED)


### PR DESCRIPTION
This seems to address this issue: https://github.com/rr-debugger/rr/issues/3397

I am not sure about the values that I added to pmu_configs, but it seems reasonable? Sorry if I've missed anything as well. I apologize as I would run the tests, but apparently WSL still doesnt work :( (error is: `[FATAL src/PerfCounters.cc:308:start_counter()] Unable to open performance counter with 'perf_event_open'; are hardware perf events available? See https://github.com/rr-debugger/rr/wiki/Will-rr-work-on-my-system`)