### PR TITLE
Add rr commands to remove and move traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ set(RR_SOURCES
   src/MmappedFileMonitor.cc
   src/MonitoredSharedMemory.cc
   src/Monkeypatcher.cc
+  src/MvCommand.cc
   src/PackCommand.cc
   src/PerfCounters.cc
   src/PidFdMonitor.cc
@@ -576,6 +577,7 @@ set(RR_SOURCES
   src/ReplayTimeline.cc
   src/RerunCommand.cc
   src/ReturnAddressList.cc
+  src/RmCommand.cc
   src/Scheduler.cc
   src/SeccompFilterRewriter.cc
   src/Session.cc
@@ -667,6 +669,7 @@ target_link_libraries(rr
   ${CMAKE_DL_LIBS}
   ${ZLIB_LDFLAGS}
   brotli
+  stdc++fs
 )
 
 if(staticlibs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,7 +669,6 @@ target_link_libraries(rr
   ${CMAKE_DL_LIBS}
   ${ZLIB_LDFLAGS}
   brotli
-  stdc++fs
 )
 
 if(staticlibs)

--- a/src/LsCommand.cc
+++ b/src/LsCommand.cc
@@ -131,16 +131,6 @@ static bool get_folder_size(string dir_name, string& size_str) {
   return true;
 }
 
-static bool is_valid_trace(const string& entry) {
-  if (entry[0] == '.' || entry[0] == '#') {
-    return false;
-  }
-  if (entry[entry.length() - 1] == '~') {
-    return false;
-  }
-  return true;
-}
-
 static string get_exec_path(TraceReader& reader) {
   while (true) {
     TraceTaskEvent r = reader.read_task_event();
@@ -173,7 +163,7 @@ static int ls(const string& traces_dir, const LsFlags& flags, FILE* out) {
     if (full_traces_dir + trace_dir->d_name == cpu_lock) {
       continue;
     }
-    if (!is_valid_trace(trace_dir->d_name)) {
+    if (!is_valid_trace_name(trace_dir->d_name)) {
       continue;
     }
     traces.emplace_back(TraceInfo(string(trace_dir->d_name)));

--- a/src/MvCommand.cc
+++ b/src/MvCommand.cc
@@ -88,7 +88,8 @@ static int mv(const string& from, const string& to, FILE* out) {
     }
   }
 
-  if (int ret = rename(from_path.c_str(), to_path.c_str())) {
+  int ret = rename(from_path.c_str(), to_path.c_str());
+  if (ret != 0) {
     const string err = strerror(errno);
     fprintf(stderr,
             "\n"

--- a/src/MvCommand.cc
+++ b/src/MvCommand.cc
@@ -27,8 +27,7 @@ protected:
 MvCommand MvCommand::singleton("mv", " rr mv <trace> <new-trace>\n");
 
 static int mv(const string& from, const string& to, FILE* out) {
-  if (!is_valid_trace_name(from, true) ||
-      !is_valid_trace_name(to, true)) {
+  if (!is_valid_trace_name(from, true) || !is_valid_trace_name(to, true)) {
     return 1;
   }
 
@@ -39,8 +38,7 @@ static int mv(const string& from, const string& to, FILE* out) {
             "\n"
             "rr: Could not access / identify '%s' as a trace (errno %d).\n"
             "\n",
-            from_path.c_str(),
-            errno);
+            from_path.c_str(), errno);
     return 1;
   }
 
@@ -80,8 +78,7 @@ static int mv(const string& from, const string& to, FILE* out) {
             "\n"
             "rr: Cannot access new trace path '%s': errno %d\n"
             "\n",
-            to_path.c_str(),
-            errno);
+            to_path.c_str(), errno);
     return 1;
   }
 

--- a/src/MvCommand.cc
+++ b/src/MvCommand.cc
@@ -1,0 +1,127 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <stdio.h>
+
+#include <sysexits.h>
+#include <vector>
+
+#include "Command.h"
+#include "TraceStream.h"
+#include "main.h"
+#include "util.h"
+
+using namespace std;
+
+namespace rr {
+
+class MvCommand : public Command {
+public:
+  virtual int run(vector<string>& args);
+
+protected:
+  MvCommand(const char* name, const char* help) : Command(name, help) {}
+
+  static MvCommand singleton;
+};
+
+MvCommand MvCommand::singleton("mv", " rr mv <trace> <new-trace>\n");
+
+static int mv(const string& from, const string& to, FILE* out) {
+  if (!is_valid_trace_name(from, true) ||
+      !is_valid_trace_name(to, true)) {
+    return 1;
+  }
+
+  string from_path = resolve_trace_name(from);
+
+  if (!is_trace(from_path)) {
+    fprintf(stderr,
+            "\n"
+            "rr: Could not access / identify '%s' as a trace (errno %d).\n"
+            "\n",
+            from_path.c_str(),
+            errno);
+    return 1;
+  }
+
+  // resolve symlinks like latest_trace and make comparable
+  from_path = real_path(from_path);
+
+  string to_path = to;
+  // if 'to' is not a path, view it as trace name and move to trace_dir/to
+  if (to.find("/") == string::npos) {
+    to_path = trace_save_dir() + "/" + to;
+  }
+
+  string to_fname = filename(to_path.c_str());
+  if (to_fname == "latest-trace") {
+    fprintf(stderr, "\nrr: Cannot rename to latest-trace.\n\n");
+    return 1;
+  }
+
+  if (from_path == to_path) {
+    fprintf(stderr,
+            "\n"
+            "rr: Old and new trace dir cannot be the same ('%s').\n"
+            "\n",
+            to_path.c_str());
+    return 1;
+  }
+
+  if (access(to_path.c_str(), F_OK) == 0) {
+    fprintf(stderr,
+            "\n"
+            "rr: New trace '%s' already exists or cannot be accessed.\n"
+            "\n",
+            to_path.c_str());
+    return 1;
+  } else if (errno != ENOENT) {
+    fprintf(stderr,
+            "\n"
+            "rr: Cannot access new trace path '%s': errno %d\n"
+            "\n",
+            to_path.c_str(),
+            errno);
+    return 1;
+  }
+
+  // remove symlink before removing trace in case the former fails
+  // a bad symlink crashes e.g. rr ls and midas
+  if (is_latest_trace(from_path)) {
+    if (!remove_latest_trace_symlink()) {
+      return 1;
+    }
+  }
+
+  int ret = rename(from_path.c_str(), to_path.c_str());
+
+  if (ret) {
+    const string err = strerror(errno);
+    fprintf(stderr,
+            "\n"
+            "rr: Cannot move '%s' to '%s': %s\n"
+            "\n",
+            from_path.c_str(), to_path.c_str(), err.c_str());
+    return 1;
+  } else {
+    fprintf(out, "rr: Moved '%s' to '%s'\n", from_path.c_str(),
+            to_path.c_str());
+    return 0;
+  }
+}
+
+int MvCommand::run(vector<string>& args) {
+  if (args.size() == 2 && verify_not_option(args)) {
+    string from = args[0];
+    args.erase(args.begin());
+    if (verify_not_option(args)) {
+      string to = args[0];
+      return mv(from, to, stdout);
+    }
+  }
+
+  print_help(stderr);
+  return 1;
+};
+
+} // namespace rr

--- a/src/RmCommand.cc
+++ b/src/RmCommand.cc
@@ -81,10 +81,10 @@ static int rm(const string& trace, const RmFlags& flags, FILE* out) {
   if (access(trace_path.c_str(), F_OK) != 0) {
     fprintf(stderr,
             "\n"
-            "rr: Cannot remove non-existent / unaccessible trace '%s': errno %d\n"
+            "rr: Cannot remove non-existent / unaccessible trace '%s':"
+            " errno %d\n"
             "\n",
-            trace_path.c_str(),
-            errno);
+            trace_path.c_str(), errno);
     return 1;
   }
 
@@ -94,10 +94,10 @@ static int rm(const string& trace, const RmFlags& flags, FILE* out) {
   if (!flags.force && !is_trace(trace_path)) {
     fprintf(stderr,
             "\n"
-            "rr: Could not idenfity '%s' as a trace, use -f to remove anyway (errno %d).\n"
+            "rr: Could not idenfity '%s' as a trace, use -f to remove anyway"
+            " (errno %d).\n"
             "\n",
-            trace_path.c_str(),
-            errno);
+            trace_path.c_str(), errno);
     return 1;
   }
 

--- a/src/RmCommand.cc
+++ b/src/RmCommand.cc
@@ -57,8 +57,9 @@ static bool parse_rm_arg(vector<string>& args, RmFlags& flags) {
 
 static int _rm_cb(const char* path, const struct stat*, int, struct FTW*) {
   int ret = remove(path);
-  if (ret)
+  if (ret) {
     perror(path);
+  }
   return ret;
 }
 
@@ -72,7 +73,13 @@ static bool remove_all(const string& path) {
 }
 
 static int rm(const string& trace, const RmFlags& flags, FILE* out) {
-  if (!is_valid_trace_name(trace, true)) {
+  string reason;
+  if (!is_valid_trace_name(trace, &reason)) {
+    fprintf(stderr,
+            "\n"
+            "rr: Trace name is invalid: %s\n"
+            "\n",
+            reason.c_str());
     return 1;
   }
 

--- a/src/RmCommand.cc
+++ b/src/RmCommand.cc
@@ -1,0 +1,151 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <ftw.h>
+#include <stdio.h>
+
+#include <vector>
+
+#include "Command.h"
+#include "TraceStream.h"
+#include "main.h"
+#include "util.h"
+
+using namespace std;
+
+namespace rr {
+
+class RmCommand : public Command {
+public:
+  virtual int run(vector<string>& args);
+
+protected:
+  RmCommand(const char* name, const char* help) : Command(name, help) {}
+
+  static RmCommand singleton;
+};
+
+RmCommand RmCommand::singleton(
+    "rm", " rr rm <trace> [OPTION]...\n"
+          "  -f, --force, remove folder even if not identifiable as trace.\n");
+
+struct RmFlags {
+  bool force;
+  RmFlags() : force(false) {}
+};
+
+static bool parse_rm_arg(vector<string>& args, RmFlags& flags) {
+  if (parse_global_option(args)) {
+    return true;
+  }
+
+  static const OptionSpec options[] = { { 'f', "force", NO_PARAMETER } };
+  ParsedOption opt;
+  if (!Command::parse_option(args, options, &opt)) {
+    return false;
+  }
+
+  switch (opt.short_name) {
+    case 'f':
+      flags.force = true;
+      break;
+    default:
+      assert(0 && "Unknown option");
+  }
+
+  return true;
+}
+
+static int _rm_cb(const char* path, const struct stat*, int, struct FTW*) {
+  int ret = remove(path);
+  if (ret)
+    perror(path);
+  return ret;
+}
+
+static bool remove_all(const string& path) {
+  int ret = nftw(path.c_str(), _rm_cb, 16, FTW_DEPTH | FTW_PHYS);
+  if (ret) {
+    perror(path.c_str());
+    return false;
+  }
+  return true;
+}
+
+static int rm(const string& trace, const RmFlags& flags, FILE* out) {
+  if (!is_valid_trace_name(trace, true)) {
+    return 1;
+  }
+
+  string trace_path = resolve_trace_name(trace);
+
+  if (access(trace_path.c_str(), F_OK) != 0) {
+    fprintf(stderr,
+            "\n"
+            "rr: Cannot remove non-existent / unaccessible trace '%s': errno %d\n"
+            "\n",
+            trace_path.c_str(),
+            errno);
+    return 1;
+  }
+
+  // resolve symlinks like latest_trace
+  trace_path = real_path(trace_path);
+
+  if (!flags.force && !is_trace(trace_path)) {
+    fprintf(stderr,
+            "\n"
+            "rr: Could not idenfity '%s' as a trace, use -f to remove anyway (errno %d).\n"
+            "\n",
+            trace_path.c_str(),
+            errno);
+    return 1;
+  }
+
+  // remove symlink before removing trace in case the former fails
+  // a bad symlink might crash other things later such as rr ls, midas
+  if (is_latest_trace(trace_path)) {
+    if (!remove_latest_trace_symlink()) {
+      return 1;
+    }
+  }
+
+  if (!remove_all(trace_path)) {
+    fprintf(stderr,
+            "\n"
+            "rr: Could not remove trace '%s'\n"
+            "\n",
+            trace_path.c_str());
+    return 1;
+  } else {
+    fprintf(out, "rr: Removed trace '%s'\n", trace_path.c_str());
+    return 0;
+  }
+}
+
+int RmCommand::run(vector<string>& args) {
+  bool found_trace = false;
+  string trace;
+  RmFlags flags;
+
+  while (!args.empty()) {
+    if (parse_rm_arg(args, flags)) {
+      continue;
+    }
+    // use parse_optional_trace_dir to parse trace name
+    if (!found_trace && parse_optional_trace_dir(args, &trace)) {
+      found_trace = true;
+      continue;
+    }
+    print_help(stderr);
+    return 1;
+  };
+
+  if (!found_trace) {
+    print_help(stderr);
+    return 1;
+  }
+
+  return rm(trace, flags, stdout);
+};
+
+} // namespace rr

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -118,7 +118,7 @@ string trace_save_dir() {
   return output_dir ? output_dir : default_rr_trace_dir();
 }
 
-static string latest_trace_symlink() {
+string latest_trace_symlink() {
   return trace_save_dir() + "/latest-trace";
 }
 

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -521,9 +521,9 @@ private:
   int quirks_;
 };
 
-extern std::string trace_save_dir();
-extern std::string resolve_trace_name(const std::string& trace_name);
-extern std::string latest_trace_symlink();
+std::string trace_save_dir();
+std::string resolve_trace_name(const std::string& trace_name);
+std::string latest_trace_symlink();
 
 } // namespace rr
 

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -523,6 +523,7 @@ private:
 
 extern std::string trace_save_dir();
 extern std::string resolve_trace_name(const std::string& trace_name);
+extern std::string latest_trace_symlink();
 
 } // namespace rr
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -2232,19 +2232,23 @@ bool is_valid_trace_name(const string& entry, bool log_error) {
   const string name = filename(entry.c_str());
 
   if (name.empty()) {
-    if (log_error) fprintf(stderr, "\nrr: Trace name cannot be empty\n\n");
+    if (log_error)
+      fprintf(stderr, "\nrr: Trace name cannot be empty\n\n");
     return false;
   }
   if (name[0] == '.' || name[0] == '#') {
-    if (log_error) fprintf(stderr, "\nrr: Trace name cannot start with . or #.\n\n");
+    if (log_error)
+      fprintf(stderr, "\nrr: Trace name cannot start with . or #.\n\n");
     return false;
   }
   if (name[name.length() - 1] == '~') {
-    if (log_error) fprintf(stderr, "\nrr: Trace name cannot end with ~.\n\n");
+    if (log_error)
+      fprintf(stderr, "\nrr: Trace name cannot end with ~.\n\n");
     return false;
   }
   if (name == "cpu_lock") {
-    if (log_error) fprintf(stderr, "\nrr: Trace name cannot be cpu_lock.\n\n");
+    if (log_error)
+      fprintf(stderr, "\nrr: Trace name cannot be cpu_lock.\n\n");
     return false;
   }
   return true;

--- a/src/util.cc
+++ b/src/util.cc
@@ -2227,30 +2227,35 @@ bool remove_latest_trace_symlink() {
   return true;
 }
 
-bool is_valid_trace_name(const string& entry, bool log_error) {
+bool is_valid_trace_name(const string& entry, std::string* reason) {
   // filename corresponds to dirname
   const string name = filename(entry.c_str());
 
   if (name.empty()) {
-    if (log_error)
-      fprintf(stderr, "\nrr: Trace name cannot be empty\n\n");
+    if (reason) {
+      *reason = "Empty";
+    }
     return false;
   }
   if (name[0] == '.' || name[0] == '#') {
-    if (log_error)
-      fprintf(stderr, "\nrr: Trace name cannot start with . or #.\n\n");
+    if (reason) {
+      *reason = "Cannot start with . or #";
+    }
     return false;
   }
   if (name[name.length() - 1] == '~') {
-    if (log_error)
-      fprintf(stderr, "\nrr: Trace name cannot end with ~.\n\n");
+    if (reason) {
+      *reason = "Cannot end with ~";
+    }
     return false;
   }
   if (name == "cpu_lock") {
-    if (log_error)
-      fprintf(stderr, "\nrr: Trace name cannot be cpu_lock.\n\n");
+    if (reason) {
+      *reason = "Name cpu_lock is reserved";
+    }
     return false;
   }
+
   return true;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -539,11 +539,13 @@ bool is_latest_trace(const std::string& trace);
 bool remove_latest_trace_symlink();
 
 /*
- * Returns whether |entry| is a valid trace name and optionally logs why not.
+ * Returns whether |entry| is a valid trace name.
+ * If invalid, optional out-param |reason| will be set to the reason.
  * I.e. does not start with . or #, does not end with ~, is neither cpu_lock
  * nor latest_trace.
  */
-bool is_valid_trace_name(const std::string& entry, bool log_error = false);
+bool is_valid_trace_name(const std::string& entry,
+                         std::string* reason = nullptr);
 
 /**
  * Read bytes from `fd` into `buf` from `offset` until the read returns an

--- a/src/util.h
+++ b/src/util.h
@@ -515,6 +515,36 @@ ssize_t pwrite_all_fallible(int fd, const void* buf, size_t size, off64_t offset
  */
 bool is_directory(const char* path);
 
+/*
+ * Returns a pointer to the filename portion of the path.
+ * That is the position after the last '/'
+ */
+const char* filename(const char* path);
+
+/*
+ * Returns whether a trace is at the path by checking for a version or
+ * incomplete file.
+ * Will set errno, if false.
+ */
+bool is_trace(const std::string& path);
+
+/*
+ * Returns whether the latest_trace symlink (if any) points to |trace|.
+ */
+bool is_latest_trace(const std::string& trace);
+
+/*
+ * Deletes the latest_trace symlink, logs an error and returns false on failure.
+ */
+bool remove_latest_trace_symlink();
+
+/*
+ * Returns whether |entry| is a valid trace name and optionally logs why not.
+ * I.e. does not start with . or #, does not end with ~, is neither cpu_lock
+ * nor latest_trace.
+ */
+bool is_valid_trace_name(const std::string& entry, bool log_error=false);
+
 /**
  * Read bytes from `fd` into `buf` from `offset` until the read returns an
  * error or 0 or the buffer is full. Returns total bytes read or -1 for error.

--- a/src/util.h
+++ b/src/util.h
@@ -543,7 +543,7 @@ bool remove_latest_trace_symlink();
  * I.e. does not start with . or #, does not end with ~, is neither cpu_lock
  * nor latest_trace.
  */
-bool is_valid_trace_name(const std::string& entry, bool log_error=false);
+bool is_valid_trace_name(const std::string& entry, bool log_error = false);
 
 /**
  * Read bytes from `fd` into `buf` from `offset` until the read returns an


### PR DESCRIPTION
As discussed in #1415, this pull request implements `rr rm` and `rr mv` commands to manage traces.

See #3558 for a similar pull request using `std::filesystem` that was closed because that library caused build errors.