### PR TITLE
Add missing M1 part numbers to PerfCounters_aarch64.h

### DIFF
--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -75,9 +75,11 @@ static CpuMicroarch compute_cpu_microarch(const CPUID &cpuid) {
     switch (cpuid.part) {
     case 0x22:
     case 0x24:
+    case 0x28:
       return AppleM1Icestorm;
     case 0x23:
     case 0x25:
+    case 0x29:
       return AppleM1Firestorm;
     case 0x32:
       return AppleM2Blizzard;


### PR DESCRIPTION
Fixes https://github.com/rr-debugger/rr/issues/3550