### PR TITLE
Fixes bug of not sending over symbols in (true) remote session

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -2153,9 +2153,8 @@ int GdbServer::open_file(Session& session, Task* continue_task, const std::strin
       // rendezvous structures.
       // Use our old hack for ld from before we read PT_INTERP for backwards
       // compat with older traces.
-      if (m.recorded_map.fsname().compare(0,
-            normalized_file_name.length(),
-            normalized_file_name) == 0
+      if (m.recorded_map.fsname().compare(0, normalized_file_name.length(), normalized_file_name) == 0
+          || m.map.fsname().compare(0, normalized_file_name.length(), normalized_file_name) == 0
           || (is_ld_mapping(m.recorded_map.fsname()) &&
               is_likely_interp(normalized_file_name)))
       {


### PR DESCRIPTION
When debugging a (truly) remote debug session using gdb command; `gdb -ex "target extended-remote host:port"` gdb will complain about file not found, example:
```
Reading /home/cx/.local/share/rr/testapp-2/mmap_clone_4_testapp from remote target... 
warning: File transfers from remote targets can be slow. Use "set sysroot" to access files locally instead. 
warning: "target:/home/cx/.local/share/rr/testapp-2/mmap_clone_4_testapp": could not open as an executable file: No such file or directory. 
Reading /home/cx/.local/share/rr/testapp-2/mmap_clone_4_testapp from remote target... 
warning: `target:/home/cx/.local/share/rr/testapp-2/mmap_clone_4_testapp': can't open to read symbols: No such file or directory.
```
After going through GdbConnection code it does reply with a -1 not found.

The bug stems from the fact that it's comparing file name `mmap_clone_4_testapp` against the _recorded map_ which is going to be "testapp" in this case, and thus fail.

This commit makes it also look in `m.map` which will match correctly. Why this is not an error on a local machine, is a mystery to me though.