### PR TITLE
Change move() to std::move() as clang++ 16 on fc38 errors during compilation

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -671,7 +671,7 @@ template <typename Arch> ScopedFd AutoRemoteSyscalls::retrieve_fd_arch(int fd) {
   vector<ScopedFd> fds = maybe_receive_fds(task()->session().tracee_socket_fd());
   ASSERT(t, !fds.empty()) << "Failed to receive fd";
   ASSERT(t, fds.size() == 1);
-  return move(fds[0]);
+  return std::move(fds[0]);
 }
 
 ScopedFd AutoRemoteSyscalls::retrieve_fd(int fd) {

--- a/src/TraceeAttentionSet.cc
+++ b/src/TraceeAttentionSet.cc
@@ -68,7 +68,7 @@ unordered_set<pid_t> TraceeAttentionSet::read() {
   if (!attention_set) {
     FATAL() << "TraceeAttentionSet not initialized";
   }
-  result = move(*attention_set);
+  result = std::move(*attention_set);
   pthread_mutex_unlock(&attention_set_lock);
   return result;
 }


### PR DESCRIPTION
clang version 16.0.0 (Fedora 16.0.0-2.fc38)

```
src/TraceeAttentionSet.cc:71:12: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  result = move(*attention_set);
           ^
           std::

src/AutoRemoteSyscalls.cc:674:10: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  return move(fds[0]);
         ^
         std::
```