### PR TITLE
amd: Add Phoenix (Zen 4) CPU ID

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -110,6 +110,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x50f00: // Cezanne (Zen 3)
     case 0x40f40: // Rembrandt (Zen 3+)
     case 0x60f10: // Raphael (Zen 4)
+    case 0x70f40: // Phoenix (Zen 4)
       if (ext_family == 0xa) {
         return AMDZen;
       }

--- a/src/counters-test/counters.cc
+++ b/src/counters-test/counters.cc
@@ -355,6 +355,7 @@ static CpuMicroarch compute_cpu_microarch(void) {
     case 0x50f00: // Cezanne (Zen 3)
     case 0x40f40: // Rembrandt (Zen 3+)
     case 0x60f10: // Raphael (Zen 4)
+    case 0x70f40: // Phoenix (Zen 4)
       if (ext_family == 0xa) {
         return AMDZen;
       }


### PR DESCRIPTION
I've done minimal testing to ensure that this works (using the usual Zen workaround).

This covers (at least) the Ryzen 7840U.