### PR TITLE
Set USES_TERMINAL on check/fastcheck custom commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2060,9 +2060,9 @@ if(NOT N EQUAL 0)
   set(JFLAG -j${N})
 endif()
 
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose ${JFLAG})
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose ${JFLAG} USES_TERMINAL)
 # Run only syscallbuf-enabled and native-bitness tests
-add_custom_target(fastcheck COMMAND ${CMAKE_CTEST_COMMAND} --verbose --exclude-regex '[-]' ${JFLAG})
+add_custom_target(fastcheck COMMAND ${CMAKE_CTEST_COMMAND} --verbose --exclude-regex '[-]' ${JFLAG} USES_TERMINAL)
 
 ##--------------------------------------------------
 ## Package configuration


### PR DESCRIPTION
This causes ctest to be given direct access to the terminal when using the ninja generator.