### PR TITLE
Restructure Android build with a Dockerfile.

### DIFF
--- a/.android/Dockerfile
+++ b/.android/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:latest
+
+ARG ndk_version=r25c
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    cmake \
+    ninja-build \
+    python3 \
+    unzip
+
+RUN curl -o ndk.zip https://dl.google.com/android/repository/android-ndk-${ndk_version}-linux.zip
+RUN unzip ndk.zip && mv android-ndk-${ndk_version} /ndk
+
+RUN curl -o capnproto.tar.gz https://capnproto.org/capnproto-c++-0.10.2.tar.gz
+RUN mkdir -p /src/capnproto
+RUN tar zxf capnproto.tar.gz -C /src/capnproto --strip-components=1
+RUN mkdir -p /build/capnproto
+RUN cd /build/capnproto
+RUN /src/capnproto/configure
+RUN make -j$(nproc) install
+RUN cd -
+
+RUN mkdir -p /build/rr
+RUN chmod 777 /build/rr
+
+WORKDIR /build/rr
+CMD ["/bin/bash", "/src/rr/.android/build.sh"]

--- a/.android/README.md
+++ b/.android/README.md
@@ -1,0 +1,22 @@
+# Building for Android
+
+To build for Android (from the root of the rr source tree):
+
+```
+docker build .android -t rr-android
+mkdir -p obj/dist
+docker run -it --rm \
+    -u $UID:$GID \
+    -v $(pwd):/src/rr \
+    -v $(pwd)/obj/dist:/dist \
+    rr-android
+```
+
+`-u $UID:GID` ensures that the build runs with your current UID/GID, which is
+necessary to avoid the output being only writable by root.
+
+`-v $(pwd):/src/rr` mounts the source tree in the container so it can be built.
+
+`-v $(pwd)/obj/dist:/dist` sets the output directory for the container to the
+current directory. The last step of the build will copy the rr tarball to the
+directory on the left of `:`.

--- a/.android/build.sh
+++ b/.android/build.sh
@@ -1,36 +1,36 @@
 #!/usr/bin/env bash
+set -e
+set -x
 
-set +x
-set +e
+DEVICE_CMAKE_DEFS="-DCMAKE_TOOLCHAIN_FILE=/ndk/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86_64 -DANDROID_PLATFORM=android-28"
 
-DEVICE_CMAKE_DEFS="-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86_64 -DANDROID_PLATFORM=android-28"
-
-apt-get install -y cmake g++
-curl -O https://capnproto.org/capnproto-c++-0.10.2.tar.gz
-tar zxf capnproto-c++-0.10.2.tar.gz
-cd capnproto-c++-0.10.2
-# Build capnp once for the host
-./configure
-make -j8
-make install
-cd ..
-rm -rf capnproto-c++-0.10.2
-tar zxf capnproto-c++-0.10.2.tar.gz
-cd capnproto-c++-0.10.2
 # Build capnp again for the device
-cmake $DEVICE_CMAKE_DEFS -DEXTERNAL_CAPNP=True -DBUILD_SHARED_LIBS=True
-make -j8
-cd ..
+INSTALL_PREFIX=$(pwd)/install
+mkdir -p $INSTALL_PREFIX
+mkdir capnproto-android
+cd capnproto-android
+cmake -G Ninja \
+  $DEVICE_CMAKE_DEFS \
+  -DEXTERNAL_CAPNP=True \
+  -DBUILD_SHARED_LIBS=True \
+  -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
+  /src/capnproto
+cmake --build .
+cmake --install .
+cd -
+
 mkdir obj
 cd obj
-cmake .. $DEVICE_CMAKE_DEFS \
-      -Ddisable32bit=True \
-      -DBUILD_TESTS=False \
-      -DSKIP_PKGCONFIG=True \
-      -DEXTRA_VERSION_STRING="$BUILD_ID" \
-      -DCAPNP_CFLAGS=-I../capnproto-c++-0.10.2/src/ \
-      -DCAPNP_LDFLAGS="-L../capnproto-c++-0.10.2/src/capnp -lcapnp -L../capnproto-c++-0.10.2/src/kj -lkj" \
-      -DZLIB_LDFLAGS="-lz" \
-      -DEXTRA_EXTERNAL_SOLIBS="capnproto-c++-0.10.2/src/kj/libkj.so;capnproto-c++-0.10.2/src/capnp/libcapnp.so"
-make -j8
+cmake -G Ninja \
+  $DEVICE_CMAKE_DEFS \
+  -Ddisable32bit=True \
+  -DBUILD_TESTS=False \
+  -DCMAKE_FIND_ROOT_PATH=$INSTALL_PREFIX \
+  -DSKIP_PKGCONFIG=True \
+  -DEXTRA_VERSION_STRING="$BUILD_ID" \
+  -DZLIB_LDFLAGS=-lz \
+  /src/rr
+cmake --build .
 cpack -G TGZ
+
+cp dist/* /dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Dockerfile
+        shell: bash
+        run: docker build -t rr-android .android
+
+      - name: Create dist dir
+        shell: bash
+        run: mkdir -p obj/dist
+
+      - name: Build RR
+        shell: bash
+        run: |
+          docker run --rm \
+            -v $(pwd):/src/rr \
+            -v $(pwd)/obj/dist:/dist \
+            rr-android
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rr
+          path: obj/dist/rr-*-Android-x86_64.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ set(rr_VERSION_MAJOR 5)
 set(rr_VERSION_MINOR 6)
 set(rr_VERSION_PATCH 0)
 
+if(ANDROID)
+  find_package(CapnProto REQUIRED)
+endif()
+
 add_definitions(-DRR_VERSION="${rr_VERSION_MAJOR}.${rr_VERSION_MINOR}.${rr_VERSION_PATCH}")
 
 execute_process(
@@ -665,6 +669,8 @@ if(staticlibs)
   target_link_libraries(rr -L/home/roc/lib -l:libcapnp.a -l:libkj.a)
   # Note that this works for both clang++ and g++
   set(RR_MAIN_LINKER_FLAGS "-static-libstdc++ ${RR_MAIN_LINKER_FLAGS}")
+elseif(ANDROID)
+  target_link_libraries(rr CapnProto::capnp)
 else()
   target_link_libraries(rr ${CAPNP_LDFLAGS})
 endif()


### PR DESCRIPTION
Remove the "works on my machine" guesswork. This keeps all the Android parts of the build in build.sh, but moves all the host dependencies (including the capnproto fetch) into the Dockerfile.

This cleans up some of the header/library directory handling as well, which was necessary for making the build script work when the host and target builds are separate (CAPNP_CFLAGS doesn't actually exist, so the build was previously finding the host's includes by coincidence?)

@khuey wdyt? This was a byproduct of me trying to debug https://github.com/rr-debugger/rr/pull/3432. It's helpful to me as someone that doesn't actually know much about building rr, but if it's just going to be in your way we should probably just close this :)

(in any case, it's not ready to submit yet as the Android CI script will need to be updated to account for this)