### PR TITLE
PerfCounters: Add support for AMD Family 15h Model 2 (Piledriver)

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -100,7 +100,7 @@ enum CpuMicroarch {
   IntelMeteorLake,
   LastIntel = IntelMeteorLake,
   FirstAMD,
-  AMDF15R30 = FirstAMD,
+  AMDF15 = FirstAMD,
   AMDZen,
   AMDZen2,
   AMDZen3,
@@ -200,7 +200,7 @@ static const PmuConfig pmu_configs[] = {
   { IntelWestmere, "Intel Westmere", 0x5101c4, 0, 0, 100, PMU_TICKS_RCB },
   { IntelPenryn, "Intel Penryn", 0, 0, 0, 100, 0 },
   { IntelMerom, "Intel Merom", 0, 0, 0, 100, 0 },
-  { AMDF15R30, "AMD Family 15h Revision 30h", 0xc4, 0xc6, 0, 250, PMU_TICKS_TAKEN_BRANCHES },
+  { AMDF15, "AMD Family 15h", 0xc4, 0xc6, 0, 250, PMU_TICKS_TAKEN_BRANCHES },
   // 0xd1 == RETIRED_CONDITIONAL_BRANCH_INSTRUCTIONS - Number of retired conditional branch instructions
   // 0x2c == INTERRUPT_TAKEN - Counts the number of interrupts taken
   // Both counters are available on all Zen microarchitecures so far.

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -96,15 +96,16 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelEmeraldRapid;
     case 0xa06a0:
       return IntelMeteorLake;
-    case 0x30f00:
-      return AMDF15R30;
+    case 0xf20:  // Piledriver
+    case 0x30f00:  // Steamroller
+      return AMDF15;
     case 0x00f10: // A8-3530MX, Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen), Milan (Zen 3) (UNTESTED)
       if (ext_family == 8) {
         return AMDZen;
       } else if (ext_family == 0xa) {
         return AMDZen3;
       } else if (ext_family == 3) {
-        return AMDF15R30;
+        return AMDF15;
       }
       break;
     case 0x00f80: // Colfax, Pinnacle Ridge (Zen+), Chagall (Zen3) (UNTESTED)

--- a/src/counters-test/counters.cc
+++ b/src/counters-test/counters.cc
@@ -67,7 +67,7 @@ enum CpuMicroarch {
   IntelSapphireRapid,
   LastIntel = IntelSapphireRapid,
   FirstAMD,
-  AMDF15R30 = FirstAMD,
+  AMDF15 = FirstAMD,
   AMDZen,
   LastAMD = AMDZen,
   FirstARM,
@@ -156,7 +156,7 @@ static const PmuConfig pmu_configs[] = {
   { IntelWestmere, "Intel Westmere", 0x5101c4, 0, 0, 100, PMU_TICKS_RCB },
   { IntelPenryn, "Intel Penryn", 0, 0, 0, 100, 0 },
   { IntelMerom, "Intel Merom", 0, 0, 0, 100, 0 },
-  { AMDF15R30, "AMD Family 15h Revision 30h", 0xc4, 0xc6, 0, 250, PMU_TICKS_TAKEN_BRANCHES },
+  { AMDF15, "AMD Family 15h", 0xc4, 0xc6, 0, 250, PMU_TICKS_TAKEN_BRANCHES },
   // 0xd1 == RETIRED_CONDITIONAL_BRANCH_INSTRUCTIONS - Number of retired conditional branch instructions
   // 0x2c == INTERRUPT_TAKEN - Counts the number of interrupts taken
   // Both counters are available on Zen, Zen+ and Zen2.
@@ -335,8 +335,9 @@ static CpuMicroarch compute_cpu_microarch(void) {
       return IntelRaptorlake;
     case 0x806f0:
       return IntelSapphireRapid;
+    case 0xf20:
     case 0x30f00:
-      return AMDF15R30;
+      return AMDF15;
     case 0x00f10: // Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen), Milan (Zen 3) (UNTESTED)
     case 0x10f10: // Raven Ridge, Great Horned Owl (Zen) (UNTESTED)
     case 0x10f80: // Banded Kestrel (Zen), Picasso (Zen+) (UNTESTED)
@@ -350,7 +351,7 @@ static CpuMicroarch compute_cpu_microarch(void) {
       if (ext_family == 8 || ext_family == 0xa) {
         return AMDZen;
       } else if (ext_family == 3) {
-        return AMDF15R30;
+        return AMDF15;
       }
       break;
     case 0x20f10: // Vermeer (Zen 3)


### PR DESCRIPTION
Extends existing Family 15h Model 30 (Steamroller) support for Piledriver. Piledriver supports PMCx0C4 (Retired Taken Branch Instructions) and PMCx0C6 (Retired Far Control Transfer), just like Model 30h. [1]

Note that PMCx0C4 counts all control flow changes, including exceptions and interrupts. AFAICT on 15h, there is no PMC for just retired conditional branches.

[1]: https://www.amd.com/system/files/TechDocs/42301_15h_Mod_00h-0Fh_BKDG.pdf

Tested:
1) counters-test:
   vsrinivas@ubuntu:~/tmp/rr/src/counters-test$ cc -O2 counters.c
   vsrinivas@ubuntu:~/tmp/rr/src/counters-test$ sudo ./a.out
   Ticks mismatch; got 1003, expected 1002
   Aborted

   Varying the number of volatile matches, we always see one more
   tick than expected, which I think is a RET instruction.

2) ctest:
97% tests passed, 45 tests failed out of 1425

Total Test time (real) = 3092.96 sec

The following tests FAILED:
         53 - x86/chew_cpu_cpuid-no-syscallbuf (Failed)
        110 - detach_state (Failed)
        162 - x86/fault_in_code_page (Failed)
        558 - x86/rdtsc_flags (Failed)
        724 - sioc (Failed)
        725 - sioc-no-syscallbuf (Failed)
        842 - vsyscall (Failed)
        843 - vsyscall-no-syscallbuf (Failed)
        844 - vsyscall_timeslice (Failed)
        845 - vsyscall_timeslice-no-syscallbuf (Failed)
        846 - x86/x87env (Failed)
        847 - x86/x87env-no-syscallbuf (Failed)
        888 - async_signal_syscalls (Failed)
        890 - async_signal_syscalls2 (Failed)
        910 - x86/blocked_sigsegv (Failed)
        916 - breakpoint_overlap (Failed)
        924 - checkpoint_dying_threads (Failed)
        932 - clone_interruption (Failed)
        938 - conditional_breakpoint_offload (Failed)
        939 - conditional_breakpoint_offload-no-syscallbuf (Failed)
        951 - daemon_read-no-syscallbuf (Failed)
        962 - dlopen (Failed)
        980 - exit_race (Failed)
        981 - exit_race-no-syscallbuf (Failed)
        984 - x86/explicit_checkpoints (Failed)
        1072 - x86/rdtsc_loop (Failed)
        1080 - reverse_continue_breakpoint (Failed)
        1081 - reverse_continue_breakpoint-no-syscallbuf (Failed)
        1089 - reverse_step_long-no-syscallbuf (Failed)
        1092 - reverse_step_threads_break (Failed)
        1100 - rseq_syscallbuf (Failed)
        1130 - strict_priorities (Failed)
        1131 - strict_priorities-no-syscallbuf (Failed)
        1150 - x86/syscallbuf_rdtsc_page (Failed)
        1174 - thread_open_race (Failed)
        1206 - watchpoint_at_sched (Failed)
        1208 - watchpoint_before_signal (Failed)
        1209 - watchpoint_before_signal-no-syscallbuf (Failed)
        1218 - async_signal_syscalls_100 (Failed)
        1219 - async_signal_syscalls_100-no-syscallbuf (Failed)
        1320 - record_replay (Failed)
        1321 - record_replay-no-syscallbuf (Failed)
        1354 - reverse_watchpoint_syscall (Failed)
        1418 - vsyscall_singlestep (Failed)
        1419 - vsyscall_singlestep-no-syscallbuf (Failed)