### PR TITLE
Annotate ReplayTask::post_vm_clone with `override`

### DIFF
--- a/src/ReplayTask.h
+++ b/src/ReplayTask.h
@@ -88,7 +88,7 @@ public:
 private:
   template <typename Arch> void init_buffers_arch(remote_ptr<void> map_hint);
 
-  virtual bool post_vm_clone(CloneReason reason, int flags, Task* origin);
+  bool post_vm_clone(CloneReason reason, int flags, Task* origin) override;
 
   std::string name_;
 


### PR DESCRIPTION
This fixes the following clang warning (treated as a build error):
```
src/ReplayTask.h:91:16: error: 'post_vm_clone' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
```

This warning only cropped up recently; I'm guessing it was from https://github.com/rr-debugger/rr/commit/7361bbfe30162f36dd6c0019c511ef4a19fd54f0 which added the first mention of `override` in this header, which is what made this already-implicitly-overriding declaration "inconsistent" (per the clang warning).