### PR TITLE
pack: Add support for using a common pack dir for multiple traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++17")
 
 # We support three build types:
 # DEBUG: suitable for debugging rr


### PR DESCRIPTION
When packaging traces from CI, it's fairly commong to have hundreds of traces that all basically share the exact same files. This can lead to some fairly large traces after packing. Of course, some file-systems support block-level deduplication and a compression library would certainly be able to dedup it back down as well, but it'd be faster to not create trace directories that big on disk in the first place.

This adds a `--pack-dir` command to `rr pack <traces...>`, which is used as a the common pack dir for all traces. Rather than packing files into their own trace dirs, they will be packed into the `pack-dir`, with relative symlinks from the original trace directories to the pack dir. An unmodified rr will be able to replay these as long as the pack dir is moved along with the trace dirs.

We've had this feature on the JuliaLang fork for a while, but it was tangled up with #2529 and I don't believe I ever PR'd it separately. I think there's a stronger case for this part of the feature, because it doesn't require any unpacking steps on the receiving side and is best done during the packing process.