### PR TITLE
Improve handling of _RR_TRACE_DIR variable

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1779,10 +1779,9 @@ void ensure_dir(const string& dir, const char* dir_type, mode_t mode) {
     }
 
     size_t last_slash = d.find_last_of('/');
-    if (last_slash == string::npos) {
-      FATAL() << "Can't find directory `" << dir << "'";
+    if (last_slash != string::npos) {
+      ensure_dir(d.substr(0, max(last_slash, (size_t)1)), dir_type, mode);
     }
-    ensure_dir(d.substr(0, max(last_slash, (size_t)1)), dir_type, mode);
 
     // Allow for a race condition where someone else creates the directory
     if (0 > mkdir(d.c_str(), mode) && errno != EEXIST) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1790,6 +1790,7 @@ void ensure_dir(const string& dir, const char* dir_type, mode_t mode) {
     if (0 > stat(d.c_str(), &st)) {
       FATAL() << "Can't stat " << dir_type << " `" << dir << "'";
     }
+    return;
   }
 
   if (!(S_IFDIR & st.st_mode)) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1766,11 +1766,12 @@ void check_for_leaks() {
 }
 
 void ensure_dir(const string& dir, const char* dir_type, mode_t mode) {
-  string d = dir;
-  while (!d.empty() && d[d.length() - 1] == '/') {
-    d = d.substr(0, d.length() - 1);
+  if (dir.empty()) {
+    FATAL() << "Empty directory name!";
   }
-
+  size_t last_dir_component = dir.find_last_not_of('/');
+  const string d = last_dir_component == string::npos
+    ? "/" : dir.substr(0, last_dir_component + 1);
   struct stat st;
   if (0 > stat(d.c_str(), &st)) {
     if (errno != ENOENT) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1779,10 +1779,10 @@ void ensure_dir(const string& dir, const char* dir_type, mode_t mode) {
     }
 
     size_t last_slash = d.find_last_of('/');
-    if (last_slash == string::npos || last_slash == 0) {
+    if (last_slash == string::npos) {
       FATAL() << "Can't find directory `" << dir << "'";
     }
-    ensure_dir(d.substr(0, last_slash), dir_type, mode);
+    ensure_dir(d.substr(0, max(last_slash, (size_t)1)), dir_type, mode);
 
     // Allow for a race condition where someone else creates the directory
     if (0 > mkdir(d.c_str(), mode) && errno != EEXIST) {


### PR DESCRIPTION
This mainly fixes #3415 and extends support for "current directory" to format a la `_RR_TRACE_DIR=mydir`. The `ensure_dir()` with directory creation code and the `access()` call commented out passes the following testing combinations for me:

```
    ensure_dir(std::string("/tmp/foo/bin///"), "", 0777);
    ensure_dir(std::string("/tmp/"), "", 0777);
    ensure_dir(std::string("/tmp/bar"), "", 0777);
    ensure_dir(std::string("/boo/bar"), "", 0777);
    ensure_dir(std::string("/"), "", 0777);
    ensure_dir(std::string("///"), "", 0777);
    ensure_dir(std::string("./foo"), "", 0777);
    ensure_dir(std::string("./"), "", 0777);
    ensure_dir(std::string("."), "", 0777);
    ensure_dir(std::string("foo"), "", 0777);
    ensure_dir(std::string("foo/bar"), "", 0777);
```

Fixes: https://github.com/rr-debugger/rr/issues/3415