### PR TITLE
ASan: Run with verify_asan_link_order=0.

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2223,6 +2223,8 @@ static ExeInfo read_exe_info(const string& exe_file) {
   ElfFileReader reader(fd);
   ret.arch = reader.arch();
 
+  // Don't try to modifiy LD_PRELOAD when rr itself is built with ASan
+#ifndef __SANITIZE_ADDRESS__
   DynamicSection dynamic = reader.read_dynamic();
   for (auto& entry : dynamic.entries) {
     if (entry.tag == DT_NEEDED && entry.val < dynamic.strtab.size()) {
@@ -2236,6 +2238,7 @@ static ExeInfo read_exe_info(const string& exe_file) {
       }
     }
   }
+#endif
 
   auto syms = reader.read_symbols(".dynsym", ".dynstr");
   for (size_t i = 0; i < syms.size(); ++i) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -2461,6 +2461,10 @@ int __lsan_is_turned_off(void)
 {
   return rr_lsan_is_turned_off;
 }
+#include <sanitizer/asan_interface.h>
+const char *__asan_default_options() {
+  return "verify_asan_link_order=0";
+}
 #endif
 
 bool coredumping_signal_takes_down_entire_vm() {


### PR DESCRIPTION
Avoids error message:
```
  ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
```

Affected tests:
```
  nested_detach_kill
  nested_detach_kill_stuck
  nested_detach_wait
```
(These tests may also need the `ASan: Copy just used pages from ANONYMOUS|NORESERVE mappings.` patch too.)