### PR TITLE
[WIP] rr support on M2

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -105,7 +105,9 @@ enum CpuMicroarch {
   ARMCortexX1,
   AppleM1Icestorm,
   AppleM1Firestorm,
-  LastARM = AppleM1Firestorm,
+  AppleM2Blizzard,
+  AppleM2Avalanche,
+  LastARM = AppleM2Avalanche,
 };
 
 /*
@@ -216,6 +218,10 @@ static const PmuConfig pmu_configs[] = {
     "apple_icestorm_pmu", 0x8c, -1, -1 },
   { AppleM1Firestorm, "Apple M1 Firestorm", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
     "apple_firestorm_pmu", 0x8c, -1, -1 },
+  { AppleM2Blizzard, "Apple M2 Blizzard", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
+    "apple_blizzard_pmu", 0x8c, -1, -1 },
+  { AppleM2Avalanche, "Apple M2 Avalanche", 0x90, 0, 0, 1000, PMU_TICKS_TAKEN_BRANCHES,
+    "apple_avalanche_pmu", 0x8c, -1, -1 },
 };
 
 #define RR_SKID_MAX 10000

--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -79,6 +79,10 @@ static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
     case 0x23:
     case 0x25:
       return AppleM1Firestorm;
+    case 0x32:
+      return AppleM2Blizzard;
+    case 0x33:
+      return AppleM2Avalanche;
     }
     break;
   }

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -175,7 +175,11 @@ RegisterInfo<rr::ARM64Arch>::Table RegisterInfo<rr::ARM64Arch>::registers = {
   // Mask out the single-step flag from the pstate. During replay, we may
   // single-step to an execution point, which could set the single-step bit
   // when it wasn't set during record.
-  RV_AARCH64_WITH_MASK(CPSR, pstate, 0xffffffffLL & ~AARCH64_DBG_SPSR_SS, 4),
+  //
+  // In Apple Air M2 SPSR bit 11 seems to be sometimes set leading to record/replay register
+  // comparison errors. This seems to be a unused/undocumented bit in SPSR as per aarch64
+  // documentation anyways so ignore it.
+  RV_AARCH64_WITH_MASK(CPSR, pstate, 0xffffffffLL & ~AARCH64_DBG_SPSR_SS & ~AARCH64_DBG_SPSR_11, 4),
 };
 
 #undef RV_X64

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -37,6 +37,7 @@ const uintptr_t X86_RF_FLAG = 1 << 16;
 const uintptr_t X86_ID_FLAG = 1 << 21;
 
 const uintptr_t AARCH64_DBG_SPSR_SS = 1 << 21;
+const uintptr_t AARCH64_DBG_SPSR_11 = 1 << 11;
 
 /**
  * A Registers object contains values for all general-purpose registers.


### PR DESCRIPTION
These changes allow `rr` to _mostly_ work on asahi linux on the M2 chip (we currently support only M1).

<details>
<summary>95% tests passed, 65 tests failed out of 1345</summary>

```
95% tests passed, 65 tests failed out of 1345

Total Test time (real) = 5502.27 sec

The following tests FAILED:
        228 - grandchild_threads_main_running (Failed)
        229 - grandchild_threads_main_running-no-syscallbuf (Failed)
        230 - grandchild_threads_thread_running (Failed)
        231 - grandchild_threads_thread_running-no-syscallbuf (Failed)
        294 - kill_ptracee (Failed)
        295 - kill_ptracee-no-syscallbuf (Failed)
        412 - no_mask_timeslice (Failed)
        413 - no_mask_timeslice-no-syscallbuf (Failed)
        433 - pid_ns_kill_child-no-syscallbuf (Failed)
        442 - pid_ns_reap (Failed)
        488 - ptrace_attach_running (Failed)
        489 - ptrace_attach_running-no-syscallbuf (Failed)
        494 - ptrace_attach_thread_running (Failed)
        495 - ptrace_attach_thread_running-no-syscallbuf (Failed)
        546 - record_replay_subject (Failed)
        547 - record_replay_subject-no-syscallbuf (Failed)
        700 - spinlock_priorities (Failed)
        701 - spinlock_priorities-no-syscallbuf (Failed)
        764 - thread_yield (Failed)
        765 - thread_yield-no-syscallbuf (Failed)
        766 - timer (Failed)
        767 - timer-no-syscallbuf (Failed)
        788 - unexpected_exit_pid_ns (Failed)
        842 - async_kill_with_syscallbuf2 (Failed)
        843 - async_kill_with_syscallbuf2-no-syscallbuf (Failed)
        846 - async_kill_with_threads_main_running (Failed)
        847 - async_kill_with_threads_main_running-no-syscallbuf (Failed)
        848 - async_kill_with_threads_thread_running (Failed)
        849 - async_kill_with_threads_thread_running-no-syscallbuf (Failed)
        850 - async_segv (Failed)
        851 - async_segv-no-syscallbuf (Failed)
        858 - async_usr1 (Failed)
        859 - async_usr1-no-syscallbuf (Failed)
        878 - breakpoint_overlap (Failed)
        879 - breakpoint_overlap-no-syscallbuf (Failed)
        900 - conditional_breakpoint_offload (Failed)
        901 - conditional_breakpoint_offload-no-syscallbuf (Failed)
        949 - function_calls-no-syscallbuf (Failed)
        962 - ignored_async_usr1 (Failed)
        963 - ignored_async_usr1-no-syscallbuf (Failed)
        984 - madvise_fracture_flags (Failed)
        985 - madvise_fracture_flags-no-syscallbuf (Failed)
        1014 - overflow_branch_counter (Failed)
        1015 - overflow_branch_counter-no-syscallbuf (Failed)
        1028 - reverse_continue_breakpoint (Failed)
        1029 - reverse_continue_breakpoint-no-syscallbuf (Failed)
        1034 - reverse_many_breakpoints (Failed)
        1035 - reverse_many_breakpoints-no-syscallbuf (Failed)
        1036 - reverse_step_long (Failed)
        1037 - reverse_step_long-no-syscallbuf (Failed)
        1046 - rseq (Failed)
        1047 - rseq-no-syscallbuf (Failed)
        1096 - term_trace_reset (Failed)
        1097 - term_trace_reset-no-syscallbuf (Failed)
        1129 - vsyscall_reverse_next-no-syscallbuf (Failed)
        1192 - cont_signal (Failed)
        1193 - cont_signal-no-syscallbuf (Failed)
        1246 - record_replay (Failed)
        1247 - record_replay-no-syscallbuf (Failed)
        1276 - reverse_step_threads2 (Failed)
        1277 - reverse_step_threads2-no-syscallbuf (Failed)
        1304 - stack_overflow_debug (Failed)
        1305 - stack_overflow_debug-no-syscallbuf (Failed)
        1322 - term_trace_cpu (Failed)
        1323 - term_trace_cpu-no-syscallbuf (Failed)
```
</details>

I'm using the `linux-asahi-edge` kernel which has more recent changes compared to `linux-asahi`.

I've narrowed down the reason for a lot of the remaining tests failing to the `PerfCounters::TIME_SLICE_SIGNAL` simply not firing on the M2 ! 

```
[FATAL src/PerfCounters.cc:824:read_ticks()] 
 (task 12764 (rec:12009) at time 6974)
 -> Assertion `!counting_period || interrupt_val <= adjusted_counting_period' failed to hold. Detected 200031 ticks, expected no more than 188676
```

Initially I thought I could increase the size of the skid region. Turns out, the issue is not with the skid region. The `TIME_SLICE_SIGNAL` in all my testing never fires at all ! 

There could be something wrong in the PMU implementation and I've filed a bug against the Asahi Linux kernel. See https://github.com/AsahiLinux/linux/issues/150

I have tried to run some of these tests with `--bind-to-cpu` to no avail. 

The `alarm` test is a simple test that regularly fails (it has succeeded by chance in the above run) and is a good test to debug this problem. 