### PR TITLE
Explicitly include <cstdint> where required.

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <type_traits>
 #include <vector>
+#include <cstdint>
 
 /**
  * Print siginfo on ostream.

--- a/src/remote_ptr.h
+++ b/src/remote_ptr.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <iostream>
+#include <cstdint>
 
 namespace rr {
 


### PR DESCRIPTION
The uint8_t and uintptr_t ptr types are from the header <cstdint>. Earlier versions of gcc appear to declare them even if the header is not included, but gcc-13 does not.  Explicitly including the header to allow compilations with gcc-13.