### PR TITLE
ci: Add basic GitHub CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,42 @@
+name: C/C++ CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      commits:
+        description: git range to include
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        DEBIAN_FRONTEND=noninteractive sudo apt-get -y install \
+          ccache cmake g++-multilib gdb \
+          manpages-dev \
+          ninja-build capnproto libcapnp-dev
+    - name: cmake
+      run: |
+        CC=clang CXX=clang++ cmake -G Ninja 
+        cmake --build .
+    - name: cherry-picks
+      if: github.event.inputs.commits
+      run: |
+        git config --global user.email "check-spelling-bot@users.noreply.github.com"
+        git config --global user.name "check-spelling-bot"
+
+        for commit in $(
+          git log --oneline ${{github.event.inputs.commits}} -- |perl -pe 's/\s.*//'|tac
+        ); do
+          git cherry-pick $commit || exit 1
+          cmake --build . || exit 2
+        done


### PR DESCRIPTION
Not everyone has Linux and the resources to build...

This provides a simple GitHub CI to validate that a given commit builds.

It also enables one to ask if a series of commits incrementally build on top of a commit.

I used this to validate that #3449  -- see https://github.com/check-spelling/rr/actions/runs/4279177139/jobs/7449627530#step:5:13

Note that this does not include running the test suite. In my naive attempt at doing that, a run hit the 6 hour time limit.
It's possible to set up a matrix and perform slices of the tests using it, but that'd require understanding how to slice the tests.