### PR TITLE
Be more flexible selecting an UTF-8 locale.

### DIFF
--- a/src/test/unicode.run
+++ b/src/test/unicode.run
@@ -1,2 +1,3 @@
 source `dirname $0`/util.sh
+set_utf_locale
 debug_test

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -207,7 +207,7 @@ nontmp_workdir=`mktemp -p $PWD -dt rr-test-$TESTNAME-XXXXXXXXX`
 cd $workdir
 # NB: the testsuite should run on any system with different settings,
 #     so create a reasonable default for all tests
-export LC_ALL=en_US.UTF-8
+export LC_ALL=C
 
 # XXX technically the trailing -XXXXXXXXXX isn't unique, since there
 # could be "foo-123456789" and "bar-123456789", but if that happens,
@@ -545,4 +545,21 @@ function wait_for_complete {
         [[ -f "$record_dir/incomplete" ]] || break
         sleep 0.1
     done
+}
+
+# If not given by user, try to find out if C.UTF-8 or en_US.UTF-8 is available, if not use any UTF-8 locale.
+function set_utf_locale {
+    unset LC_ALL
+    if [ -z "$(which locale)" ]; then
+        if [ -z "$LC_ALL" ]; then export LC_ALL=en_US.UTF-8; fi
+    else
+        if [ -z "$LC_ALL" ]; then export LC_ALL=$(locale -a | grep -i -E "C\.utf.*8" | head -n1); fi
+        if [ -z "$LC_ALL" ]; then export LC_ALL=$(locale -a | grep -i -E "en_US\.utf.*8" | head -n1); fi
+        if [ -z "$LC_ALL" ]; then export LC_ALL=$(locale -a | grep -i -E ".*\.utf.*8" | head -n1); fi
+        if [ -z "$LC_ALL" ]; then
+            echo "Warning: no UTF-8 locale found."
+        else
+            echo "Using LC_ALL=$LC_ALL"
+        fi
+    fi
 }


### PR DESCRIPTION
The current used en_US.UTF-8 is not guaranteed to be available in e.g. Debian, which has for this reason C-UTF-8.
The Debian downstream maintainer has for this a patch in the [rr sources](https://sources.debian.org/src/rr/5.7.0-2/debian/patches/test-locale.patch/).
But this C.UTF-8 seems not to be guaranteed to be available on systems with GNU libc < 2.35, [link](https://unix.stackexchange.com/questions/597962/how-widespread-is-the-c-utf-8-locale).

Therefore this attempt to select an existing UTF-8 locale.
This changes also the default from `LC_ALL=en_US.UTF-8` to `LC_ALL=C`.

See discussion at the end of https://github.com/rr-debugger/rr/issues/3545.

CC: @GitMensch 