### PR TITLE
CI: use a more specific name for the "Build Android" job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
-name: Build
+name: Android Build
 
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build
+  android-build:
+    name: Android Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently this job shows up as "Build", which I think is a little confusing. So this PR renames that job to "Build Android", which is what that job is specifically testing.