### PR TITLE
[Do not merge] CI: exit_race fails

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -2244,6 +2244,9 @@ remote_ptr<void> AddressSpace::chaos_mode_find_free_memory(RecordTask* t,
     hint = nullptr;
   }
 
+  /* add three pages for allocate_extended_jump_x86ish */
+  len += 3 * page_size();
+
   int bits = random_addr_bits(t->arch());
   remote_ptr<void> start = hint;
   if (!start) {


### PR DESCRIPTION
I was able to reproduce the exit_race failure from the CI also in my test VM.
A bisect leads to commit 1ff7164c.

This pull request contains some more logging.
With the `if (!m.map.is_vsyscall()) {` commented out,
it always fails when "random()" selected the `vsyscall` mapping as starting point.
And therefore mmap gets called with `0x7ffffff00000`, but fails with ENOMEM.

I found this with the default kernel 4.15.0-204-generic, but also with a 6.2.0-060200-generic.
No other versions tested yet.

This pull requests tries therefore to avoid using vsyscall mapping
as starting point in function `chaos_mode_find_free_memory`.
What do you think?


```
$ RR_LOG=all bin/rr record --chaos bin/exit_race
...
[INFO log_pending_events()] SYSCALL: rrcall_init_buffers
[INFO log_pending_events()] (none)
[RecordSession] EXEC_SYSCALL_DONE: status=0x857f (SYSCALL)
[RecordSession]   original_syscallno:1001 (rrcall_init_buffers); return val:0xffffffffffffffda
[record_syscall] 25443: processing: SYSCALL: rrcall_init_buffers -- time: 1596
[AddressSpace] candidate map[0]: 0x68000000-0x68200000 rwxp 00000000 00:00 0          
[AddressSpace] candidate map[1]: 0x6fffd000-0x70000000 r-xp 00000000 fd:00 415037     /home/benutzer/obj/lib/rr/librrpage.so
[AddressSpace] candidate map[2]: 0x70000000-0x70001000 r-xp 00003000 fd:00 415037     /home/benutzer/obj/lib/rr/librrpage.so
[AddressSpace] candidate map[3]: 0x70001000-0x70002000 rw-s 00000000 fd:00 402546     /tmp/rr-shared-preload_thread_locals-25383-0
[AddressSpace] candidate map[4]: 0xe0000000-0xe001a000 r-xp 00000000 fd:00 789215     /lib/x86_64-linux-gnu/libpthread-2.27.so
[AddressSpace] candidate map[5]: 0xe001a000-0xe0219000 ---p 0001a000 fd:00 789215     /lib/x86_64-linux-gnu/libpthread-2.27.so
[AddressSpace] candidate map[6]: 0xe0219000-0xe021a000 r--p 00019000 fd:00 789215     /lib/x86_64-linux-gnu/libpthread-2.27.so
[AddressSpace] candidate map[7]: 0xe021a000-0xe021b000 rw-p 0001a000 fd:00 789215     /lib/x86_64-linux-gnu/libpthread-2.27.so
[AddressSpace] candidate map[8]: 0xe021b000-0xe021f000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[9]: 0xe0220000-0xe0221000 r-xp 00000000 00:00 0          
[AddressSpace] candidate map[10]: 0x6d141f79000-0x6d142160000 r-xp 00000000 fd:00 787257     /lib/x86_64-linux-gnu/libc-2.27.so
[AddressSpace] candidate map[11]: 0x6d142160000-0x6d142360000 ---p 001e7000 fd:00 787257     /lib/x86_64-linux-gnu/libc-2.27.so
[AddressSpace] candidate map[12]: 0x6d142360000-0x6d142364000 r--p 001e7000 fd:00 787257     /lib/x86_64-linux-gnu/libc-2.27.so
[AddressSpace] candidate map[13]: 0x6d142364000-0x6d142366000 rw-p 001eb000 fd:00 787257     /lib/x86_64-linux-gnu/libc-2.27.so
[AddressSpace] candidate map[14]: 0x6d142366000-0x6d14236a000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[15]: 0x6d14236b000-0x6d14236c000 r-xp 00000000 00:00 0          
[AddressSpace] candidate map[16]: 0x9784befb000-0x9784befe000 r-xp 00000000 fd:00 787275     /lib/x86_64-linux-gnu/libdl-2.27.so
[AddressSpace] candidate map[17]: 0x9784befe000-0x9784c0fd000 ---p 00003000 fd:00 787275     /lib/x86_64-linux-gnu/libdl-2.27.so
[AddressSpace] candidate map[18]: 0x9784c0fd000-0x9784c0fe000 r--p 00002000 fd:00 787275     /lib/x86_64-linux-gnu/libdl-2.27.so
[AddressSpace] candidate map[19]: 0x9784c0fe000-0x9784c0ff000 rw-p 00003000 fd:00 787275     /lib/x86_64-linux-gnu/libdl-2.27.so
[AddressSpace] candidate map[20]: 0x9784c108000-0x9784c111000 r-xp 00000000 fd:00 416793     /home/benutzer/obj/lib/rr/librrpreload.so
[AddressSpace] candidate map[21]: 0x9784c111000-0x9784c310000 ---p 00009000 fd:00 416793     /home/benutzer/obj/lib/rr/librrpreload.so
[AddressSpace] candidate map[22]: 0x9784c310000-0x9784c311000 r--p 00008000 fd:00 416793     /home/benutzer/obj/lib/rr/librrpreload.so
[AddressSpace] candidate map[23]: 0x9784c311000-0x9784c312000 rw-p 00009000 fd:00 416793     /home/benutzer/obj/lib/rr/librrpreload.so
[AddressSpace] candidate map[24]: 0x9784c312000-0x9784c318000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[25]: 0x19520293a000-0x19520293b000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[26]: 0x4ce662dde000-0x4ce662de0000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[27]: 0x51e2102cf000-0x51e2102d1000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[28]: 0x55ac98c0a000-0x55ac98c0c000 r-xp 00000000 fd:00 417409     /home/benutzer/obj/bin/exit_race
[AddressSpace] candidate map[29]: 0x55ac98e0b000-0x55ac98e0c000 r--p 00001000 fd:00 417409     /home/benutzer/obj/bin/exit_race
[AddressSpace] candidate map[30]: 0x55ac98e0c000-0x55ac98e0d000 rw-p 00002000 fd:00 417409     /home/benutzer/obj/bin/exit_race
[AddressSpace] candidate map[31]: 0x55ac9aafe000-0x55ac9ab1f000 rw-p 00000000 00:00 0          [heap]
[AddressSpace] candidate map[32]: 0x6d4e5ef21000-0x6d4e5ef22000 ---p 00000000 00:00 0          
[AddressSpace] candidate map[33]: 0x6d4e5ef22000-0x6d4e5f722000 rw-p 00000000 00:00 0          [stack]
[AddressSpace] candidate map[34]: 0x7b0e39f81000-0x7b0e3a081000 rw-s 00000000 fd:00 404248     /tmp/rr-shared-syscallbuf.25383-25383-1
[AddressSpace] candidate map[35]: 0x7f3e8b05d000-0x7f3e8b25d000 rwxp 00000000 00:00 0          
[AddressSpace] candidate map[36]: 0x7f3e8b25d000-0x7f3e8b286000 r-xp 00000000 fd:00 787226     /lib/x86_64-linux-gnu/ld-2.27.so
[AddressSpace] candidate map[37]: 0x7f3e8b287000-0x7f3e8b288000 r-xp 00000000 00:00 0          
[AddressSpace] candidate map[38]: 0x7f3e8b486000-0x7f3e8b487000 r--p 00029000 fd:00 787226     /lib/x86_64-linux-gnu/ld-2.27.so
[AddressSpace] candidate map[39]: 0x7f3e8b487000-0x7f3e8b488000 rw-p 0002a000 fd:00 787226     /lib/x86_64-linux-gnu/ld-2.27.so
[AddressSpace] candidate map[40]: 0x7f3e8b488000-0x7f3e8b489000 rw-p 00000000 00:00 0          
[AddressSpace] candidate map[41]: 0x7ffd35b3f000-0x7ffd35b61000 rw-p 00000000 00:00 0          [stack]
[AddressSpace] candidate map[42]: 0x7ffd35b75000-0x7ffd35b77000 r-xp 00000000 00:00 0          [vdso]
[AddressSpace] candidate map[43]: 0xffffffffff600000-0xffffffffff601000 r-xp 00000000 00:00 0          [vsyscall]
[AddressSpace] map_index=43
[AddressSpace] random() % 2 was false, addr_space_limit=0x800000000000 start=0x7ffffff00000 len=0x100000 map_index=43 mem.size()=44 orig_hint=0 direction=1
[AddressSpace] mmap(0x7ffffff00000, 1048576, 0x3, 0x1, 0)
[AddressSpace] munmap(0x7ffffff00000, 1048576)
[AddressSpace]   mapping at 0xffffffffff600000 out of range, done.
[AddressSpace]   mapping 0x7ffffff00000-0x800000000000 rw-s 00000000 fd:00 413817     /tmp/rr-shared-syscallbuf.25443-25383-61
[AddressSpace]   no mappings to coalesce
[AutoRemoteSyscalls] Sending fd 15 via socket fd 11
[AutoRemoteSyscalls] syscall recvmsg { ip:0x7000000f args:(0x3e9,0x7f3e8b25cd90,0,0,0,0) orig_syscall: 1001 syscallno: -38 }
[Task] resuming execution of 25443 with PTRACE_SINGLESTEP tick_period -2 wait 0
[Task] Flushing registers for tid 25443 { ip:0x7000000f args:(0x3e9,0x7f3e8b25cd90,0,0,0,0) orig_syscall: 47 syscallno: 47 }
[Task] going into blocking wait for 25443 ...
[Task]   Task 25443 changed status to 0x57f (STOP-SIGTRAP)
[Task]   (refreshing register cache)
[Task] Requesting registers from tracee 25443
[AutoRemoteSyscalls] Used singlestep path; status=0x57f (STOP-SIGTRAP)
[AutoRemoteSyscalls] done, result=1
[Session] created shmem segment /tmp/rr-shared-syscallbuf.25443-25383-61 with size 0x100000 at 0x7ffffff00000 required_child_addr=0
[AutoRemoteSyscalls] syscall mmap { ip:0x7000000f args:(0x7ffffff00000,0x100000,0x3,0x11,0x3,0) orig_syscall: 0x3e9 syscallno: 0xffffffffffffffda }
[Task] resuming execution of 0x6363 with PTRACE_SINGLESTEP tick_period 0xfffffffe wait 0
[Task] Flushing registers for tid 0x6363 { ip:0x7000000f args:(0x7ffffff00000,0x100000,0x3,0x11,0x3,0) orig_syscall: 0x9 syscallno: 0x9 }
[Task] going into blocking wait for 0x6363 ...
[Task]   Task 0x6363 changed status to 0x57f (STOP-SIGTRAP)
[Task]   (refreshing register cache)
[Task] Requesting registers from tracee 0x6363
[AutoRemoteSyscalls] Used singlestep path; status=0x57f (STOP-SIGTRAP)
[AutoRemoteSyscalls] done, result=0xfffffffffffffff4
[FATAL /home/benutzer/rr/src/AutoRemoteSyscalls.cc:0x311:check_syscall_result()] 
 (task 0x6363 (rec:0x6363) at time 0x63c)
 -> Assertion `false' failed to hold. Syscall mmap failed with errno ENOMEM
...
```