### PR TITLE
Adding support for Intel Icelake cpu_type 0x80660

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -70,6 +70,7 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelTremont;
     case 0x706e0:
     case 0x606a0:
+    case 0x80660:
       return IntelIcelake;
     case 0x806c0:
     case 0x806d0:


### PR DESCRIPTION
This change addresses error when running on newer Icelake CPU sku:
[FATAL ...] Intel CPU type 0x80660 unknown

$ cat /proc/cpuinfo | grep name | uniq
model name      : Intel Xeon Processor (Icelake)