### PR TITLE
Skip test transient_fault_replay_all when built with force32bit.

### DIFF
--- a/src/test/transient_fault_replay_all.run
+++ b/src/test/transient_fault_replay_all.run
@@ -1,5 +1,7 @@
 source `dirname $0`/util.sh
 
+skip_if_rr_32_bit_with_shell_64_bit
+
 RECORD_ARGS=-M
 just_record seq "1 100"
 RR_SIMULATE_ERROR_AT_EVENT=300 replay -M


### PR DESCRIPTION
The test uses the `seq` utility, which is most probably 64-bit, and can therefore not be recorded by a 32-bit rr.