### PR TITLE
CI: Try relaxing architecture restriction on generator script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,6 @@ steps:
     agents:
       queue: "juliaecosystem"
       os: "linux"
-      arch: "x86_64"
     commands: |
       echo "--- Instantiate the environment"
       julia --project=.buildkite -e 'import Pkg; Pkg.instantiate()'


### PR DESCRIPTION
The script that schedules the actual CI jobs is currently required to run on x86_64. When the x86_64 queues are backed up (like today), it would be nice to be able to run this on aarch64, to at least get some indication of whether the PR works. Try this and see if everything just magically works.