### PR TITLE
Add the entry program file to 'rr traceinfo'

### DIFF
--- a/src/TraceInfoCommand.cc
+++ b/src/TraceInfoCommand.cc
@@ -115,7 +115,10 @@ static int dump_trace_info(const string& trace_dir, FILE* out) {
         }
         fprintf(out, "\n    \"%s\"", json_escape(environ[i]).c_str());
       }
-      fputs("\n  ]\n", out);
+      fputs("\n  ],\n", out);
+
+      fprintf(out, "  \"program\": \"%s\"\n", json_escape(replay_session->vms()[0]->exe_image()).c_str());
+
       break;
     }
     if (result.status == REPLAY_EXITED) {


### PR DESCRIPTION
Add the path of the entry program to the json returned by `rr traceinfo`, this will allow consumers to know exactly which program is being debugged as part of a trace, which may be useful for tools that use another debugger on top of RR.

Fixes #3507 