### PR TITLE
Implement SIOCGETSGCNT_IN6 ioctl

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -20,6 +20,8 @@
 #include <linux/if_bonding.h>
 #include <linux/ipc.h>
 #include <linux/mqueue.h>
+#include <linux/mroute.h>
+#include <linux/mroute6.h>
 #include <linux/msg.h>
 #include <linux/net.h>
 #include <linux/netfilter/x_tables.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -525,11 +525,35 @@ struct BaseArch : public wordsize,
     ptr<void> sival_ptr;
   };
 
+  struct in_addr {
+    uint32_t s_addr;
+  };
+  RR_VERIFY_TYPE(in_addr);
+
+  struct in6_addr {
+    union {
+      /* don't call these s6_addrX - those are macros */
+      uint8_t addr8[16];
+      uint16_t addr16[8];
+      uint32_t addr32[4];
+    };
+  };
+  RR_VERIFY_TYPE(in_addr);
+
   struct sockaddr {
     unsigned_short sa_family;
     char sa_data[14];
   };
   RR_VERIFY_TYPE(sockaddr);
+
+  struct sockaddr_in6 {
+    unsigned_short sin6_family;
+    unsigned_short sin6_port;
+    uint32_t sin6_flowinfo;
+    in6_addr sin6_addr;
+    uint32_t sin6_scope_id;
+  };
+  RR_VERIFY_TYPE(sockaddr_in6);
 
   struct sockaddr_storage {
     char sa_data[128];
@@ -1048,6 +1072,24 @@ struct BaseArch : public wordsize,
     iwreq_data u;
   };
   RR_VERIFY_TYPE(iwreq);
+
+  struct sioc_sg_req {
+    in_addr src;
+    in_addr grp;
+    unsigned long pktcnt;
+    unsigned long bytecnt;
+    unsigned long wrong_if;
+  };
+  RR_VERIFY_TYPE(sioc_sg_req);
+
+  struct sioc_sg_req6 {
+    sockaddr_in6 src;
+    sockaddr_in6 grp;
+    unsigned long pktcnt;
+    unsigned long bytecnt;
+    unsigned long wrong_if;
+  };
+  RR_VERIFY_TYPE(sioc_sg_req6);
 
   struct _flock {
     signed_short l_type;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -23,6 +23,8 @@
 #include <linux/ipc.h>
 #include <linux/joystick.h>
 #include <linux/kd.h>
+#include <linux/mroute.h>
+#include <linux/mroute6.h>
 #include <linux/msdos_fs.h>
 #include <linux/msg.h>
 #include <linux/net.h>
@@ -1715,6 +1717,22 @@ static Switchable prepare_ioctl(RecordTask* t,
     case SIOCGIFMETRIC:
     case SIOCGIFMAP:
       syscall_state.reg_parameter<typename Arch::ifreq>(3);
+      syscall_state.after_syscall_action(record_page_below_stack_ptr);
+      return PREVENT_SWITCH;
+
+#if 0
+    /* TODO: the IPv4 and IPv6 variants of this ioctl have the same value.
+     * (SIOCPROTOPRIVATE+1) - and there are other uses of this in other
+     * protocols.  So this probably needs a dispatch by fd socket type :(
+     */
+    case SIOCGETSGCNT:
+      syscall_state.reg_parameter<typename Arch::sioc_sg_req>(3);
+      syscall_state.after_syscall_action(record_page_below_stack_ptr);
+      return PREVENT_SWITCH;
+#endif
+
+    case SIOCGETSGCNT_IN6:
+      syscall_state.reg_parameter<typename Arch::sioc_sg_req6>(3);
       syscall_state.after_syscall_action(record_page_below_stack_ptr);
       return PREVENT_SWITCH;
 


### PR DESCRIPTION
Unfortunately this isn't really done as-is since the ioctl value does not uniquely identify this ioctl.  Some way to check the socket AF is needed to disambiguate :(

---
If someone with more experience in hacking on `rr` could take this off my hands that'd be much appreciated… I'm not sure I can dig through to implement figuring out the socket's AF