### PR TITLE
Preserve the type of the trace time in Task::trace_time()

### DIFF
--- a/src/StdioMonitor.cc
+++ b/src/StdioMonitor.cc
@@ -13,7 +13,7 @@ namespace rr {
 Switchable StdioMonitor::will_write(Task* t) {
   if (t->session().mark_stdio()) {
     char buf[256];
-    snprintf(buf, sizeof(buf) - 1, "[rr %d %d]", t->tgid(), t->trace_time());
+    snprintf(buf, sizeof(buf) - 1, "[rr %d %ld]", t->tgid(), t->trace_time());
     ssize_t len = strlen(buf);
     if (write(original_fd, buf, len) != len) {
       ASSERT(t, false) << "Couldn't write to " << original_fd;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1974,7 +1974,7 @@ const string& Task::trace_dir() const {
   return trace->dir();
 }
 
-uint32_t Task::trace_time() const {
+FrameTime Task::trace_time() const {
   const TraceStream* trace = trace_stream();
   return trace ? trace->time() : 0;
 }

--- a/src/Task.h
+++ b/src/Task.h
@@ -704,7 +704,7 @@ public:
    * events.  |task_time()| returns that "time" wrt this task
    * only.
    */
-  uint32_t trace_time() const;
+  FrameTime trace_time() const;
 
   /**
    * Call this to reset syscallbuf_hdr->num_rec_bytes and zero out the data


### PR DESCRIPTION
FrameTime is a long (int64 in the trace) while trace_time() casts it to a u32. Preserve the original type by making the function return type FrameTime.