### PR TITLE
Cleanup outer temporary directory in nested_detach tests on success.

### DIFF
--- a/src/test/nested_detach.run
+++ b/src/test/nested_detach.run
@@ -7,7 +7,9 @@ replay
 check_record
 # Replay inner
 cd inner
+workdir_orig=$workdir
 workdir=$PWD
 wait_for_complete
 replay
 check_replay_token EXIT-SUCCESS
+workdir=$workdir_orig

--- a/src/test/nested_detach_kill.run
+++ b/src/test/nested_detach_kill.run
@@ -32,7 +32,9 @@ wait
 replay
 # Replay inner
 cd $workdir/inner
+workdir_orig=$workdir
 workdir=$PWD
 wait_for_complete
 replay
 check_replay_token $SYNC_TOKEN
+workdir=$workdir_orig

--- a/src/test/nested_detach_kill_stuck.run
+++ b/src/test/nested_detach_kill_stuck.run
@@ -32,7 +32,9 @@ wait
 replay
 # Replay inner
 cd $workdir/inner
+workdir_orig=$workdir
 workdir=$PWD
 wait_for_complete
 replay
 check_replay_token $SYNC_TOKEN
+workdir=$workdir_orig

--- a/src/test/nested_detach_wait.run
+++ b/src/test/nested_detach_wait.run
@@ -8,6 +8,8 @@ replay
 check_record EXIT-WAITED
 # Replay inner
 cd $workdir/inner
+workdir_orig=$workdir
 workdir=$PWD
 replay
 check_replay_token EXIT-SUCCESS
+workdir=$workdir_orig


### PR DESCRIPTION
This got visible for example when downloading buildkite artifacts.

Currently workdir gets set to the inner recording directory, therefore just the inner directory get removed.