### PR TITLE
Another batch of seek-ticks fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1515,6 +1515,7 @@ set(TESTS_WITH_PROGRAM
   seccomp_blocks_rr
   seccomp_open
   seccomp_signals
+  seekticks_threads
   segfault
   setuid
   shared_map

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1571,13 +1571,19 @@ static FrameTime compute_time_from_ticks(ReplayTimeline& timeline, Ticks target)
         break;
       }
     }
+  } else if (target < session.current_trace_frame().ticks()) {
+    // The target tick is entirely within the current frame.
+    // If not handled here, the below loop might otherwise skip over
+    // it if the next frame is for another tid.
+    return last_time;
   }
+  
   while (true) {
     if (tmp_reader.at_end()) {
       return -1;
     }
     TraceFrame frame = tmp_reader.read_frame();
-    if (frame.tid() == task->tuid().tid() && frame.ticks() >= target) {
+    if (frame.tid() == task->tuid().tid() && target < frame.ticks()) {
       break;
     }
     last_time = frame.time() + 1;

--- a/src/test/seekticks_threads.c
+++ b/src/test/seekticks_threads.c
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+// Run two threads until there have been at least a couple
+// (approx. 20) context switches between them.
+// Races are technically possible, but they'll only increase the
+// context switch count, which is fine.
+volatile int counter;
+static void* start_thread(__attribute__((unused)) void* p) {
+  while (1) {
+    int c = counter;
+    if ((c&1) == 1) counter = c+1;
+  }
+  
+  return NULL;
+}
+
+int main(void) {
+  pthread_t thread;
+  pthread_create(&thread, NULL, start_thread, NULL);
+  
+  while (1) {
+    int c = counter;
+    if ((c&1) == 0) counter = c+1;
+    if (counter >= 20) break;
+  }
+
+  return 0;
+}

--- a/src/test/seekticks_threads.py
+++ b/src/test/seekticks_threads.py
@@ -1,0 +1,88 @@
+from util import *
+import re, os
+
+def curr_thread():
+    send_gdb('thread')
+    expect_gdb(re.compile(r'\[Current thread is \d+ \(Thread (.*?)\)\]'))
+    return last_match().group(1)
+
+def expect_thread_tick(expected_thread, expected_tick):
+    if curr_thread() != expected_thread:
+        failed('ERROR: Incorrect thread: expected %s, got %s' % (expected_thread, curr_thread()))
+    
+    send_gdb('when-ticks')
+    expect_gdb(re.compile(r'Current tick: (\d+)'))
+    got_tick = int(last_match().group(1))
+    if expected_tick != got_tick:
+        failed('ERROR: Incorrect ticks: expected %d, got %d' % (expected_tick, got_tick))
+
+def expect_stopped():
+    expect_gdb(re.compile(r'(Thread \d+|Program) stopped'))
+    
+
+
+sched_matches = re.compile(r'global_time:(\d+).*ticks:(\d+)').findall(os.environ['SCHED_EVENTS'])
+sched_events = [[int(y) for y in x] for x in sched_matches][:-2]
+adj_count = 5
+while True:
+    if (len(sched_events) < adj_count):
+        failed('ERROR: Adjacent SCHED events not found')
+    last = sched_events[-adj_count:]
+    if all([last[0][0]+i == last[i][0] for i in range(adj_count)]):
+        break
+    sched_events.pop()
+
+sched_events = sched_events[-adj_count:]
+[event_A, tick_A] = sched_events[1]
+[event_B, tick_B] = sched_events[2]
+[event_C, tick_C] = sched_events[3]
+[event_D, tick_D] = sched_events[4]
+
+tests = [
+    # event; expected tick at event; another tick on the same thread
+    [event_B, tick_A, tick_C],
+    [event_C, tick_B, tick_D]]
+
+threads = set()
+for [start_event, initial_tick, other_tick] in tests:
+    center_tick = (initial_tick + other_tick) // 2
+    
+    send_gdb('run %d' % start_event)
+    expect_gdb('from the beginning')
+    send_gdb('y')
+    expect_stopped()
+    
+    thread = curr_thread()
+    threads.add(thread)
+    
+    expect_thread_tick(thread, initial_tick)
+
+    send_gdb('seek-ticks %d' % center_tick)
+    expect_stopped()
+    expect_thread_tick(thread, center_tick)
+
+    send_gdb('seek-ticks %d' % center_tick)
+    expect_stopped()
+    expect_thread_tick(thread, center_tick)
+
+    ticks = center_tick + 1
+    send_gdb('seek-ticks %d' % ticks)
+    expect_stopped()
+    expect_thread_tick(thread, ticks)
+
+    ticks = center_tick - 1
+    send_gdb('seek-ticks %d' % ticks)
+    expect_stopped()
+    expect_thread_tick(thread, ticks)
+
+    send_gdb('seek-ticks %d' % initial_tick)
+    expect_stopped()
+    expect_thread_tick(thread, initial_tick)
+
+    send_gdb('seek-ticks %d' % other_tick)
+    expect_stopped()
+    expect_thread_tick(thread, other_tick)
+if len(threads) != 2:
+    failed('ERROR: Tested events had the same thread')
+
+ok()

--- a/src/test/seekticks_threads.run
+++ b/src/test/seekticks_threads.run
@@ -1,0 +1,4 @@
+source `dirname $0`/util.sh
+record seekticks_threads$bitness
+SCHED_EVENTS="$(get_events | grep \`SCHED\')" \
+debug seekticks_threads

--- a/src/test/tick0.py
+++ b/src/test/tick0.py
@@ -3,36 +3,47 @@ import re
 
 send_gdb('handle SIGKILL stop')
 
-send_gdb('when')
-expect_gdb(re.compile(r'Current event: (\d+)'))
-event = eval(last_match().group(1));
+def get_when():
+    send_gdb('when')
+    expect_gdb(re.compile(r'Current event: (\d+)'))
+    event = eval(last_match().group(1))
 
-send_gdb('when-ticks')
-expect_gdb(re.compile(r'Current tick: (\d+)'))
-ticks = eval(last_match().group(1));
-if ticks != 0:
-    failed('ERROR in first "when-ticks"')
+    send_gdb('when-ticks')
+    expect_gdb(re.compile(r'Current tick: (\d+)'))
+    ticks = eval(last_match().group(1))
+    return (event, ticks)
+
+(event_start, ticks_start) = get_when()
+if ticks_start != 0:
+    failed('ERROR: Wrong initial ticks')
 
 send_gdb('c')
 
-send_gdb('when-ticks')
-expect_gdb(re.compile(r'Current tick: (\d+)'))
-ticks2 = eval(last_match().group(1));
-if ticks2 < 99999:
-    failed('ERROR in second "when-ticks"')
+(event_end, ticks_end) = get_when()
+if ticks_end < 99999:
+    failed('End ticks too low')
 
-send_gdb("seek-ticks %d" % ticks)
+send_gdb("seek-ticks %d" % ticks_start)
 expect_gdb("Program stopped.")
-send_gdb('when-ticks')
-expect_gdb(re.compile(r'Current tick: (\d+)'))
-ticks3 = eval(last_match().group(1));
-if ticks3 != ticks:
-    failed('ERROR: Failed to seek back to ticks')
+(event_exp, ticks_from_end) = get_when()
+if ticks_from_end != ticks_start:
+    failed('ERROR: Failed to seek back to tick 0 from end')
 
-send_gdb('when')
-expect_gdb(re.compile(r'Current event: (\d+)'))
-event2 = eval(last_match().group(1));
-if event2 != event:
-    failed('ERROR: Failed to seek back to ticks')
+# test at some starting events
+for event in range(event_start-1, min(event_start+5, event_end-1)):
+    send_gdb('run %d' % event)
+    expect_gdb('from the beginning')
+    send_gdb('y')
+    expect_gdb(re.compile(r'(Thread \d+|Program) stopped'))
+    
+    
+    send_gdb("seek-ticks %d" % ticks_start)
+    expect_gdb("Program stopped.")
+    
+    (event, ticks) = get_when()
+    if ticks != 0:
+        failed('ERROR: Failed to seek back to tick 0 from run')
+    if event != event_exp:
+        failed('ERROR: Inconsistent result events from seek-ticks 0')
 
 ok()

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -488,9 +488,14 @@ function rerun_singlestep_test {
     rerun "--singlestep=rip,gp_x16,flags"
 }
 
+# Return an rr dump result of the most recent local recording.
+function get_events {
+    $RR_EXE $GLOBAL_OPTIONS dump "$@" latest-trace
+}
+
 # Return the number of events in the most recent local recording.
 function count_events {
-    local events=$($RR_EXE $GLOBAL_OPTIONS dump -r latest-trace | wc -l)
+    local events=$(get_events -r | wc -l)
     # The |simple| test is just about the simplest possible C program,
     # and has around 180 events (when recorded on a particular
     # developer's machine).  If we count a number of events


### PR DESCRIPTION
This fixes two bugs:

- `seek-ticks` to a tick exactly on a `SCHED` event goes to the other thread, not the current one (the `>=` → `<` change);

- `seek-ticks` to within the current event skips too far if the next event is for a different `tid`.

Additionally, this extracts the logic for tick→time conversion to a function (first commit doing nothing but that).