### PR TITLE
support for Intel SapphireRapid

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -86,7 +86,8 @@ enum CpuMicroarch {
   IntelRocketlake,
   IntelAlderlake,
   IntelRaptorlake,
-  LastIntel = IntelRaptorlake,
+  IntelSapphireRapid,
+  LastIntel = IntelSapphireRapid,
   FirstAMD,
   AMDF15R30 = FirstAMD,
   AMDZen,
@@ -155,6 +156,7 @@ struct PmuConfig {
 // See Intel 64 and IA32 Architectures Performance Monitoring Events.
 // See check_events from libpfm4.
 static const PmuConfig pmu_configs[] = {
+  { IntelSapphireRapid, "Intel SapphireRapid", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRaptorlake, "Intel Raptorlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRocketlake, "Intel Rocketlake", 0x5111c4, 0, 0, 100, PMU_TICKS_RCB },

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -85,6 +85,8 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelAlderlake;
     case 0xb0670:
       return IntelRaptorlake;
+    case 0x806f0:
+      return IntelSapphireRapid;
     case 0x30f00:
       return AMDF15R30;
     case 0x00f10: // Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen), Milan (Zen 3) (UNTESTED)


### PR DESCRIPTION
This adds support for Intel Xeon 4th gen codename SapphireRapids. Let me know if there are any issues.