### PR TITLE
Create a known-patchable sequence for rdtsc trapping

### DIFF
--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -183,6 +183,11 @@ static inline const char* extract_file_name(const char* s) {
  * (rather than the first), which requires special handling.
  */
 #define PATCH_SYSCALL_INSTRUCTION_IS_LAST (1 << 1)
+/* All instructions in the patch are nop and their execution is thus not
+ * observable. This may allow more aggressive handling of interfering branches.
+ */
+#define PATCH_IS_NOP_INSTRUCTIONS (1 << 2)
+
 
 /**
  * To support syscall buffering, we replace syscall instructions with a "call"

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -650,6 +650,10 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_48_89_fb)
         callq __morestack
 SYSCALLHOOK_END(_syscall_hook_trampoline_48_89_fb)
 
+SYSCALLHOOK_START(_syscall_hook_trampoline_nops)
+        callq __morestack
+SYSCALLHOOK_END(_syscall_hook_trampoline_nops)
+
 #elif defined(__aarch64__)
         .text
 

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -784,6 +784,7 @@ static void __attribute__((constructor)) init_process(void) {
   extern RR_HIDDEN void _syscall_hook_trampoline_48_89_e5(void);
   extern RR_HIDDEN void _syscall_hook_trampoline_48_89_fb(void);
   extern RR_HIDDEN void _syscall_hook_trampoline_48_8d_b3_f0_08_00_00(void);
+  extern RR_HIDDEN void _syscall_hook_trampoline_nops(void);
 
 #define MOV_RDX_VARIANTS \
   MOV_RDX_TO_REG(48, d0) \
@@ -1002,6 +1003,12 @@ static void __attribute__((constructor)) init_process(void) {
       3,
       { 0x48, 0x89, 0xfb },
       (uintptr_t)_syscall_hook_trampoline_48_89_fb },
+    /* Support explicit 5 byte nop (`nopl 0(%ax, %ax, 1)`) before 'rdtsc' or syscall (may ignore interfering branches) */
+    { PATCH_SYSCALL_INSTRUCTION_IS_LAST |
+      PATCH_IS_NOP_INSTRUCTIONS,
+      5,
+      { 0x0f, 0x1f, 0x44, 0x00, 0x00 },
+      (uintptr_t)_syscall_hook_trampoline_nops }
   };
 #elif defined(__aarch64__)
   extern RR_HIDDEN void _syscall_hook_trampoline_raw(void);

--- a/src/test/x86/rdtsc_interfering.c
+++ b/src/test/x86/rdtsc_interfering.c
@@ -2,6 +2,33 @@
 
 #include "util.h"
 
+void do_rdtsc_loop(uint32_t with_jump) {
+#ifdef __x86_64__
+  int i;
+
+  uint64_t prev_tsc = 0;
+  for (i = 0; i < 2500000; ++i) {
+    uint32_t out;
+    uint32_t out_hi;
+    asm volatile ("test %%rcx, %%rcx\n\t"
+                  // This branch is useless, but let's make sure it works anyway.
+                  // In practice, we mostly want to make sure that spurious interfering
+                  // branches don't prevent patching so that the `nopl 0(%ax, %ax, 1); rdtsc`
+                  // sequence is guaranteed to patch properly.
+                  "jnz 1f\n\t"
+                  ".byte 0x0f, 0x1f, 0x44, 0x00, 0x00\n\t"
+                  "1: rdtsc\n\t"
+                  : "=a"(out), "=d"(out_hi)
+                  : "c"(with_jump)
+                  : "cc");
+    uint64_t tsc = ((uint64_t)out_hi << 32) + out;
+    test_assert(prev_tsc < tsc);
+    prev_tsc = tsc;
+  }
+#endif
+  (void)with_jump;
+}
+
 uint64_t rdtsc_interfering_sideeffect(uint32_t do_jump) {
   uint64_t check = 0xdeadbeef;
   uint64_t challenge = 0xfeedbeef;
@@ -33,6 +60,8 @@ int main(void) {
   uint64_t tsc1 = rdtsc_interfering_sideeffect(0);
   uint64_t tsc2 = rdtsc_interfering_sideeffect(1);
   test_assert(tsc1 < tsc2);
+  do_rdtsc_loop(0);
+  do_rdtsc_loop(1);
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }


### PR DESCRIPTION
I was looking some disassembly that looked like this:
```
   0x00007f5d7d0e7ffd <+29>:	48 89 7c 24 10	mov    %rdi,0x10(%rsp)
   0x00007f5d7d0e8002 <+34>:	4c 8d 64 24 20	lea    0x20(%rsp),%r12
   0x00007f5d7d0e8007 <+39>:	eb 37	jmp    0x7f5d7d0e8040 <_ZN5tracy8Profiler14CalibrateDelayEv+96>
   0x00007f5d7d0e8009 <+41>:	0f 1f 80 00 00 00 00	nopl   0x0(%rax)
   0x00007f5d7d0e8010 <+48>:	e9 03 8b 1a 3c	jmpq   0x7f5db9290b18
   0x00007f5d7d0e8015 <+53>:	90	nop
   0x00007f5d7d0e8016 <+54>:	4c 8d 2c 02	lea    (%rdx,%rax,1),%r13
   0x00007f5d7d0e801a <+58>:	e8 31 60 fc ff	callq  0x7f5d7d0ae050 <_ZN5tracy28HardwareSupportsInvariantTSCEv@plt>
   0x00007f5d7d0e801f <+63>:	84 c0	test   %al,%al
   0x00007f5d7d0e8021 <+65>:	74 4a	je     0x7f5d7d0e806d <_ZN5tracy8Profiler14CalibrateDelayEv+141>
=> 0x00007f5d7d0e8023 <+67>:	0f 31	rdtsc
   0x00007f5d7d0e8025 <+69>:	48 c1 e2 20	shl    $0x20,%rdx
```
We do have a syscallbuf template for `shl $0x20,%rdx`. Irritatingly, however, the `7c 24` at the top trigger's rr's interfering branch heuristic by false-positive coincidence. Even more unfortunately, this is a calibration loop for a tracing library, so it does actually just call `rdtsc` in a loop a bunch. Additionally this is shipped as a binary, so every user is hitting this unfortunate coincidence. Of course, since we're shipping the library, I can suggest we modify the source to make it more friendly to rr patching. That said, I wasn't quite sure what would be best to suggest here.

At first I thought, I could simply insert a bunch of nops after. Unfortunately, that doesn't actually do anything, because the branch could still be interfering into the middle of the nop sled.
Then I thought maybe a singular large `nop` would be sufficient, but of course, there could be something that intentionally conditionally skips the rdtsc.

In this PR, I propose that we make the following sequence known-safe:
```
nopl 0(%ax, %ax, 1) # single instruction, 5-byte nop
rdtsc
```

This currently wouldn't quite work, because an interfering jump to the `rdtsc` would simply hit the trailing nop padding, ignoring the rdtsc. However, if we slightly tweak the patch to instead use:

```
1: jmp %hook # returns at 2f as usual
[usual nop padding here]
jmp 1b
2:
```

Then everything works out well. Our return address is past the entire patch region, so we return to the correct place and it doesn't matter whether we jump to the nop or to the instruction itself. Of course, and actual interfering branch over the nop is unlikely (though I supposed not impossible depending on what comes before), since interfering branches are supported, this nicely takes care of the spurious branch problem above (assuming the extra 5-byte nop is inserted).