### PR TITLE
Fix deadlock in TraceeAttentionSet

### DIFF
--- a/src/TraceeAttentionSet.cc
+++ b/src/TraceeAttentionSet.cc
@@ -40,9 +40,7 @@ static void* tracee_attention_set_thread(__attribute__((unused)) void* p) {
 }
 
 void TraceeAttentionSet::initialize() {
-  pthread_mutex_lock(&attention_set_lock);
   if (attention_set) {
-    pthread_mutex_unlock(&attention_set_lock);
     return;
   }
   attention_set = new unordered_set<pid_t>();
@@ -51,7 +49,6 @@ void TraceeAttentionSet::initialize() {
   sigset_t set;
   sigfillset(&set);
   sigprocmask(SIG_BLOCK, &set, &original_mask);
-  pthread_mutex_unlock(&attention_set_lock);
 
   pthread_t thread;
   pthread_create(&thread, nullptr, tracee_attention_set_thread, nullptr);
@@ -77,13 +74,11 @@ unordered_set<pid_t> TraceeAttentionSet::read() {
 }
 
 void TraceeAttentionSet::get_original_sigmask(sigset_t* out) {
-  pthread_mutex_lock(&attention_set_lock);
   if (attention_set) {
     *out = original_mask;
   } else {
     sigprocmask(SIG_BLOCK, nullptr, out);
   }
-  pthread_mutex_unlock(&attention_set_lock);
 }
 
 } // namespace rr


### PR DESCRIPTION
This fixes issue #3472. In the detach tests, it is possible for run_initial_child to happen while the TraceeAttentionSet thread is processing a SIGCHLD and is holding the attention_set_lock. run_initial_child then queries `TraceeAttentionSet::get_original_sigmask`, which attempts to acquire this lock, resulting in a deadlock.

However, the locking here is unnecessary. The `attention_set` pointer is only ever written from the main thread and in fact only written once prior to the creation of the child thread. As such, neither locking nor memory barriers are required for access to the `attention_set` pointer. The contents of the `attention_set` itself do still need to be protected by the lock, but `TraceeAttentionSet::get_original_sigmask` does not look at it.