### PR TITLE
Add parameter to check if files are mapped in processes not part of the recording.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1556,6 +1556,7 @@ set(TESTS_WITH_PROGRAM
   many_yields
   mmap_fd_reuse_checkpoint
   mmap_replace_most_mappings
+  mmap_shared_extern
   mmap_shared_prot
   mmap_shared_write_exec_race
   mmap_tmpfs

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -107,6 +107,10 @@ void KernelMapIterator::init(bool* ok) {
 }
 
 void KernelMapIterator::operator++() {
+  if (!maps_file) {
+    return;
+  }
+
   char line[PATH_MAX * 2];
   if (!fgets(line, sizeof(line), maps_file)) {
     fclose(maps_file);

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2386,7 +2386,8 @@ static string lookup_by_path(const string& name) {
     bool unmap_vdso,
     bool force_asan_active,
     bool force_tsan_active,
-    bool intel_pt) {
+    bool intel_pt,
+    bool check_outside_mmaps) {
   TraceeAttentionSet::initialize();
 
   // The syscallbuf library interposes some critical
@@ -2494,7 +2495,7 @@ static string lookup_by_path(const string& name) {
       new RecordSession(full_path, argv, env, disable_cpuid_features,
                         syscallbuf, syscallbuf_desched_sig, bind_cpu,
                         output_trace_dir, trace_id, use_audit, unmap_vdso,
-                        intel_pt));
+                        intel_pt, check_outside_mmaps));
   session->excluded_ranges_ = std::move(exe_info.sanitizer_exclude_memory_ranges);
   session->fixed_global_exclusion_range_ = std::move(exe_info.fixed_global_exclusion_range);
   return session;
@@ -2511,7 +2512,8 @@ RecordSession::RecordSession(const std::string& exe_path,
                              const TraceUuid* trace_id,
                              bool use_audit,
                              bool unmap_vdso,
-                             bool intel_pt_enabled)
+                             bool intel_pt_enabled,
+                             bool check_outside_mmaps)
     : trace_out(argv[0], output_trace_dir, ticks_semantics_),
       scheduler_(*this),
       trace_id(trace_id),
@@ -2527,7 +2529,8 @@ RecordSession::RecordSession(const std::string& exe_path,
       enable_chaos_(false),
       wait_for_all_(false),
       use_audit_(use_audit),
-      unmap_vdso_(unmap_vdso) {
+      unmap_vdso_(unmap_vdso),
+      check_outside_mmaps_(check_outside_mmaps) {
   set_intel_pt_enabled(intel_pt_enabled);
   if (intel_pt_enabled) {
     PerfCounters::start_pt_copy_thread();

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -72,7 +72,8 @@ public:
       bool unmap_vdso = false,
       bool force_asan_active = false,
       bool force_tsan_active = false,
-      bool intel_pt = false);
+      bool intel_pt = false,
+      bool check_outside_mmaps = false);
 
   ~RecordSession() override;
 
@@ -98,6 +99,7 @@ public:
   }
   bool use_audit() const { return use_audit_; }
   bool unmap_vdso() { return unmap_vdso_; }
+  bool check_outside_mmaps() { return check_outside_mmaps_; }
   uint64_t rr_signal_mask() const;
 
   enum RecordStatus {
@@ -221,7 +223,8 @@ private:
                 const TraceUuid* trace_id,
                 bool use_audit,
                 bool unmap_vdso,
-                bool intel_pt);
+                bool intel_pt,
+                bool check_outside_mmaps);
 
   virtual void on_create(Task* t) override;
 
@@ -286,6 +289,7 @@ private:
 
   bool use_audit_;
   bool unmap_vdso_;
+  bool check_outside_mmaps_;
 };
 
 } // namespace rr

--- a/src/test/mmap_shared_extern.c
+++ b/src/test/mmap_shared_extern.c
@@ -1,0 +1,49 @@
+#include "util.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+int main(__attribute__((unused)) int argc, char* argv[], char* argenv[]) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char last = 0;
+  char* p;
+  int proc_num = argv[2][0] - '0';
+  int timeout = 30000; // 30 seconds
+
+  if (argv[3][0] > '0') {
+    if (fork() == 0) {
+      char proc_num_arg[2] = {'0' + proc_num + 1, '\0'};
+      char proc_to_start_arg[2] = {argv[3][0] - 1, '\0'};
+      char* execv_argv[] = {argv[0], argv[1], proc_num_arg, proc_to_start_arg, NULL};
+      execve("/proc/self/exe", execv_argv, argenv);
+    }
+  }
+
+  int fd = open(argv[1], O_RDWR|O_CREAT, 0600);
+  test_assert(fd >= 0);
+  ftruncate(fd, page_size);
+  p = (char*)mmap(0, page_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+  assert(p != MAP_FAILED);
+
+  while (1) {
+    if ((*p % 2) == proc_num) {
+      if ((*p)++ >= 6) {
+        atomic_printf("%d %d exiting.\n", getpid(), proc_num);
+        usleep(50000); /* first recorded process exiting kills all others, wait a little. */
+        return 0;
+      }
+    }
+    if (last != *p)
+      atomic_printf("%d\n", last = *p);
+    usleep(50000);
+    timeout -= 50;
+    if (timeout < 0) {
+        atomic_printf("timeout reached.\n");
+        return 0;
+    }
+  }
+  return 0;
+}

--- a/src/test/mmap_shared_extern.run
+++ b/src/test/mmap_shared_extern.run
@@ -1,0 +1,25 @@
+source `dirname $0`/util.sh
+
+skip_if_rr_32_bit_with_shell_64_bit
+
+rm -rf $workdir/map_file
+RECORD_ARGS="--check-outside-mmaps"
+record mmap_shared_extern$bitness $workdir/map_file 0 1
+mv record.out record.out.1
+mv record.err record.err.1
+grep "could cause diversion" $workdir/record.out.1 > /dev/null
+if [[ $? != 1 ]]; then
+  failed "\"could cause diversion\" was returned when all processes are inside the recording."
+  exit
+fi
+
+rm -rf $workdir/map_file
+mmap_shared_extern$bitness $workdir/map_file 0 0 > /dev/null&
+RECORD_ARGS="--check-outside-mmaps"
+record mmap_shared_extern$bitness $workdir/map_file 1 0
+mv record.out record.out.2
+mv record.err record.err.2
+grep "could cause diversion" $workdir/record.out.2 > /dev/null
+if [[ $? != 0 ]]; then
+  failed "\"could cause diversion\" was not returned when some processes are outside the recording."
+fi


### PR DESCRIPTION
In its current state it just calls lsof with the pids inside the the recording excluded.

It would show the mapping that caused the issue in #3417,
but the others are probably just read-only mappings due to /proc/pid/maps.
```
$ rr record --lsof -n atril sshfs/home/benutzer/test2.pdfrr: Saving execution to trace directory `/home/bernhard/data/entwicklung/2022/rr/rr-recordings/atril-14'.
Warning: /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /home/bernhard/.cache/fontconfig/a6050266-6adb-4e1c-8a1d-f55d18a3f9c3-le64.cache-7 seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /run/user/1000/dconf/user seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /home/bernhard/.local/share/mime/mime.cache seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /usr/local/share/mime/mime.cache seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /usr/share/mime/mime.cache seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /home/bernhard/.local/share/gvfs-metadata/root seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
Warning: /home/bernhard/.local/share/gvfs-metadata/root-5c301c7a.log seems to be mapped by a process outside of the recording. Diversions might happen when replaying this trace.
...
```