### PR TITLE
Allow SIOCGIFDSTADDR in sioc tests to return EADDRNOTAVAIL.

### DIFF
--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -106,7 +106,7 @@ static int generic_request_by_name(int sockfd, struct ifreq* req, int nr,
   ret = ioctl(sockfd, nr, req);
   VERIFY_GUARD(req);
   atomic_printf("%s(ret:%d): %s ", nr_str, ret, req->ifr_name);
-  if (ret < 0 && nr == SIOCGIFADDR) {
+  if (ret < 0 && (nr == SIOCGIFADDR || nr == SIOCGIFDSTADDR)) {
     if (errno == EFAULT) {
       /* Work around https://bugzilla.kernel.org/show_bug.cgi?id=202273 */
       atomic_puts("Buggy kernel detected; aborting test");


### PR DESCRIPTION
Error message:
  SIOCGIFADDR(ret:-1): eth3 SIOCGIFDSTADDR(ret:-1): eth3 FAILED at src/test/sioc.c:123: !(0 == ret) errno:99 (Cannot assign requested address)

Fault shows up in CI, just when run at exclusive-amdci1.0:
  https://buildkite.com/julialang/rr/builds/1061
  https://buildkite.com/julialang/rr/builds/1063
  https://buildkite.com/julialang/rr/builds/1065
  https://buildkite.com/julialang/rr/builds/1084
  https://buildkite.com/julialang/rr/builds/1085
  https://buildkite.com/julialang/rr/builds/1086
  [https://buildkite.com/julialang/rr/builds/1087](https://buildkite.com/julialang/rr/builds/1087#01877f2a-e02d-4924-8e81-6fc150c3a7b1/3905-6044)

I guess this is related to a different configuration of exclusive-amdci1.0,
but I have no way to reproduce it and threfore cannot test this change.

What do you think?