### PR TITLE
Require cmake that has add_compile_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # *-* Mode: cmake; *-*
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.12.0)
 project(rr C CXX ASM)
 
 # "Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property."


### PR DESCRIPTION
Building with cmake 3.10 fails with this error
CMake Error at CMakeLists.txt:341 (add_compile_definitions):
  Unknown CMake command "add_compile_definitions".

add_compile_definitions was added in 3.12, which should be reflected in the cmake_minimum_version requirement