### PR TITLE
AMD: Add Hawk Point (Zen 4) CPU ID

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -117,6 +117,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x40f40: // Rembrandt (Zen 3+)
     case 0x60f10: // Raphael (Zen 4)
     case 0x70f40: // Phoenix (Zen 4)
+    case 0x70f50: // Hawk Point (Zen 4)
       if (ext_family == 0xa) {
         return AMDZen;
       }

--- a/src/counters-test/counters.cc
+++ b/src/counters-test/counters.cc
@@ -358,6 +358,7 @@ static CpuMicroarch compute_cpu_microarch(void) {
     case 0x40f40: // Rembrandt (Zen 3+)
     case 0x60f10: // Raphael (Zen 4)
     case 0x70f40: // Phoenix (Zen 4)
+    case 0x70f50: // Hawk Point (Zen 4)
       if (ext_family == 0xa) {
         return AMDZen;
       }


### PR DESCRIPTION
I noticed that it does not support my AMD Ryzen™ 7 8845HS.
(I also ran a `make check` in local environment.)