### PR TITLE
buildkite: Skip the tests when a very simple rr run already fails.

### DIFF
--- a/.buildkite/lib/generate.jl
+++ b/.buildkite/lib/generate.jl
@@ -31,7 +31,13 @@ function generate(platform::Platform)
     echo "--- Test"
     mkdir -p Testing/Temporary
     mv ../.buildkite/CTestCostData.txt Testing/Temporary
-    julia ../.buildkite/capture_tmpdir.jl ctest --output-on-failure -j\$\$(expr \$\${JULIA_CPU_THREADS:?} - 2)
+    if bin/rr record bin/simple; then
+      julia ../.buildkite/capture_tmpdir.jl ctest --output-on-failure -j\$\$(expr \$\${JULIA_CPU_THREADS:?} - 2)
+    else
+      echo -n -e "rr seems not able to run, skipping running test suite.\nhostname: "
+      hostname
+      exit 1
+    fi
     """
     job_label = "Test $(platform.arch)"
     job_key = "test-$(platform.arch)"


### PR DESCRIPTION
This could avoid occupying CI infrastructure
when all tests fail like here:
  https://buildkite.com/julialang/rr/builds/1221#01882e04-ac8c-4566-94fd-357bc3466d5b