### PR TITLE
Fix assert_segments_match to really output information.

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1529,9 +1529,9 @@ static void assert_segments_match(Task* t, const KernelMapping& input_m,
     err = "inodes differ";
   }
   if (err.size()) {
-    LOG(error) << "cached mmap:";
+    cerr << "cached mmap:" << endl;
     t->vm()->dump();
-    LOG(error) << "/proc/" << t->tid << "/mmaps:";
+    cerr << "/proc/" << t->tid << "/mmaps:" << endl;
     AddressSpace::print_process_maps(t);
     ASSERT(t, false) << "\nCached mapping " << m << " should be " << km << "; "
                      << err;


### PR DESCRIPTION
Looks like `LOG(error)` aborts rr. Therefore the information about the mappings gets not written out.

Example without this patch:
  https://buildkite.com/julialang/rr/builds/1197#0187b750-3714-416f-aa7f-59d2aca36716/2342-2421
```
  24/1341 Test  #902: cont_race ..............................................***Failed  Error regular expression found in output. Regex=[FAILED]  4.84 sec
source_dir/src/test/util.sh: line 254: 26153 Aborted                 _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT record.err $RR_EXE $GLOBAL_OPTIONS record $LIB_ARG $RECORD_ARGS "$exe" $exeargs > record.out 2> record.err
Test 'cont_race' FAILED: : error during recording:
--------------------------------------------------
[ERROR src/AddressSpace.cc:1532:assert_segments_match()] cached mmap:
=== Start rr backtrace:
rr(_ZN2rr13dump_rr_stackEv+0x30)[0xaaaac27208e4]
rr(_ZN2rr15notifying_abortEv+0x10)[0xaaaac2720874]
rr(_ZN2rr25NewlineTerminatingOstreamD1Ev+0x70)[0xaaaac2568f1c]
rr(+0x36a9a8)[0xaaaac249d9a8]
rr(_ZNK2rr12AddressSpace6verifyEPNS_4TaskE+0x2d0)[0xaaaac249e590]
rr(_ZN2rr13RecordSession21syscall_state_changedEPNS_10RecordTaskEPNS0_9StepStateE+0xa68)[0xaaaac25d7c10]
rr(_ZN2rr13RecordSession11record_stepEv+0x4e0)[0xaaaac25dc920]
rr(+0x49f17c)[0xaaaac25d217c]
rr(_ZN2rr13RecordCommand3runERSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE+0x360)[0xaaaac25d2d0c]
rr(main+0x268)[0xaaaac2577800]
/lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0xc4)[0xffffab346494]
rr(_start+0x38)[0xaaaac2496178]
=== End rr backtrace
process 26154 sent SIGURG
```

Example with this patch:
  https://buildkite.com/julialang/rr/builds/1200#0187ccd7-396d-40d4-8bdf-4ee8d8804fd5/2362-2443
```
  25/1343 Test  #904: cont_race ..............................................***Failed  Error regular expression found in output. Regex=[FAILED]  5.26 sec
source_dir/src/test/util.sh: line 261: 27317 Aborted                 _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT record.err $RR_EXE $GLOBAL_OPTIONS record $LIB_ARG $RECORD_ARGS "$exe" $exeargs > record.out 2> record.err
Test 'cont_race' FAILED: : error during recording:
--------------------------------------------------
cached mmap:
  (heap: 0xaaab12bf8000-0xaaab12c19000)
0x68000000-0x68200000 rwxp 00000000 00:00 0
0x6ffd0000-0x70000000 r-xp 00000000 103:03 12488969   /cache/build/default-armageddon-6/julialang/rr/obj/lib/rr/librrpage.so
0x70000000-0x70010000 r-xp 00030000 103:03 12488969   /cache/build/default-armageddon-6/julialang/rr/obj/lib/rr/librrpage.so[unknown_flags]
0x70010000-0x70011000 rw-s 00000000 103:03 17050109   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-preload_thread_locals-27766-207 [thread_locals]
0x70011000-0x70111000 rw-s 00000000 103:03 17050092   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-syscallbuf.27336-27336-1 [syscallbuf]
0x70111000-0x70211000 rw-s 00000000 103:03 17050085   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-syscallbuf.27766-27766-208 [syscallbuf]
0xaaaae1139000-0xaaaae113b000 r-xp 00000000 103:03 17050020   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
0xaaaae114a000-0xaaaae114b000 r--p 00001000 103:03 17050020   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
0xaaaae114b000-0xaaaae114c000 rw-p 00002000 103:03 17050020   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
0xaaab12bf8000-0xaaab12c19000 rw-p 00000000 00:00 0          [heap]
...
0xffffdbaec000-0xffffdbb10000 rw-p 00000000 00:00 0          [stack]
/proc/27766/mmaps:
68000000-68200000 rwxp 00000000 00:00 0
6ffd0000-70010000 r-xp 00000000 103:03 12488969                          /cache/build/default-armageddon-6/julialang/rr/obj/lib/rr/librrpage.so
70010000-70011000 rw-s 00000000 103:03 17050109                          /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-preload_thread_locals-27766-207 (deleted)
70011000-70111000 rw-s 00000000 103:03 17050092                          /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-syscallbuf.27336-27336-1 (deleted)
aaaae1139000-aaaae113b000 r-xp 00000000 103:03 17050020                  /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
aaaae114a000-aaaae114b000 r--p 00001000 103:03 17050020                  /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
aaaae114b000-aaaae114c000 rw-p 00002000 103:03 17050020                  /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6
aaab12bf8000-aaab12c19000 rw-p 00000000 00:00 0                          [heap]
...
ffffdbaec000-ffffdbb10000 rw-p 00000000 00:00 0                          [stack]
[FATAL src/AddressSpace.cc:1536:assert_segments_match()]
 (task 27766 (rec:27766) at time 2408)
 -> Assertion `false' failed to hold.
Cached mapping 0x70111000-0x70211000 rw-s 00000000 103:03 17050085   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-shared-syscallbuf.27766-27766-208 should be 0xaaaae1139000-0xaaaae113b000 r-xp 00000000 103:03 17050020   /cache/build/default-armageddon-6/julialang/rr/obj/my_temp_parent_dir/jl_RJ51ND/rr-test-cont_race-ceFXQh4G6/cont_race-ceFXQh4G6; starts differ
Tail of trace dump:
```
