### PR TITLE
Add additional Raptor Lake microarchitecture type

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -88,6 +88,7 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelAlderlake;
     case 0xb0670:
     case 0xb06a0:
+    case 0xb06f0:
       return IntelRaptorlake;
     case 0x806f0:
       return IntelSapphireRapid;


### PR DESCRIPTION
observed on i7-13700HX. I was able to run a basic real-world debugging job after applying this patch, including reverse execution.