### PR TITLE
Allow invalid memfd_create *name arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1096,6 +1096,7 @@ set(BASIC_TESTS
   map_shared_syscall
   membarrier
   memfd_create
+  memfd_create_efault
   memfd_create_shared
   memfd_create_shared_huge
   mincore

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4383,8 +4383,11 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
     }
 
     case Arch::memfd_create: {
-      string name = t->read_c_str(remote_ptr<char>(regs.arg1()));
-      if (is_blacklisted_memfd(name.c_str())) {
+      bool ok = true;
+      string name = t->read_c_str(remote_ptr<char>(regs.arg1()), &ok);
+      if (!ok) {
+        syscall_state.expect_errno = EFAULT;
+      } else if (is_blacklisted_memfd(name.c_str())) {
         LOG(warn) << "Cowardly refusing to memfd_create " << name;
         Registers r = regs;
         r.set_arg1(0);

--- a/src/test/memfd_create_efault.c
+++ b/src/test/memfd_create_efault.c
@@ -1,0 +1,19 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  int fd;
+
+  /* There's no libc helper for this syscall. */
+  fd = syscall(RR_memfd_create, NULL, 0);
+  if (ENOSYS == errno) {
+    atomic_puts("SYS_memfd_create not supported on this kernel");
+  } else {
+    test_assert(fd == -1);
+    test_assert(errno == EFAULT);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Hi! I tried running Azul Prime JVM under rr, and as it seems that it's using memfd_create with NULL to check whether the kernel supports it, it broke rr. So here's a fixie, I hope it's reasonable 😄