### PR TITLE
fix compilation without PTRACE_EVENT_STOP

### DIFF
--- a/src/test/vfork_done.c
+++ b/src/test/vfork_done.c
@@ -1,6 +1,10 @@
 /* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 #include "util.h"
 
+#ifndef PTRACE_EVENT_STOP
+#define PTRACE_EVENT_STOP 128
+#endif
+
 #include <math.h>
 #include <signal.h>
 


### PR DESCRIPTION
for test vfork_done, copied from test ptrace_kill_grandtracee (34a9f5d8cc3a95899b1a2ce3a98664406e3972f0)