### PR TITLE
Fix seek-ticks when already at the target event

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1588,7 +1588,7 @@ void GdbServer::restart_session(const GdbRequest& req) {
         }
       }
       // Forward the frame reader to the current event
-      last_time = ticks_start_time;
+      last_time = ticks_start_time + 1;
       while (true) {
         TraceFrame frame = tmp_reader.read_frame();
         if (frame.time() >= ticks_start_time) {
@@ -1598,7 +1598,7 @@ void GdbServer::restart_session(const GdbRequest& req) {
     }
     while (true) {
       if (tmp_reader.at_end()) {
-        cout << "No event found matching specified ticks target.";
+        cout << "No event found matching specified ticks target.\n";
         dbg->notify_restart_failed();
         return;
       }
@@ -1606,9 +1606,9 @@ void GdbServer::restart_session(const GdbRequest& req) {
       if (frame.tid() == task->tuid().tid() && frame.ticks() >= target) {
         break;
       }
-      last_time = frame.time();
+      last_time = frame.time() + 1;
     }
-    timeline.seek_to_ticks(last_time + 1, target);
+    timeline.seek_to_ticks(last_time, target);
   }
 
   interrupt_pending = true;

--- a/src/test/seekticks.py
+++ b/src/test/seekticks.py
@@ -57,4 +57,19 @@ ticks6 = eval(last_match().group(1));
 if ticks6 != ticks2:
     failed('ERROR: Failed to seek forwards to ticks2')
 
+if ticks2 < 4:
+    failed('ERROR: ticks2 too small to test nearby ticks')
+
+tests = [ticks2, ticks2, ticks2-2, 1, 1, 0, 0, 2, 0, 2, ticks2-2, ticks2-1, ticks2-2, ticks2]
+
+for i in range(len(tests)):
+    ticks7 = tests[i]
+    send_gdb("seek-ticks %d" % ticks7)
+    expect_gdb("Program stopped.")
+    send_gdb('when-ticks')
+    expect_gdb(re.compile(r'Current tick: (\d+)'))
+    ticks8 = eval(last_match().group(1));
+    if ticks8 != ticks7:
+        failed("ERROR: seek-ticks didn't go to correct tick on test %d" % i)
+
 ok()


### PR DESCRIPTION
Before this, `seek-ticks` would go to an incorrect tick if the current event and target tick event are the same, easiest reproducible by running `seek-ticks` with the same argument twice (where there isn't an event on exactly that tick).

This patch passes manual testing seeking back, forward, over events or not, and on tick numbers immediately before/after an event.