### PR TITLE
Various fixes for invalid things

### DIFF
--- a/src/GdbCommand.cc
+++ b/src/GdbCommand.cc
@@ -109,6 +109,9 @@ static int gNextCheckpointId = 0;
 string invoke_checkpoint(GdbServer& gdb_server, Task*,
                          const vector<string>& args) {
   const string& where = args[0];
+  if (gdb_server.in_debuggee_end_state) {
+    return string("The program is not being run.");
+  }
   int checkpoint_id = ++gNextCheckpointId;
   GdbServer::Checkpoint::Explicit e;
   if (gdb_server.timeline.can_add_checkpoint()) {

--- a/src/GdbCommand.cc
+++ b/src/GdbCommand.cc
@@ -128,6 +128,9 @@ static SimpleGdbCommand checkpoint(
 
 string invoke_delete_checkpoint(GdbServer& gdb_server, Task*,
                                 const vector<string>& args) {
+  if (args.size() < 1) {
+    return "'delete checkpoint' requires an argument";
+  }
   int id = stoi(args[0]);
   auto it = gdb_server.checkpoints.find(id);
   if (it != gdb_server.checkpoints.end()) {

--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -111,8 +111,9 @@ class RRCmd(gdb.Command):
 
     def rr_cmd(self, args):
         # Ensure gdb tells rr its current thread
+        curr_thread = gdb.selected_thread()
         cmd_prefix = ("maint packet qRRCmd:%s:%d"%
-            (self.cmd_name, gdb.selected_thread().ptid[1]))
+            (self.cmd_name, -1 if curr_thread is None else curr_thread.ptid[1]))
         arg_strs = []
         for auto_arg in self.auto_args:
             arg_strs.append(":" + gdb_escape(gdb.execute(auto_arg, to_string=True)))
@@ -256,6 +257,10 @@ static string gdb_unescape(const string& str) {
   }
   LOG(debug) << "invoking command: " << cmd->name();
   Task* target = t->session().find_task(rr_cmd.target_tid);
+  
+  // perhaps not the best option, but better than a nullptr
+  if (target == nullptr) target = t;
+  
   string resp = cmd->invoke(gdb_server, target, args);
 
   if (resp == GdbCommandHandler::cmd_end_diversion()) {

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -209,6 +209,8 @@ private:
   // siginfo for last notified stop.
   siginfo_t stop_siginfo;
   bool in_debuggee_end_state;
+  // True when a restart was attempted but didn't succeed.
+  bool failed_restart;
   // True when the user has interrupted replaying to a target event.
   volatile bool stop_replaying_to_target;
   // True when a DREQ_INTERRUPT has been received but not handled, or when

--- a/src/test/restart_invalid_checkpoint.py
+++ b/src/test/restart_invalid_checkpoint.py
@@ -1,8 +1,12 @@
 from util import *
 
+send_gdb('c')
+send_gdb('checkpoint')
+expect_gdb('is not being run')
+
 send_gdb('b main')
 expect_gdb('Breakpoint 1')
-send_gdb('c')
+restart_replay()
 expect_gdb('Breakpoint 1')
 send_gdb('b atomic_puts')
 expect_gdb('Breakpoint 2')

--- a/src/test/restart_invalid_checkpoint.py
+++ b/src/test/restart_invalid_checkpoint.py
@@ -16,6 +16,12 @@ expect_gdb('Breakpoint 2')
 send_gdb('checkpoint')
 expect_gdb('Checkpoint 1 at')
 send_gdb('restart 8')
+
+send_gdb('info threads')
+# Don't expect anything specific from 'info threads', but make sure gdb at least functions
+send_gdb('p 987654321+1')
+expect_gdb('987654322')
+
 send_gdb('restart -1')
 send_gdb('restart abc')
 send_gdb('restart 1')

--- a/src/test/seekticks.py
+++ b/src/test/seekticks.py
@@ -72,4 +72,10 @@ for i in range(len(tests)):
     if ticks8 != ticks7:
         failed("ERROR: seek-ticks didn't go to correct tick on test %d" % i)
 
+send_gdb('seek-ticks 2000000000')
+expect_gdb('No event found matching specified ticks target')
+send_gdb('info threads')
+# don't expect anything specific from 'info threads', but make sure gdb at least functions
+send_gdb('p 123456789+1')
+expect_gdb('123456790')
 ok()

--- a/src/test/x86/explicit_checkpoints.py
+++ b/src/test/x86/explicit_checkpoints.py
@@ -61,4 +61,7 @@ send_gdb("restart 2");
 send_gdb('c')
 expect_gdb('failed')
 
+send_gdb('delete checkpoint')
+expect_gdb('requires an argument')
+
 ok()


### PR DESCRIPTION
This fixes a couple things:

- `delete checkpoint` without an argument reads outside array bounds

- Checkpoints created at the end state, or when the process has finished, cannot be functionally restored, so disallow those

- After a failed `run`, gdb generally doesn't query anything, except `info threads` (perhaps there are more, but I haven't looked). And if rr responds with any threads, things soon break. Perhaps there's a better way to check for/handle this than my introduced `bool failed_restart;`?