### PR TITLE
Skip rdtsc_loop with a 32-bit rr.

### DIFF
--- a/src/test/x86/rdtsc_loop2.run
+++ b/src/test/x86/rdtsc_loop2.run
@@ -1,4 +1,5 @@
 source `dirname $0`/util.sh
 skip_if_no_syscall_buf
 skip_if_test_32_bit
+skip_if_rr_32_bit
 compare_test EXIT-SUCCESS


### PR DESCRIPTION
Currently with skip_if_test_32_bit it is just skipped with a 64-bit rr running the 32-bit test.

This test `x86/rdtsc_loop2` finishes for me just in time near 120 seconds,
when running at bare metal and below a 64-bit kernel with 32-bit rr.
But it fails when running inside a qemu VM running a 32-bit kernel - there it needs near 240 seconds.

So this patch adds the `skip_if_rr_32_bit` to avoid running below a 32-bit rr.

Or would it be better to change `skip_if_test_32_bit` to match this case too?
Because `skip_if_rr_32_bit` just checks bitness based at `$bitness`, which seems not set for a 32-bit rr.