### PR TITLE
Improve robustness of SIGTERM with detached tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1426,6 +1426,7 @@ set(TESTS_WITH_PROGRAM
   mprotect_syscallbuf_overflow
   mutex_pi_stress
   nested_detach_wait
+  nested_detach_kill_stuck
   overflow_branch_counter
   patch_page_end
   x86/patch_40_80_f6_81

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2635,9 +2635,10 @@ void RecordSession::term_detached_tasks() {
     }
     ::kill(t->rec_tid, SIGTERM);
   }
-  for (auto& v : task_map) {
-    RecordTask* t = static_cast<RecordTask*>(v.second);
+  for (auto it = task_map.begin(); it != task_map.end(); ) {
+    RecordTask* t = static_cast<RecordTask*>(it->second);
     if (!t->detached_proxy) {
+      ++it;
       continue;
     }
     WaitResult result = WaitManager::wait_exit(WaitOptions(t->rec_tid));
@@ -2647,6 +2648,8 @@ void RecordSession::term_detached_tasks() {
       LOG(warn) << "Unexpected wait status " << result.status <<
         " while waiting for detached child " << t->rec_tid;
     }
+    ++it;
+    delete t;
   }
 }
 

--- a/src/test/nested_detach_kill_stuck.c
+++ b/src/test/nested_detach_kill_stuck.c
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+struct timespec ts = { 10000, 0 };
+
+static void handle_sigterm(__attribute__((unused)) int sig,
+                           __attribute__((unused)) siginfo_t* info,
+                           __attribute__((unused)) void* mcontext) {
+  /* This simulates a process that takes a long time to exit on SIGTERM.
+     Maybe it's a database trying to flush or a process that's trying to
+     print backtraces or something. */
+  nanosleep(&ts, NULL);
+  exit(1);
+}
+
+int main(void) {
+  struct sigaction sa;
+
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = handle_sigterm;
+  sigaction(SIGTERM, &sa, NULL);
+
+  atomic_puts("sleeping");
+  nanosleep(&ts, NULL);
+
+  return 1;
+}

--- a/src/test/nested_detach_kill_stuck.run
+++ b/src/test/nested_detach_kill_stuck.run
@@ -1,0 +1,38 @@
+source `dirname $0`/util.sh
+
+NEST_EXE=nested_detach_wait
+SLEEP_EXE=nested_detach_kill_stuck
+SYNC_TOKEN=sleeping
+WAIT_SECS=1
+
+mkdir $workdir/inner
+RECORD_ARGS="--wait --env=_RR_TRACE_DIR=$workdir/inner"
+save_exe "$NEST_EXE"
+save_exe "$SLEEP_EXE"
+touch record.out
+just_record $NEST_EXE-$nonce "$(which rr) record --nested=detach $PWD/$SLEEP_EXE-$nonce" &
+SUB_ID=$!
+
+echo "Waiting for token '$SYNC_TOKEN' from tracee ..."
+until grep -q $SYNC_TOKEN record.out; do
+    sleep 0
+    if ! kill -0 "$SUB_ID" >/dev/null 2>&1; then failed "subshell died, no need to longer wait for '$SYNC_TOKEN'"; exit; fi
+done
+
+rrpid=$(parent_pid_of $(pidof $NEST_EXE-$nonce))
+echo "  done.  Delivering SIGTERM to $rrpid ..."
+kill -TERM $rrpid
+
+echo "  done."
+
+# Wait for 'record' to actually terminate.
+wait
+
+# Replay outer
+replay
+# Replay inner
+cd $workdir/inner
+workdir=$PWD
+wait_for_complete
+replay
+check_replay_token $SYNC_TOKEN


### PR DESCRIPTION
Fix https://github.com/rr-debugger/rr/issues/3464
- Allow `result.code == WAIT_NO_STATUS` when waiting for exit and retry
  since we could have gotten EINTR'd (in this case by the SIGTERM)
- Increase the timeout for the kernel and rr to cleanup after shooting down
  the tracees to 5s. I'm still not convinced this is necessarily sufficient for
  huge tracees under load, but 1s was observably insufficient, so set it to 5 for
  now and we can increase further if required. After 1s, it will print the user to
  reassure that something is happening still and the wait is deliberate.
- Once a detached tracee has been waited for, make sure to actually delete it,
  otherwise we might get confused trying to wait for it later.
