### PR TITLE
test: Include <sys/mount.h> in util.h

### DIFF
--- a/src/test/util.h
+++ b/src/test/util.h
@@ -80,6 +80,7 @@
 #include <sys/ioctl.h>
 #include <sys/ipc.h>
 #include <sys/mman.h>
+#include <sys/mount.h>
 #include <sys/msg.h>
 #include <sys/prctl.h>
 #include <sys/ptrace.h>


### PR DESCRIPTION
The mount_ns_exec test needs it to call the mount function.