### PR TITLE
Fix the force32bit build by using a longlong constant.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5697,7 +5697,7 @@ static void process_execve(RecordTask* t, TaskSyscallState& syscall_state) {
         ASSERT(t, r == sizeof(pfn));
         // If the page is physically present (bit 63) or in swap (bit 62)
         // then it was modified by the kernel and we need to record it.
-        if (pfn & ((1UL << 63) | (1UL << 62))) {
+        if (pfn & ((1ULL << 63) | (1ULL << 62))) {
           pages_to_record.push_back(ptr);
         }
         ptr += page_size();


### PR DESCRIPTION
A git bisect leads to commit 1cf13c629.

Also a build shows this warning:
```
src/record_syscall.cc:5648:25: warning: left shift count >= width of type [-Wshift-count-overflow]
 5648 |         if (pfn & ((1UL << 63) | (1UL << 62))) {
```

With this patch a 32bit and a 64bit build succeeds all tests for me.
(Except detach_sigkill because of issue 3385.)