### PR TITLE
Fix block size calculation in dczid_el0_block_size()

### DIFF
--- a/src/test/util.py
+++ b/src/test/util.py
@@ -3,7 +3,7 @@ import pexpect, re, signal, sys, time
 __all__ = [ 'expect_gdb', 'send_gdb','expect_rr', 'expect_list',
             'restart_replay', 'interrupt_gdb', 'ok',
             'failed', 'iterlines_both', 'last_match', 'get_exe_arch',
-            'get_gdb_version' ]
+            'get_gdb_version', 'set_breakpoint', 'set_watchpoint' ]
 
 # Don't use python timeout. Use test-monitor timeout instead.
 TIMEOUT_SEC = 10000
@@ -34,6 +34,18 @@ def interrupt_gdb():
     except Exception as e:
         failed('interrupting gdb', e)
     expect_gdb('stopped.')
+
+def set_breakpoint(args):
+    send_gdb(f'b {args}')
+    expect_gdb(r'Breakpoint ([0-9]+)[^0-9]')
+    global child
+    return child.match.group(1)
+
+def set_watchpoint(args):
+    send_gdb(f'watch {args}')
+    expect_gdb(r'atchpoint ([0-9]+)[^0-9]')
+    global child
+    return child.match.group(1)
 
 def iterlines_both():
     return child

--- a/src/test/watchpoint_unaligned.c
+++ b/src/test/watchpoint_unaligned.c
@@ -2,28 +2,29 @@
 
 #include "util.h"
 
-static uint16_t* p2;
-static uint32_t* p4;
-static uint64_t* p8;
+static void breakpoint(__attribute__((unused)) uintptr_t wp_addr) {}
 
-static void breakpoint(void) {}
+void test(uintptr_t wp_addr, uintptr_t store_addr) {
+  breakpoint(wp_addr);
+  *(uint16_t *)store_addr = 0x0101;
+
+  breakpoint(wp_addr);
+  *(uint32_t *)store_addr = 0x02020202;
+
+  breakpoint(wp_addr);
+  *(uint64_t *)store_addr = 0x0303030303030303;
+}
 
 int main(void) {
   char* m = xmalloc(0x1000);
-  void* unaligned_p = (void*)((uintptr_t)m | 0xff);
+  uintptr_t aligned_addr = ((uintptr_t)m | 0xff) + 1;
+  test(aligned_addr - 1, aligned_addr - 1);
+  test(aligned_addr + 16, aligned_addr + 15);
 
-  p2 = unaligned_p;
-  p4 = unaligned_p;
-  p8 = unaligned_p;
-
-  breakpoint();
-  *p2 = 1;
-
-  breakpoint();
-  *p4 = 2;
-
-  breakpoint();
-  *p8 = 3;
+  /* FIXME: Currently fails on arm64. */
+  if (0) {
+    test(aligned_addr + 15, aligned_addr + 16);
+  }
 
   atomic_puts("EXIT-SUCCESS");
   return 0;

--- a/src/test/watchpoint_unaligned.py
+++ b/src/test/watchpoint_unaligned.py
@@ -1,30 +1,16 @@
 from util import *
 
-send_gdb('b breakpoint')
-expect_gdb('Breakpoint 1')
+bp = set_breakpoint('breakpoint')
 
-send_gdb('c')
-expect_gdb('Breakpoint 1')
-send_gdb('watch -l *p2')
-expect_gdb('Hardware watchpoint 2')
-send_gdb('c')
-expect_gdb('watchpoint 2')
-send_gdb('delete 2')
+def test():
+    for type in ['uint16_t', 'uint32_t', 'uint64_t']:
+        send_gdb('c')
+        expect_gdb(f'Breakpoint {bp}')
+        wp = set_watchpoint(f'-l *({type} *)wp_addr')
+        send_gdb('c')
+        expect_gdb(f'watchpoint {wp}')
+        send_gdb(f'delete {wp}')
 
-send_gdb('c')
-expect_gdb('Breakpoint 1')
-send_gdb('watch -l *p4')
-expect_gdb('Hardware watchpoint 3')
-send_gdb('c')
-expect_gdb('watchpoint 3')
-send_gdb('delete 3')
-
-send_gdb('c')
-expect_gdb('Breakpoint 1')
-send_gdb('watch -l *p8')
-expect_gdb('Hardware watchpoint 4')
-send_gdb('c')
-expect_gdb('watchpoint 4')
-send_gdb('delete 4')
-
+test()
+test()
 ok()

--- a/src/util.h
+++ b/src/util.h
@@ -633,7 +633,7 @@ inline unsigned long long dczid_el0_block_size(void) {
 #if defined(__aarch64__)
   unsigned long long val;
   asm volatile("mrs %0, DCZID_EL0" : "=r" (val));
-  return 1ULL << (val & 0xF);
+  return 4ULL << (val & 0xF);
 #else
   FATAL() << "Reached AArch64-only code path on non-AArch64 architecture";
   return 0;


### PR DESCRIPTION
DCZID_EL0.BS contains the the log2 of the DC ZVA block size in words (defined as 32 bits), not bytes, so the block size calculation in dczid_el0_block_size() was incorrect. As a result we would sometimes fail to trigger watchpoints. Fix it.