### PR TITLE
Fixes precedence bug in counters-test/counters.cc

### DIFF
--- a/src/counters-test/counters.cc
+++ b/src/counters-test/counters.cc
@@ -819,8 +819,8 @@ int main(int argc, char** argv) {
   }
   CHECK(pmu);
 
-  do_test_ticks_basic = pmu->flags & PMU_TICKS_RCB != 0;
-  do_test_ticks_syscalls = pmu->flags & PMU_TICKS_RCB != 0;
+  do_test_ticks_basic = (pmu->flags & PMU_TICKS_RCB) != 0;
+  do_test_ticks_syscalls = (pmu->flags & PMU_TICKS_RCB) != 0;
 
   CHECK(0 == pipe(parent_to_child_fds));
   CHECK(0 == pipe(child_to_parent_fds));


### PR DESCRIPTION
I haven't actually checked the logic for what these pseudo-bools mean, but seeing as how `PMU_TICKS_RCB` is a constant (that isn't 0), comparing it to `not 0` will always yield `true`.

foo & bar != baz, will evaluate bar != baz, then foo & ...

This can be verified by building with clang which will catch this error (`-Wparentheses`) 