### PR TITLE
Revert to minimum cmake version 3.1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # *-* Mode: cmake; *-*
 
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.1.0)
 project(rr C CXX ASM)
 
 # "Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property."
@@ -338,7 +338,11 @@ list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
 check_symbol_exists(backtrace "execinfo.h" EXECINFO_BACKTRACE)
 if(EXECINFO_BACKTRACE)
-  add_compile_definitions(EXECINFO_BACKTRACE)
+  if("${CMAKE_VERSION}" VERSION_LESS "3.12")
+    message(AUTHOR_WARNING "backtrace(3) present, but cmake ${CMAKE_VERSION} too old, needs 3.12 or later. Automatic backtraces for failures in rr are disabled.")
+  else()
+    add_compile_definitions(EXECINFO_BACKTRACE)
+  endif()
 else()
   message(AUTHOR_WARNING "backtrace(3) not present in execinfo.h. Automatic backtraces for failures in rr are disabled.")
 endif()


### PR DESCRIPTION
And use add_compile_definitions just equal or above cmake 3.12.

Related: f39e6e9ea
Related: 797278698

Raising the minimum cmake version broke at least a vanilla Ubuntu 18.04
with 3.10.2, which worked before those commits, except the backtrace.
Maybe it is worth to leave the minimum version 3.1 for now?