### PR TITLE
initialize the GdbServer::failed_restart variable in constructors

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -51,6 +51,7 @@ GdbServer::GdbServer(std::unique_ptr<GdbServerConnection>& dbg, Task* t)
       last_continue_tuid(t->tuid()),
       last_query_tuid(t->tuid()),
       final_event(UINT32_MAX),
+      failed_restart(false),
       stop_replaying_to_target(false),
       interrupt_pending(false),
       exit_sigkill_pending(false),

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -65,6 +65,7 @@ public:
       : target(target),
         final_event(UINT32_MAX),
         in_debuggee_end_state(false),
+        failed_restart(false),
         stop_replaying_to_target(false),
         interrupt_pending(false),
         exit_sigkill_pending(false),


### PR DESCRIPTION
initialize the GdbServer::failed_restart variable in constructors otherwise random values will cause problems