### PR TITLE
CI: Allow manual retry of succesful builds

### DIFF
--- a/.buildkite/lib/generate.jl
+++ b/.buildkite/lib/generate.jl
@@ -65,6 +65,7 @@ function generate(platform::Platform)
                     ),
                 ],
                 "soft_fail" => "$(platform.allow_fail)",
+                "retry" => Dict("manual" => Dict("permit_on_passed" => true))
             ),
         ],
     )


### PR DESCRIPTION
By default, retry is only enabled for failed builds. When investigating intermittent failures, it can be useful to retry successful builds also, so enable that in the UI.

https://buildkite.com/docs/pipelines/command-step#retry-attributes-manual-retry-attributes

cc @staticfloat @DilumAluthge 