### PR TITLE
Fix invalid_jump running at i386 kernel.

### DIFF
--- a/src/test/invalid_jump.c
+++ b/src/test/invalid_jump.c
@@ -7,9 +7,13 @@ static void sighandler(int sig) {
   _exit(0);
 }
 
-char invalid_jump_here[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
-
 int main(void) {
+  char* invalid_jump_here;
+  size_t page_size = sysconf(_SC_PAGESIZE);
+
+  invalid_jump_here = (char*)mmap(NULL, page_size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  test_assert(invalid_jump_here != MAP_FAILED);
+
   // Just for clean exit to not worry people running the test manually ;).
   signal(SIGSEGV, sighandler);
   ((void (*)(void))invalid_jump_here)();


### PR DESCRIPTION
The function invalid_jump_here is initialized with zeros which get seen as two `add %al,(%eax)` instructions.
Unfortunately $eax contains the function pointer itself, and because for some reason this function is mapped to rw memory running at an i386 kernel, this instructions succeed. Therefore the test fails as the reverse-stepi just stays inside invalid_jump_here.

This was at least observed inside a i386 qemu VM with a Ryzen host, both running Debian testing.

The patch does three things:
* change that `add %al,(%eax)` into `add %al,(%ecx)`
* attempts to clear register ecx right before the invalid call
* changes the function storage to const (that would also fix the issue alone already)

Also, I am uncertain if this change would still work with arm64.

This is an example gdb session to demonstrate:
```gdb
$ gdb -q --args bin/invalid_jump
Reading symbols from bin/invalid_jump...
(gdb) b main
Breakpoint 1 at 0x1349: file .../rr/src/test/invalid_jump.c, line 14.
(gdb) run
Starting program: .../i686/obj/bin/invalid_jump 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/i386-linux-gnu/libthread_db.so.1".

Breakpoint 1, main () at .../rr/src/test/invalid_jump.c:14
14        signal(SIGSEGV, sighandler);
(gdb) next
15        ((void (*)(void))invalid_jump_here)();
(gdb) display/i $pc
1: x/i $pc
=> 0x40135d <main+46>:  lea    0x48(%ebx),%eax
(gdb) display/x $eax
2: /x $eax = 0x0
(gdb) display/x *(int*)$eax
3: /x *(int*)$eax = <error: Cannot access memory at address 0x0>
(gdb) stepi
0x00401363      15        ((void (*)(void))invalid_jump_here)();
1: x/i $pc
=> 0x401363 <main+52>:  call   *%eax
2: /x $eax = 0x40403c
3: /x *(int*)$eax = 0x0
(gdb) 
0x0040403c in invalid_jump_here ()
1: x/i $pc
=> 0x40403c <invalid_jump_here>:        add    %al,(%eax)
2: /x $eax = 0x40403c
3: /x *(int*)$eax = 0x0
(gdb) 
0x0040403e in invalid_jump_here ()
1: x/i $pc
=> 0x40403e <invalid_jump_here+2>:      add    %al,(%eax)
2: /x $eax = 0x40403c
3: /x *(int*)$eax = 0x3c
(gdb) info thread
  Id   Target Id                                    Frame 
* 1    Thread 0xb7fc4540 (LWP 25251) "invalid_jump" 0x0040403e in invalid_jump_here ()
(gdb) shell cat /proc/25251/maps | grep 404000-
00404000-00405000 rw-p 00003000 08:11 404177     .../i686/obj/bin/invalid_jump

$ uname -a
Linux debian 6.1.0-3-686-pae #1 SMP PREEMPT_DYNAMIC Debian 6.1.8-1 (2023-01-29) i686 GNU/Linux
```