### PR TITLE
ASan: Copy just used pages from ANONYMOUS mappings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,6 +929,7 @@ set(BASIC_TESTS
   daemon
   desched_blocking_poll
   desched_sigkill
+  detach_huge_mmap
   detach_state
   detach_threads
   detach_sigkill

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -674,6 +674,9 @@ public:
   ScopedFd& mem_fd() { return child_mem_fd; }
   void set_mem_fd(ScopedFd&& fd) { child_mem_fd = std::move(fd); }
 
+  ScopedFd& pagemap_fd() { return child_pagemap_fd; }
+  void set_pagemap_fd(ScopedFd&& fd) { child_pagemap_fd = std::move(fd); }
+
   Monkeypatcher& monkeypatcher() {
     DEBUG_ASSERT(monkeypatch_state);
     return *monkeypatch_state;
@@ -1209,6 +1212,8 @@ private:
                                      const struct map_iterator_data* data);
 
   AddressSpace operator=(const AddressSpace&) = delete;
+
+  ScopedFd child_pagemap_fd;
 };
 
 /**

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2727,6 +2727,18 @@ void Task::open_mem_fd_if_needed() {
   }
 }
 
+ScopedFd& Task::pagemap_fd() {
+  if (!as->pagemap_fd().is_open()) {
+    ScopedFd fd(proc_pagemap_path().c_str(), O_RDONLY);
+    if (fd.is_open()) {
+      as->set_pagemap_fd(std::move(fd));
+    } else {
+      LOG(info) << "Can't retrieve pagemap fd for " << tid;
+    }
+  }
+  return as->pagemap_fd();
+}
+
 KernelMapping Task::init_syscall_buffer(AutoRemoteSyscalls& remote,
                                         remote_ptr<void> map_hint) {
   char name[50];

--- a/src/Task.h
+++ b/src/Task.h
@@ -821,6 +821,11 @@ public:
   void open_mem_fd_if_needed();
 
   /**
+   * Open /proc/[tid]/pagemap fd for our AddressSpace.
+   */
+  ScopedFd& pagemap_fd();
+
+  /**
    * Perform a PTRACE_INTERRUPT set up the counter for potential spurious stops
    * to be detected in `account_for_potential_ptrace_interrupt_stop`.
    */

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5656,7 +5656,7 @@ static void process_execve(RecordTask* t, TaskSyscallState& syscall_state) {
   // The kernel may modify some of the pages in the mapping according to
   // ELF BSS metadata. We use /proc/<pid>/pagemap to observe which pages
   // have been changed and mark them for recording.
-  ScopedFd pagemap(t->proc_pagemap_path().c_str(), O_RDONLY, 0);
+  ScopedFd& pagemap = t->pagemap_fd();
   ASSERT(t, pagemap.is_open());
   vector<remote_ptr<void>> pages_to_record;
 

--- a/src/test/detach_huge_mmap.c
+++ b/src/test/detach_huge_mmap.c
@@ -1,0 +1,74 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util_internal.h"
+
+static const int magic = 0xab;
+static uint64_t size = 0x400000; /* 4 MB, at least the value in Task::dup_from */
+static size_t page_size;
+static void* pages[10];
+static unsigned int idx; /*next index of pages*/
+
+void test_alloc(char* mem, unsigned int count, off_t offset) {
+
+  test_assert(0 == munmap(mem + size, page_size));
+
+  /* one page near the start */
+  test_assert(idx < sizeof(pages)/sizeof(pages[0]));
+  pages[idx] = mem + page_size;
+  memset(pages[idx], magic, page_size);
+  idx++;
+
+  /* one or more pages near or at the end */
+  for (unsigned int i = 0; i < count; i++) {
+    test_assert(idx < sizeof(pages)/sizeof(pages[0]));
+    pages[idx] = mem + offset + i * page_size;
+    memset(pages[idx], magic, page_size);
+    idx++;
+  }
+}
+
+int main(void) {
+  page_size = sysconf(_SC_PAGESIZE);
+
+  /* Create one big mapping, then break it up by munmap
+   * into smaller ones, to better test the handling in
+   * the end of mappings. */
+
+  void* mem1 = mmap(NULL, 4 * (size + page_size), PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  test_assert(mem1 != MAP_FAILED);
+
+  void* mem2 = mem1 + size + page_size;
+  void* mem3 = mem2 + size + page_size;
+  void* mem4 = mem3 + size + page_size;
+
+  test_alloc(mem1, 1, size - page_size);     /* one page used at last page */
+  test_alloc(mem2, 1, size - page_size * 2); /* one page used before last page */
+  test_alloc(mem3, 2, size - page_size * 2); /* two consecutive pages at last two pages */
+  test_alloc(mem4, 2, size - page_size * 3); /* two consecutive pages before last page */
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    if (running_under_rr()) {
+      rr_detach_teleport();
+    }
+
+    /* create one page for easier comparison */
+    char* cmp = malloc(page_size * 3);
+    test_assert(cmp != NULL);
+    memset(cmp, magic, page_size * 3);
+
+    /* check if the saved pages have the expected value */
+    for (unsigned int i = 0; i < idx; i++) {
+      test_assert(memcmp(pages[i], cmp, page_size) == 0);
+    }
+
+    return 0;
+  }
+
+  int status;
+  wait(&status);
+  test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
ASan creates a "shadow" of the used memory.
This is done in a mapping of around 20 TB address space, but most of it is not yet used.

This patch aids an ASan-enabled rr build in following tests:
```
  nested_detach
  nested_detach_kill
  nested_detach_kill_stuck
  nested_detach_wait
  nested_release
```

Avoids error message:
```
  ERROR: AddressSanitizer: requested allocation size 0x20000000000 (0x20000001000 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
```
