### PR TITLE
Add rr commands to remove and move traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ set(RR_SOURCES
   src/MmappedFileMonitor.cc
   src/MonitoredSharedMemory.cc
   src/Monkeypatcher.cc
+  src/MvCommand.cc
   src/PackCommand.cc
   src/PerfCounters.cc
   src/PidFdMonitor.cc
@@ -576,6 +577,7 @@ set(RR_SOURCES
   src/ReplayTimeline.cc
   src/RerunCommand.cc
   src/ReturnAddressList.cc
+  src/RmCommand.cc
   src/Scheduler.cc
   src/SeccompFilterRewriter.cc
   src/Session.cc
@@ -667,6 +669,7 @@ target_link_libraries(rr
   ${CMAKE_DL_LIBS}
   ${ZLIB_LDFLAGS}
   brotli
+  stdc++fs
 )
 
 if(staticlibs)

--- a/src/MvCommand.cc
+++ b/src/MvCommand.cc
@@ -1,0 +1,140 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <stdio.h>
+
+#include <vector>
+#include <experimental/filesystem>
+
+#include "Command.h"
+#include "main.h"
+#include "TraceStream.h"
+#include "util.h"
+
+using namespace std;
+namespace fs = std::experimental::filesystem;
+
+namespace rr {
+
+class MvCommand : public Command {
+public:
+  virtual int run(vector<string>& args);
+
+protected:
+  MvCommand(const char* name, const char* help) : Command(name, help) {}
+
+  static MvCommand singleton;
+};
+
+MvCommand MvCommand::singleton(
+    "mv", " rr mv <trace> <new-trace>\n");
+
+static int mv(const string& from, const string& to, FILE* out) {
+  if (!ensure_valid_trace_name(from) ||
+      !ensure_valid_trace_name(to)) {
+    return 1;
+  }
+  
+  fs::path from_path = resolve_trace_name(from);
+
+  if (!is_trace(from_path)) {
+    fprintf(
+      stderr,
+      "\n"
+      "rr: Could not idenfity '%s' as a trace.\n"
+      "\n",
+      from_path.c_str());
+      return 1;
+  }
+
+  // canonical will resolve latest_trace
+  from_path = fs::canonical(from_path);
+
+  fs::path to_path = to;
+  // if 'to' is not a path, view it as trace name and move to trace_dir/to
+  if (to.find("/") == string::npos) {
+    to_path = fs::path(trace_save_dir()) / to;
+  }
+
+  if (to_path.filename() == "latest-trace") {
+    fprintf(stderr, "\nrr: Cannot rename to latest-trace.\n\n");
+    return 1;
+  }
+
+  if (from_path == to_path) {
+    fprintf(stderr,
+            "\n"
+            "rr: Old and new trace dir cannot be the same ('%s').\n"
+            "\n",
+            to_path.c_str());
+    return 1;
+  }
+
+  if (fs::exists(to_path)) {
+    fprintf(
+      stderr,
+      "\n"
+      "rr: New trace '%s' already exists.\n"
+      "\n",
+      to_path.c_str());
+      return 1;
+  }
+
+  // remove symlink before removing trace in case the former fails
+  // a bad symlink crashes e.g. rr ls and midas
+  if (is_latest_trace(from_path)) {
+    if (!remove_latest_trace_symlink()) {
+      return 1;
+    }
+  }
+
+  error_code ec;
+  fs::rename(from_path, to_path, ec);
+  
+  if (ec) {
+    const string msg = ec.message();
+    fprintf(
+      stderr,
+      "\n"
+      "rr: Cannot move '%s' to '%s': %s\n"
+      "\n",
+      from_path.c_str(),
+      to_path.c_str(),
+      msg.c_str());
+    return 1;
+  } else {
+    fprintf(
+      out,
+      "rr: Moved '%s' to '%s'\n",
+      from_path.c_str(),
+      to_path.c_str());
+    return 0;
+  }
+}
+
+int MvCommand::run(vector<string>& args) {
+  if (args.size() == 2 && verify_not_option(args)) {
+    string from = args[0];
+    args.erase(args.begin());
+    if (verify_not_option(args)) {
+      string to = args[0];
+      try {
+        return mv(from, to, stdout);
+      } catch (const fs::filesystem_error& e) {
+        const string msg = e.what();
+        fprintf(
+          stderr,
+          "\n"
+          "rr: Unexpected filesystem error: %s\n"
+          "\n",
+          msg.c_str()
+        );
+        return 1;
+      }
+    }
+  }
+
+  print_help(stderr);
+  return 1;
+};
+
+} // namespace rr

--- a/src/MvCommand.cc
+++ b/src/MvCommand.cc
@@ -2,12 +2,12 @@
 
 #include <stdio.h>
 
-#include <vector>
 #include <experimental/filesystem>
+#include <vector>
 
 #include "Command.h"
-#include "main.h"
 #include "TraceStream.h"
+#include "main.h"
 #include "util.h"
 
 using namespace std;
@@ -25,25 +25,22 @@ protected:
   static MvCommand singleton;
 };
 
-MvCommand MvCommand::singleton(
-    "mv", " rr mv <trace> <new-trace>\n");
+MvCommand MvCommand::singleton("mv", " rr mv <trace> <new-trace>\n");
 
 static int mv(const string& from, const string& to, FILE* out) {
-  if (!ensure_valid_trace_name(from) ||
-      !ensure_valid_trace_name(to)) {
+  if (!ensure_valid_trace_name(from) || !ensure_valid_trace_name(to)) {
     return 1;
   }
-  
+
   fs::path from_path = resolve_trace_name(from);
 
   if (!is_trace(from_path)) {
-    fprintf(
-      stderr,
-      "\n"
-      "rr: Could not idenfity '%s' as a trace.\n"
-      "\n",
-      from_path.c_str());
-      return 1;
+    fprintf(stderr,
+            "\n"
+            "rr: Could not idenfity '%s' as a trace.\n"
+            "\n",
+            from_path.c_str());
+    return 1;
   }
 
   // canonical will resolve latest_trace
@@ -70,13 +67,12 @@ static int mv(const string& from, const string& to, FILE* out) {
   }
 
   if (fs::exists(to_path)) {
-    fprintf(
-      stderr,
-      "\n"
-      "rr: New trace '%s' already exists.\n"
-      "\n",
-      to_path.c_str());
-      return 1;
+    fprintf(stderr,
+            "\n"
+            "rr: New trace '%s' already exists.\n"
+            "\n",
+            to_path.c_str());
+    return 1;
   }
 
   // remove symlink before removing trace in case the former fails
@@ -89,24 +85,18 @@ static int mv(const string& from, const string& to, FILE* out) {
 
   error_code ec;
   fs::rename(from_path, to_path, ec);
-  
+
   if (ec) {
     const string msg = ec.message();
-    fprintf(
-      stderr,
-      "\n"
-      "rr: Cannot move '%s' to '%s': %s\n"
-      "\n",
-      from_path.c_str(),
-      to_path.c_str(),
-      msg.c_str());
+    fprintf(stderr,
+            "\n"
+            "rr: Cannot move '%s' to '%s': %s\n"
+            "\n",
+            from_path.c_str(), to_path.c_str(), msg.c_str());
     return 1;
   } else {
-    fprintf(
-      out,
-      "rr: Moved '%s' to '%s'\n",
-      from_path.c_str(),
-      to_path.c_str());
+    fprintf(out, "rr: Moved '%s' to '%s'\n", from_path.c_str(),
+            to_path.c_str());
     return 0;
   }
 }
@@ -121,13 +111,11 @@ int MvCommand::run(vector<string>& args) {
         return mv(from, to, stdout);
       } catch (const fs::filesystem_error& e) {
         const string msg = e.what();
-        fprintf(
-          stderr,
-          "\n"
-          "rr: Unexpected filesystem error: %s\n"
-          "\n",
-          msg.c_str()
-        );
+        fprintf(stderr,
+                "\n"
+                "rr: Unexpected filesystem error: %s\n"
+                "\n",
+                msg.c_str());
         return 1;
       }
     }

--- a/src/RmCommand.cc
+++ b/src/RmCommand.cc
@@ -1,0 +1,154 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <stdio.h>
+
+#include <vector>
+#include <experimental/filesystem>
+
+#include "Command.h"
+#include "main.h"
+#include "TraceStream.h"
+#include "util.h"
+
+using namespace std;
+namespace fs = std::experimental::filesystem;
+
+namespace rr {
+
+class RmCommand : public Command {
+public:
+  virtual int run(vector<string>& args);
+
+protected:
+  RmCommand(const char* name, const char* help) : Command(name, help) {}
+
+  static RmCommand singleton;
+};
+
+RmCommand RmCommand::singleton(
+    "rm", " rr rm <trace> [OPTION]...\n"
+          "  -f, --force, remove folder even if not identifiable as trace.\n");
+
+struct RmFlags {
+  bool force;
+  RmFlags() : force(false) {}
+};
+
+static bool parse_rm_arg(vector<string>& args, RmFlags& flags) {
+  if (parse_global_option(args)) {
+    return true;
+  }
+
+  static const OptionSpec options[] = { { 'f', "force", NO_PARAMETER } };
+  ParsedOption opt;
+  if (!Command::parse_option(args, options, &opt)) {
+    return false;
+  }
+
+  switch (opt.short_name) {
+    case 'f':
+      flags.force = true;
+      break;
+    default:
+      assert(0 && "Unknown option");
+  }
+
+  return true;
+}
+
+static int rm(const string& trace, const RmFlags& flags, FILE* out) {
+  if (!ensure_valid_trace_name(trace)) {
+    return 1;
+  }
+
+  fs::path trace_path = resolve_trace_name(trace);
+
+  if (!fs::exists(trace_path)) {
+    fprintf(
+      stderr,
+      "\n"
+      "rr: Cannot remove non-existent trace '%s'\n"
+      "\n",
+      trace_path.c_str()
+    );
+    return 1;
+  }
+
+  // canonical will resolve latest_trace
+  trace_path = fs::canonical(trace_path);
+
+  if (!flags.force && !is_trace(trace_path)) {
+    fprintf(
+        stderr,
+        "\n"
+        "rr: Could not idenfity '%s' as a trace, use -f to remove anyway.\n"
+        "\n",
+        trace_path.c_str());
+    return 1;
+  }
+
+  // remove symlink before removing trace in case the former fails
+  // a bad symlink might crash other things later such as rr ls, midas
+  if (is_latest_trace(trace_path)) {
+    if (!remove_latest_trace_symlink()) {
+      return 1;
+    }
+  }
+
+  error_code ec;
+  remove_all(trace_path, ec);
+  if (ec) {
+    const string msg = ec.message();
+    fprintf(
+        stderr,
+        "\n"
+        "rr: Could not remove trace '%s': %s\n"
+        "\n",
+        trace_path.c_str(),
+        msg.c_str());
+    return 1;
+  } else {
+    fprintf(out, "rr: Removed trace '%s'\n", trace_path.c_str());
+    return 0;
+  }
+}
+
+int RmCommand::run(vector<string>& args) {
+  bool found_trace = false;
+  string trace;
+  RmFlags flags;
+
+  while (!args.empty()) {
+    if (parse_rm_arg(args, flags)) {
+      continue;
+    }
+    // use parse_optional_trace_dir to parse trace name
+    if (!found_trace && parse_optional_trace_dir(args, &trace)) {
+      found_trace = true;
+      continue;
+    }
+    print_help(stderr);
+    return 1;
+  };
+
+  if (!found_trace) {
+    print_help(stderr);
+    return 1;
+  }
+
+  try {
+    return rm(trace, flags, stdout);
+  } catch (const fs::filesystem_error& e) {
+    const string msg = e.what();
+    fprintf(
+      stderr,
+      "\n"
+      "rr: Unexpected filesystem error: %s\n"
+      "\n",
+      msg.c_str()
+    );
+    return 1;
+  }
+};
+
+} // namespace rr

--- a/src/RmCommand.cc
+++ b/src/RmCommand.cc
@@ -2,12 +2,12 @@
 
 #include <stdio.h>
 
-#include <vector>
 #include <experimental/filesystem>
+#include <vector>
 
 #include "Command.h"
-#include "main.h"
 #include "TraceStream.h"
+#include "main.h"
 #include "util.h"
 
 using namespace std;
@@ -64,13 +64,11 @@ static int rm(const string& trace, const RmFlags& flags, FILE* out) {
   fs::path trace_path = resolve_trace_name(trace);
 
   if (!fs::exists(trace_path)) {
-    fprintf(
-      stderr,
-      "\n"
-      "rr: Cannot remove non-existent trace '%s'\n"
-      "\n",
-      trace_path.c_str()
-    );
+    fprintf(stderr,
+            "\n"
+            "rr: Cannot remove non-existent trace '%s'\n"
+            "\n",
+            trace_path.c_str());
     return 1;
   }
 
@@ -78,12 +76,11 @@ static int rm(const string& trace, const RmFlags& flags, FILE* out) {
   trace_path = fs::canonical(trace_path);
 
   if (!flags.force && !is_trace(trace_path)) {
-    fprintf(
-        stderr,
-        "\n"
-        "rr: Could not idenfity '%s' as a trace, use -f to remove anyway.\n"
-        "\n",
-        trace_path.c_str());
+    fprintf(stderr,
+            "\n"
+            "rr: Could not idenfity '%s' as a trace, use -f to remove anyway.\n"
+            "\n",
+            trace_path.c_str());
     return 1;
   }
 
@@ -99,13 +96,11 @@ static int rm(const string& trace, const RmFlags& flags, FILE* out) {
   remove_all(trace_path, ec);
   if (ec) {
     const string msg = ec.message();
-    fprintf(
-        stderr,
-        "\n"
-        "rr: Could not remove trace '%s': %s\n"
-        "\n",
-        trace_path.c_str(),
-        msg.c_str());
+    fprintf(stderr,
+            "\n"
+            "rr: Could not remove trace '%s': %s\n"
+            "\n",
+            trace_path.c_str(), msg.c_str());
     return 1;
   } else {
     fprintf(out, "rr: Removed trace '%s'\n", trace_path.c_str());
@@ -140,13 +135,11 @@ int RmCommand::run(vector<string>& args) {
     return rm(trace, flags, stdout);
   } catch (const fs::filesystem_error& e) {
     const string msg = e.what();
-    fprintf(
-      stderr,
-      "\n"
-      "rr: Unexpected filesystem error: %s\n"
-      "\n",
-      msg.c_str()
-    );
+    fprintf(stderr,
+            "\n"
+            "rr: Unexpected filesystem error: %s\n"
+            "\n",
+            msg.c_str());
     return 1;
   }
 };

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -118,7 +118,7 @@ string trace_save_dir() {
   return output_dir ? output_dir : default_rr_trace_dir();
 }
 
-static string latest_trace_symlink() {
+string latest_trace_symlink() {
   return trace_save_dir() + "/latest-trace";
 }
 

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -523,6 +523,7 @@ private:
 
 extern std::string trace_save_dir();
 extern std::string resolve_trace_name(const std::string& trace_name);
+extern std::string latest_trace_symlink();
 
 } // namespace rr
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -27,12 +27,12 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <experimental/filesystem>
 #include <fstream>
 #include <string>
 #include <numeric>
 #include <random>
 #include <sstream>
-#include <experimental/filesystem>
 
 #include "preload/preload_interface.h"
 
@@ -2212,13 +2212,11 @@ bool remove_latest_trace_symlink() {
   fs::remove(latest, ec);
   if (ec) {
     const string msg = ec.message();
-    fprintf(
-      stderr,
-      "\n"
-      "rr: Failed to remove latest_trace symlink: %s\n"
-      "\n",
-      msg.c_str()
-    );
+    fprintf(stderr,
+            "\n"
+            "rr: Failed to remove latest_trace symlink: %s\n"
+            "\n",
+            msg.c_str());
     return false;
   }
   return true;
@@ -2229,7 +2227,8 @@ bool ensure_valid_trace_name(const fs::path& entry) {
   const string name = entry.filename();
 
   if (*entry.string().rbegin() == '/') {
-    // filename() will resolve name as '.' which might be a confusing error message
+    // filename() will resolve name as '.' which might be a confusing error
+    // message
     fprintf(stderr, "\nrr: Trace name cannot be empty\n\n");
     return false;
   }

--- a/src/util.h
+++ b/src/util.h
@@ -8,11 +8,11 @@
 #include <math.h>
 
 #include <array>
+#include <experimental/filesystem>
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
-#include <experimental/filesystem>
 
 #if defined(__i386__) || defined(__x86_64__)
 #include <x86intrin.h>

--- a/src/util.h
+++ b/src/util.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <experimental/filesystem>
 
 #if defined(__i386__) || defined(__x86_64__)
 #include <x86intrin.h>
@@ -514,6 +515,14 @@ ssize_t pwrite_all_fallible(int fd, const void* buf, size_t size, off64_t offset
  * was an error.
  */
 bool is_directory(const char* path);
+
+bool is_trace(const std::experimental::filesystem::path& trace);
+
+bool is_latest_trace(const std::experimental::filesystem::path& trace);
+
+bool remove_latest_trace_symlink();
+
+bool ensure_valid_trace_name(const std::experimental::filesystem::path& entry);
 
 /**
  * Read bytes from `fd` into `buf` from `offset` until the read returns an


### PR DESCRIPTION
As discussed in #1415, this pull request implements `rr rm` and `rr mv` commands to manage traces.