### PR TITLE
Disable test large_file on 32-bit rr.

### DIFF
--- a/src/test/large_file.run
+++ b/src/test/large_file.run
@@ -1,5 +1,6 @@
 source `dirname $0`/util.sh
 
+skip_if_rr_32_bit
 exe=simple$bitness
 cp ${OBJDIR}/bin/$exe $exe-$nonce
 truncate -s 2G $exe-$nonce


### PR DESCRIPTION
Because 32-bit rr is compiled without `-D_FILE_OFFSET_BITS=64`. Therefore the open of the large file fails with EOVERFLOW.

 [FATAL src/record_syscall.cc:5531:process_execve() errno: EOVERFLOW]
  (task 2019470 (rec:2019470) at time 14)
  -> Assertion `fd.is_open()' failed to hold.

------

My attempts to either use `-D_FILE_OFFSET_BITS=64` or open64/stat64 were leading to a row of changes involving size_t/off_t or struct stat, which I guess are not desired for the fading 32-bit architecture?