### PR TITLE
Intel EmeraldRappids Support

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -91,7 +91,8 @@ enum CpuMicroarch {
   IntelAlderlake,
   IntelRaptorlake,
   IntelSapphireRapid,
-  LastIntel = IntelSapphireRapid,
+  IntelEmeraldRapid,
+  LastIntel = IntelEmeraldRapid,
   FirstAMD,
   AMDF15R30 = FirstAMD,
   AMDZen,
@@ -168,6 +169,7 @@ struct PmuConfig {
 // See Intel 64 and IA32 Architectures Performance Monitoring Events.
 // See check_events from libpfm4.
 static const PmuConfig pmu_configs[] = {
+  { IntelEmeraldRapid, "Intel EmeraldRapid", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelSapphireRapid, "Intel SapphireRapid", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRaptorlake, "Intel Raptorlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -91,6 +91,8 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelRaptorlake;
     case 0x806f0:
       return IntelSapphireRapid;
+    case 0xc06f0:
+      return IntelEmeraldRapid;
     case 0x30f00:
       return AMDF15R30;
     case 0x00f10: // Naples, Whitehaven, Summit Ridge, Snowy Owl (Zen), Milan (Zen 3) (UNTESTED)


### PR DESCRIPTION
This adds support for Intel Xeon 5th gen codename EmeraldRappids. All tests pass locally.

![image](https://github.com/rr-debugger/rr/assets/1198314/f7481380-0530-4e78-b845-8eb1732d2f5e)
