### PR TITLE
Add a path for BPF-accelerated async signal emulation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,16 @@ if(NOT ANDROID)
   add_definitions(-DZSTD=1)
 endif()
 
+option(bpf "Enable bpf acceleration")
+
+if(bpf)
+  add_definitions(-DBPF=1)
+  set(REQUIRED_LIBS
+    ${REQUIRED_LIBS}
+    libbpf
+  )
+endif(bpf)
+
 foreach(required_lib ${REQUIRED_LIBS})
   string(TOUPPER ${required_lib} PKG)
   if(NOT SKIP_PKGCONFIG)
@@ -692,6 +702,19 @@ post_build_executable(rr)
 set(RR_BIN rr)
 add_dependencies(rr Generated)
 
+if(bpf)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/share/rr/async_event_filter.o
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bpf/async_event_filter.c
+    COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/bpf/async_event_filter.c -o ${CMAKE_CURRENT_BINARY_DIR}/share/rr/async_event_filter.o)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/rr/async_event_filter.o
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/rr)
+
+  add_custom_target(BPF DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/share/rr/async_event_filter.o)
+
+  add_dependencies(rr BPF)
+endif()
+
 option(strip "Strip debug info from rr binary")
 
 set(RR_MAIN_LINKER_FLAGS ${LINKER_FLAGS})
@@ -724,6 +747,7 @@ endif()
 target_link_libraries(rr
   ${CMAKE_DL_LIBS}
   ${ZLIB_LDFLAGS}
+  ${LIBBPF_LDFLAGS}
   brotli
 )
 
@@ -733,7 +757,7 @@ endif()
 
 if(staticlibs)
   # Urgh ... this might not work for everyone, but there doesn't seem to be
-  # a way to persuade pkg-confing/pkg_check_modules to produce the right flags
+  # a way to persuade pkg-config/pkg_check_modules to produce the right flags
   target_link_libraries(rr -L/home/roc/lib -l:libcapnp.a -l:libkj.a)
   # Note that this works for both clang++ and g++
   set(RR_MAIN_LINKER_FLAGS "-static-libstdc++ ${RR_MAIN_LINKER_FLAGS}")

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1387,6 +1387,9 @@ TrapReasons Task::compute_trap_reasons() {
           << " expected breakpoint at " << ip_at_breakpoint << ", got siginfo "
           << si;
     }
+    // If we got a SIGTRAP via a FASYNC signal it must be our bpf-enabled
+    // hardware breakpoint.
+    reasons.breakpoint |= si.si_code == SI_SIGIO;
   }
   return reasons;
 }

--- a/src/bpf/async_event_filter.c
+++ b/src/bpf/async_event_filter.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <linux/bpf.h>
+#include <linux/bpf_perf_event.h>
+#include <bpf/bpf_helpers.h>
+#include <stdint.h>
+
+const uint32_t REGISTER_COUNT = sizeof(struct pt_regs)/sizeof(uint64_t);
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, REGISTER_COUNT);
+  __uint(map_flags, BPF_F_MMAPABLE);
+  __type(key, uint32_t);
+  __type(value, uint64_t);
+} registers SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 1);
+  __uint(map_flags, BPF_F_MMAPABLE);
+  __type(key, uint32_t);
+  __type(value, uint64_t);
+} skips SEC(".maps");
+
+SEC("perf_event")
+int match_registers(struct bpf_perf_event_data* event) {
+#define CHECK_REG(name)                                                        \
+  do {                                                                         \
+    const uint32_t i = offsetof(struct pt_regs, name) / sizeof(uint64_t);      \
+    uint64_t* reg = bpf_map_lookup_elem(&registers, &i);                       \
+    if (!reg) {                                                                \
+      return 1;                                                                \
+    }                                                                          \
+    if (event->regs.name != *reg) {                                            \
+      const uint32_t j = 0;                                                    \
+      uint64_t* s = bpf_map_lookup_elem(&skips, &j);                           \
+      if (s) {                                                                 \
+        *s += 1;                                                               \
+      }                                                                        \
+      return 0;                                                                \
+    }                                                                          \
+  } while(0)
+
+  CHECK_REG(r15);
+  CHECK_REG(r14);
+  CHECK_REG(r13);
+  CHECK_REG(r12);
+  CHECK_REG(rbp);
+  CHECK_REG(rbx);
+  CHECK_REG(r11);
+  CHECK_REG(r10);
+  CHECK_REG(r9);
+  CHECK_REG(r8);
+  CHECK_REG(rax);
+  CHECK_REG(rcx);
+  CHECK_REG(rdx);
+  CHECK_REG(rsi);
+  CHECK_REG(rdi);
+  CHECK_REG(rsp);
+
+  return 1;
+}
+
+char _license[] SEC("license") = "Dual MIT/GPL";

--- a/src/fast_forward.cc
+++ b/src/fast_forward.cc
@@ -404,7 +404,8 @@ static int fallible_read_byte(Task* t, remote_ptr<uint8_t> ip) {
   return byte;
 }
 
-bool is_string_instruction_at(Task* t, remote_code_ptr ip) {
+#if defined(__i386__) || defined(__x86_64__)
+bool is_x86_string_instruction_at(Task* t, remote_code_ptr ip) {
   bool found_rep = false;
   remote_ptr<uint8_t> bare_ip = ip.to_data_ptr<uint8_t>();
   while (true) {
@@ -421,6 +422,7 @@ bool is_string_instruction_at(Task* t, remote_code_ptr ip) {
     ++bare_ip;
   }
 }
+#endif
 
 static bool is_string_instruction_before(Task* t, remote_code_ptr ip) {
   remote_ptr<uint8_t> bare_ip = ip.to_data_ptr<uint8_t>();
@@ -447,7 +449,7 @@ bool maybe_at_or_after_x86_string_instruction(Task* t) {
     return false;
   }
 
-  return is_string_instruction_at(t, t->ip()) ||
+  return is_x86_string_instruction_at(t, t->ip()) ||
          is_string_instruction_before(t, t->ip());
 }
 
@@ -456,7 +458,7 @@ bool at_x86_string_instruction(Task* t) {
     return false;
   }
 
-  return is_string_instruction_at(t, t->ip());
+  return is_x86_string_instruction_at(t, t->ip());
 }
 
 } // namespace rr

--- a/src/fast_forward.h
+++ b/src/fast_forward.h
@@ -60,6 +60,14 @@ bool maybe_at_or_after_x86_string_instruction(Task* t);
 /* Return true if the instruction at t->ip() is a string instruction */
 bool at_x86_string_instruction(Task* t);
 
+#if defined(__i386__) || defined(__x86_64__)
+bool is_x86_string_instruction_at(Task* t, remote_code_ptr ip);
+#else
+inline bool is_x86_string_instruction_at(Task*, remote_code_ptr) {
+  return false;
+}
+#endif
+
 } // namespace rr
 
 #endif // RR_FAST_FORWARD_H_


### PR DESCRIPTION
Starting in kernel 6.10 BPF filters can choose whether or not to trigger the SIGIO behavior for a perf event that becomes readable. We combine that with a hardware breakpoint and a BPF filter that matches the GPRs to produce an accelerated internal breakpoint type that can fast forward through loop iterations to deliver async signals. On one trace this reduced rr's replay overhead by 94%.

This adds a runtime dependency on libbpf and a compile time dependency on clang --target bpf. rr also needs CAP_BPF and CAP_PERFMON to use this feature. Because of all of that, this isn't really suitable for wide use at this point and is instead a CMake feature usebpf. Set -Dusebpf=ON to test it.

(I think we should wait until the kernel side hits Linus's tree to merge this.)