### PR TITLE
Support interposing a (very basic) gdb script that sets debug file paths in the `sources` command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,6 +793,9 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/src/preload/rr_page.ld"
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scripts/rr-collect-symbols.py"
                "${CMAKE_CURRENT_BINARY_DIR}/bin/rr-collect-symbols.py"
                COPYONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scripts/rr-gdb-script-host.py"
+               "${CMAKE_CURRENT_BINARY_DIR}/bin/rr-gdb-script-host.py"
+               COPYONLY)
 
 install(PROGRAMS scripts/signal-rr-recording.sh
                  scripts/rr-collect-symbols.py

--- a/scripts/rr-gdb-script-host.py
+++ b/scripts/rr-gdb-script-host.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """ rr-gdb-script-host.py <output> <user-gdb-script> <primary binary name>"""
+# Performs a limited emulation of the runtime environment of gdb scripts so that
+# we can run them for `rr sources` to locate debug information.
 from typing import Optional, List, Callable
 import logging
 import os

--- a/scripts/rr-gdb-script-host.py
+++ b/scripts/rr-gdb-script-host.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+""" rr-gdb-script-host.py <output> <user-gdb-script> <primary binary name>"""
+from typing import Optional, List, Callable
+import logging
+import os
+import signal
+import sys
+
+def strip_prefix(s: str, needle: str) -> Optional[str]:
+    if s.startswith(needle):
+        return s[len(needle):]
+
+    return None
+
+GdbNewObjfileEventCallback = Callable[[object], None]
+
+class GdbScriptHost:
+    """ The filename of the main symbol file """
+    _filename: str = ""
+    """ The current value of the gdb dir """
+    _dir: str = ""
+    """ The current value of debug-file-directory """
+    debug_file_directory: str = "/usr/lib/debug"
+
+    new_objfile_events: List[GdbNewObjfileEventCallback] = []
+
+    def __init__(self, *args, **kwargs):
+        self._filename = args[0]
+
+    def show(self, cmd: str) -> Optional[str]:
+        cmd.rstrip()
+        if cmd == "debug-file-directory":
+            return self.debug_file_directory
+        if cmd == "dir":
+            return "Source directories searched: %s:$cdir:$cwd"%self._dir
+
+        return None
+
+    def set(self, cmd: str) -> str:
+        dfd = strip_prefix(cmd, "debug-file-directory ")
+        if dfd:
+            self.debug_file_directory = dfd
+            # Prints nothing upon success.
+            return ""
+
+        # This seems to be the default error message.
+        return "No symbol table is loaded.  Use the \"file\" command."
+
+    def execute_script(self, script: str):
+        gdb_api: GdbApiRoot = GdbApiRoot(self)
+        exec(script, {'gdb': gdb_api})
+
+    def new_objfile(self, f: str):
+        new_objfile: GdbNewObjfile = GdbNewObjfile(self, f)
+        new_objfile_event: GdbNewObjfileEvent = GdbNewObjfileEvent(self, new_objfile)
+        for callback in self.new_objfile_events:
+            callback(new_objfile_event)
+
+class GdbApiObject(object):
+    def __init__(self, *args, **kwargs):
+        self.gdb = args[0]
+
+    def __getattr__(self, attr):
+        logging.warning("Accessing unsupported GDB api %s.%s" % (self.__class__.__name__, attr))
+
+class GdbProgspace(GdbApiObject):
+    filename: str
+
+    def __init__(self, *args, **kwargs):
+        GdbApiObject.__init__(self, *args, **kwargs)
+        self.filename = self.gdb._filename
+
+class GdbNewObjfile(GdbApiObject):
+    filename: str
+    def __init__(self, *args, **kwargs):
+        GdbApiObject.__init__(self, *args, **kwargs)
+        self.filename = args[1]
+
+class GdbNewObjfileEvent(GdbApiObject):
+    new_objfile: GdbNewObjfile
+
+    def __init__(self, *args, **kwargs):
+        GdbApiObject.__init__(self, *args, **kwargs)
+        self.new_objfile = args[1]
+
+class GdbNewObjfileEvents(GdbApiObject):
+    def connect(self, c: GdbNewObjfileEventCallback):
+        logging.debug("EventRegistry.connect")
+        self.gdb.new_objfile_events.append(c)
+
+class GdbApiEvents(GdbApiObject):
+    _new_objfile: Optional[GdbNewObjfileEvents] = None
+
+    @property
+    def new_objfile(self) -> GdbNewObjfileEvents:
+        logging.debug("gdb.events.new_objfile")
+        if self._new_objfile == None:
+            self._new_objfile = GdbNewObjfileEvents(self.gdb)
+        return self._new_objfile
+
+class GdbApiRoot(GdbApiObject):
+    _events: Optional[GdbApiEvents] = None
+    _current_progspace: Optional[GdbProgspace] = None
+
+    def execute(self, command: str, from_tty: bool = False, to_string: bool = False) -> Optional[str]:
+        logging.debug("gdb.execute(\"%s\", from_tty=%s, to_string=%s)"%(command, str(from_tty), str(to_string)))
+        if from_tty:
+            logging.warning("Unsupported gdb.execute with from_tty == True")
+            return None
+
+        remainder = strip_prefix(command, "show ")
+        if remainder:
+            r = self.gdb.show(remainder)
+            if to_string:
+                return r
+            else:
+                print(r, file=sys.stderr)
+                return None
+        remainder = strip_prefix(command, "set ")
+        if remainder:
+            r = self.gdb.set(remainder)
+            if to_string:
+                return r
+            else:
+                print(r, file=sys.stderr)
+                return None
+        remainder = strip_prefix(command, "dir ")
+        if remainder:
+            self.gdb._dir = remainder
+            s = "Source directories searched: %s:$cdir:$cwd"%remainder
+            if to_string:
+                return s
+            else:
+                print(s, file=sys.stderr)
+                return None
+
+        logging.warning("Unsupported gdb.execute \"%s\""%command)
+        return None
+
+    def lookup_global_symbol(self, s: str) -> Optional[object]:
+        #logging.debug("gdb.lookup_global_symbol(\"%s\")"%s)
+        logging.warning("gdb.lookup_global_symbol(\"%s\") is not yet implemented, pretending we found something"%s)
+        return object()
+
+    def current_progspace(self) -> GdbProgspace:
+        logging.debug("gdb.current_progspace()")
+        if self._current_progspace == None:
+            self._current_progspace = GdbProgspace(self.gdb)
+        return self._current_progspace
+
+    @property
+    def events(self) -> GdbApiEvents:
+        logging.debug("gdb.events")
+        if self._events == None:
+            self._events = GdbApiEvents(self.gdb)
+        return self._events
+
+def synchronize():
+    os.kill(os.getpid(), signal.SIGSTOP)
+
+if __name__ == '__main__':
+    with open(sys.argv[1], 'w') as output:
+        with open(sys.argv[2], 'r') as user_script_file:
+            user_script = user_script_file.read()
+            host = GdbScriptHost(sys.argv[3])
+            try:
+                host.execute_script(user_script)
+            except NameError as e:
+                if getattr(e, "name", None) == "python" or e == "NameError: name 'python' is not defined":
+                    # This might be a gdb script that wraps a python script.
+                    start = user_script.find("python") + len("python")
+                    end = user_script.find("end")
+                    if end == -1:
+                        raise(e)
+                    user_script = user_script[start:end]
+                    try:
+                        host.execute_script(user_script)
+                    except:
+                        raise(e)
+
+            print(host.debug_file_directory, file=output, flush=True)
+            print(host._dir, file=output, flush=True)
+            synchronize()
+            for line in sys.stdin:
+                line = line.rstrip()
+                logging.debug("Processing %s"%line)
+                host.new_objfile(line)
+                print(host.debug_file_directory, file=output, flush=True)
+                print(host._dir, file=output, flush=True)
+                synchronize()

--- a/src/ElfReader.cc
+++ b/src/ElfReader.cc
@@ -541,7 +541,7 @@ DwarfSpan ElfReader::dwarf_section(const char* name, bool known_to_be_compressed
   offsets.compressed |= known_to_be_compressed;
   if (offsets.start && offsets.compressed) {
     auto decompressed = impl().decompress_section(offsets);
-    return DwarfSpan(&decompressed->front(), &decompressed->back());
+    return DwarfSpan(decompressed->data(), decompressed->data() + decompressed->size());
   }
   return DwarfSpan(map + offsets.start, map + offsets.end);
 }

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -16,6 +16,7 @@
 #include "ElfReader.h"
 #include "Flags.h"
 #include "ReplaySession.h"
+#include "StringVectorToCharArray.h"
 #include "TraceStream.h"
 #include "core.h"
 #include "cpp_supplement.h"
@@ -219,15 +220,10 @@ DebugDirManager::DebugDirManager(const string& program, const string& gdb_script
 
   string gdb_script_host_path = resource_path() + "bin/rr-gdb-script-host.py";
   pid_t pid;
-  char* gdb_script_host_argv[] = {
-    strdup(gdb_script_host_path.c_str()),
-    strdup(output_file.name.c_str()),
-    strdup(gdb_script.c_str()),
-    strdup(program.c_str()),
-    nullptr,
-  };
+  vector<string> gdb_script_host_argv_vec = { gdb_script_host_path, output_file.name, gdb_script, program };
+  StringVectorToCharArray gdb_script_host_argv(gdb_script_host_argv_vec);
   ret = posix_spawn(&pid, gdb_script_host_path.c_str(), &file_actions, nullptr,
-                    gdb_script_host_argv, environ);
+                    gdb_script_host_argv.get(), environ);
   if (ret != 0) {
     FATAL() << "posix_spawn failed with " << ret;
   }

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -284,15 +284,10 @@ DebugDirs DebugDirManager::read_result() {
 
   char* token = strtok(buf, delimiter);
   while (token != nullptr) {
-    char* buf = realpath(token, nullptr);
-    if (buf) {
-      auto s = string(buf);
-      result.debug_file_directories.push_back(s);
-      LOG(debug) << "gdb script added debug dir '" << s << "'";
-      free(buf);
-    } else {
-      LOG(debug) << "realpath(" << token << ") = " << strerror(errno);
-    }
+    string s(token);
+    s = real_path(s);
+    result.debug_file_directories.push_back(s);
+    LOG(debug) << "gdb script added debug dir '" << s << "'";
     token = strtok(nullptr, delimiter);
   }
 

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -186,7 +186,7 @@ DebugDirManager::~DebugDirManager() {
 }
 
 DebugDirManager::DebugDirManager(const string& program, const string& gdb_script)
-  : pipe_fd(-1), pid(-1), output_file(NULL)
+  : pipe_fd(-1), pid(-1), output_file(nullptr)
 {
   if (gdb_script.empty()) {
     return;
@@ -224,9 +224,9 @@ DebugDirManager::DebugDirManager(const string& program, const string& gdb_script
     strdup(output_file.name.c_str()),
     strdup(gdb_script.c_str()),
     strdup(program.c_str()),
-    NULL,
+    nullptr,
   };
-  ret = posix_spawn(&pid, gdb_script_host_path.c_str(), &file_actions, NULL,
+  ret = posix_spawn(&pid, gdb_script_host_path.c_str(), &file_actions, nullptr,
                     gdb_script_host_argv, environ);
   if (ret != 0) {
     FATAL() << "posix_spawn failed with " << ret;
@@ -283,8 +283,8 @@ DebugDirs DebugDirManager::read_result() {
   buf[index] = 0;
 
   char* token = strtok(buf, delimiter);
-  while (token != NULL) {
-    char* buf = realpath(token, NULL);
+  while (token != nullptr) {
+    char* buf = realpath(token, nullptr);
     if (buf) {
       auto s = string(buf);
       result.debug_file_directories.push_back(s);
@@ -293,7 +293,7 @@ DebugDirs DebugDirManager::read_result() {
     } else {
       LOG(debug) << "realpath(" << token << ") = " << strerror(errno);
     }
-    token = strtok(NULL, delimiter);
+    token = strtok(nullptr, delimiter);
   }
 
   if (!fgets(buf, sizeof(buf) - 1, output_file)) {
@@ -303,8 +303,8 @@ DebugDirs DebugDirManager::read_result() {
   buf[index] = 0;
 
   token = strtok(buf, delimiter);
-  while (token != NULL) {
-    char* buf = realpath(token, NULL);
+  while (token != nullptr) {
+    char* buf = realpath(token, nullptr);
     if (buf) {
       auto s = string(buf);
       result.source_directories.push_back(s);
@@ -313,7 +313,7 @@ DebugDirs DebugDirManager::read_result() {
     } else {
       LOG(debug) << "realpath(" << token << ") = " << strerror(errno);
     }
-    token = strtok(NULL, delimiter);
+    token = strtok(nullptr, delimiter);
   }
 
   return result;
@@ -823,12 +823,12 @@ static bool try_debuglink_file(ElfFileReader& trace_file_reader,
     dd = debug_dirs->process_one_binary(original_file_name);
   }
 
-  const string* chosen_debug_dir = NULL;
+  const string* chosen_debug_dir = nullptr;
   if (!dd.debug_file_directories.empty()) {
     // XXXkhuey what do we do if there's more than one directory?
     chosen_debug_dir = &dd.debug_file_directories.back();
   }
-  const string* chosen_src_dir = NULL;
+  const string* chosen_src_dir = nullptr;
   if (!dd.source_directories.empty()) {
     chosen_src_dir = &dd.source_directories.back();
   }
@@ -1080,14 +1080,14 @@ static int sources(const iterable& binary_file_names,
       has_source_files = process_compilation_units(reader, altlink_reader.get(),
                                                    trace_relative_name, pair.second,
                                                    it->second, output_comp_dir_substitutions,
-                                                   NULL, NULL, &file_names, &dwos,
+                                                   nullptr, nullptr, &file_names, &dwos,
                                                    dir_exists_cache);
     } else {
       LOG(debug) << "\tNo comp_dir substitution found";
       has_source_files = process_compilation_units(reader, altlink_reader.get(),
                                                    trace_relative_name, pair.second,
                                                    {}, output_comp_dir_substitutions,
-                                                   NULL, NULL, &file_names, &dwos,
+                                                   nullptr, nullptr, &file_names, &dwos,
                                                    dir_exists_cache);
     }
     /* If the original binary had source files, force the inclusion of any debugaltlink
@@ -1109,8 +1109,8 @@ static int sources(const iterable& binary_file_names,
       has_source_files |= process_auxiliary_file(reader, *altlink_reader, nullptr,
                                                  trace_relative_name, pair.second,
                                                  &file_names, full_altfile_name,
-                                                 DEBUGALTLINK, comp_dir_substitutions, output_comp_dir_substitutions, NULL, NULL,
-                                                 &dwos, &external_debug_info,
+                                                 DEBUGALTLINK, comp_dir_substitutions, output_comp_dir_substitutions,
+                                                 nullptr, nullptr, &dwos, &external_debug_info,
                                                  original_had_source_files, dir_exists_cache);
     }
 

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -147,6 +147,10 @@ struct DebugDirs {
   vector<string> source_directories;
 };
 
+/// Manages integration with rr-gdb-script-host.py to allow a gdb script to
+/// controll which directories we search. If pipe_fd is open we have a
+/// python child process. If pipe_fd is closed then everything here
+/// becomes a no-op.
 class DebugDirManager {
 public:
   DebugDirManager(const string& program, const string& gdb_script);

--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -148,7 +148,7 @@ struct DebugDirs {
 };
 
 /// Manages integration with rr-gdb-script-host.py to allow a gdb script to
-/// controll which directories we search. If pipe_fd is open we have a
+/// control which directories we search. If pipe_fd is open we have a
 /// python child process. If pipe_fd is closed then everything here
 /// becomes a no-op.
 class DebugDirManager {


### PR DESCRIPTION
This is relatively straightforward, just ugly. One notable difference in the behavior from gdb is that when multiple paths are provided gdb will try them all in sequence but this code just tries the last one. That works for the use case that's motivating this PR but may cause issues down the line.

I'm reasonably confident I didn't regress anything but there's no automated testing for `rr sources`.