### PR TITLE
Avoid some warnings about possible uses of unintialized variables.

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -282,7 +282,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
   Task* t = remote.task();
   SupportedArch arch = t->arch();
 
-  const char *fname;
+  const char *fname = nullptr;
   switch (t->arch()) {
     case x86_64:
     case aarch64:

--- a/src/PackCommand.cc
+++ b/src/PackCommand.cc
@@ -192,8 +192,7 @@ static map<string, FileInfo> gather_file_info(const string& trace_dir) {
   vector<vector<pair<TraceReader::MappedData, FileInfo>>> thread_files;
   thread_files.resize(use_cpus);
   for (size_t i = 0; i < files.size(); ++i) {
-    FileInfo info;
-    thread_files[i % use_cpus].push_back(make_pair(files[i], info));
+    thread_files[i % use_cpus].push_back(make_pair(files[i], FileInfo()));
   }
 
   vector<pthread_t> threads;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1191,7 +1191,9 @@ bool Task::set_aarch64_debug_regs(int, ARM64Arch::user_hwdebug_state *, size_t) 
   FATAL() << "Reached aarch64 code path on non-aarch64 system";
   return false;
 }
-bool Task::get_aarch64_debug_regs(int, ARM64Arch::user_hwdebug_state *) {
+bool Task::get_aarch64_debug_regs(int, ARM64Arch::user_hwdebug_state *regs) {
+  // Following memset just to silence a warning about dbg_info may be used uninitialized.
+  memset(regs, 0, sizeof(*regs));
   FATAL() << "Reached aarch64 code path on non-aarch64 system";
   return false;
 }


### PR DESCRIPTION
Found with g++ 12.2.