### PR TITLE
Use one byte less in strncpy to avoid warning.

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -576,7 +576,7 @@ const AddressSpace::Mapping& Session::steal_mapping(
   // We will include the name of the full path of the original mapping in the
   // name of the shared mapping, replacing slashes by dashes.
   char name[PATH_MAX - 40];
-  strncpy(name, m.map.fsname().c_str(), sizeof(name));
+  strncpy(name, m.map.fsname().c_str(), sizeof(name)-1);
   name[sizeof(name) - 1] = '\0';
   for (char* ptr = name; *ptr != '\0'; ++ptr) {
     if (*ptr == '/') {


### PR DESCRIPTION
This last byte gets written in the next line anyway.

```c++
.../rr/src/Session.cc: In static member function ‘static const rr::AddressSpace::Mapping& rr::Session::steal_mapping(rr::AutoRemoteSyscalls&, const rr::AddressSpace::Mapping&, rr::MonitoredSharedMemory::shr_ptr)’:
.../rr/src/Session.cc:579:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 4056 equals destination size [-Wstringop-truncation]
  579 |   strncpy(name, m.map.fsname().c_str(), sizeof(name));
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```