### PR TITLE
Add Snapdragon 8cx Gen 3 support

### DIFF
--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -48,8 +48,10 @@ static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
     case 0xd40:
       return ARMNeoverseV1;
     case 0xd41:
+    case 0xd4b: // ARM Cortex A78C
       return ARMCortexA78;
     case 0xd44:
+    case 0xd4c: // ARM Cortex X1C
       return ARMCortexX1;
     case 0xd49:
       return ARMNeoverseN2;


### PR DESCRIPTION
This adds support for arch ARM Cortex A78C and ARM Cortex X1C.
They are the ARM Cortex A78 and X1 variants used by Snapdragon 8cx Gen 3,
and the differences are small enough that I don't think a new arch type is needed.

The relevant manuals can be found here.

https://developer.arm.com/documentation/102226/0002/Debug-descriptions/Performance-Monitoring-Unit/PMU-events?lang=en
https://developer.arm.com/documentation/101968/0002/Debug-descriptions/Performance-Monitoring-Unit/PMU-events?lang=en
https://developer.arm.com/documentation/101968/0002/Register-descriptions/AArch64-system-registers/MIDR-EL1--Main-ID-Register--EL1?lang=en

Tested on Thinkpad X13s.