### PR TITLE
allow compile without FS_IOC_FSGETXATTR

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2018,7 +2018,9 @@ static Switchable prepare_ioctl(RecordTask* t,
     case IOCTL_MASK_SIZE(TIOCGPTLCK):
     case IOCTL_MASK_SIZE(TIOCGEXCL):
     case IOCTL_MASK_SIZE(USBDEVFS_GET_CAPABILITIES):
+#ifdef FS_IOC_FSGETXATTR
     case IOCTL_MASK_SIZE(FS_IOC_FSGETXATTR):
+#endif
     // FS_IOC_GETVERSION has the same number as VIDIOCGCAP (but different size)
     // but the same treatment works for both.
     case IOCTL_MASK_SIZE(FS_IOC_GETVERSION):

--- a/src/test/ioctl_fs.c
+++ b/src/test/ioctl_fs.c
@@ -8,7 +8,6 @@ int main(void) {
   int fd = open("dummy.txt", O_RDWR | O_CREAT, 0600);
   long* version;
   long* flags;
-  struct fsxattr* xattr;
   char filebuf[4096] = {};
   char fmbuf[4096] = {};
   struct fiemap *fm;
@@ -34,6 +33,8 @@ int main(void) {
     atomic_printf("flags=%lx\n", *flags);
   }
 
+#ifdef FS_IOC_FSGETXATTR
+  struct fsxattr* xattr;
   ALLOCATE_GUARD(xattr, 'c');
   ret = ioctl(fd, FS_IOC_FSGETXATTR, xattr);
   VERIFY_GUARD(xattr);
@@ -42,6 +43,7 @@ int main(void) {
   } else {
     atomic_printf("xflags=%d\n", xattr->fsx_xflags);
   }
+#endif
 
   test_assert(sizeof(filebuf) == write(fd, &filebuf, sizeof(filebuf)));
   fm = (struct fiemap*)fmbuf;


### PR DESCRIPTION
follow-up to a2d76a6c7e0b49ed2312a333a962f4767ac21d04