### PR TITLE
Fix the condition for watchpoint matching on arm64

### DIFF
--- a/src/test/watchpoint_unaligned.c
+++ b/src/test/watchpoint_unaligned.c
@@ -20,11 +20,7 @@ int main(void) {
   uintptr_t aligned_addr = ((uintptr_t)m | 0xff) + 1;
   test(aligned_addr - 1, aligned_addr - 1);
   test(aligned_addr + 16, aligned_addr + 15);
-
-  /* FIXME: Currently fails on arm64. */
-  if (0) {
-    test(aligned_addr + 15, aligned_addr + 16);
-  }
+  test(aligned_addr + 15, aligned_addr + 16);
 
   atomic_puts("EXIT-SUCCESS");
   return 0;

--- a/src/test/watchpoint_unaligned.py
+++ b/src/test/watchpoint_unaligned.py
@@ -13,4 +13,5 @@ def test():
 
 test()
 test()
+test()
 ok()


### PR DESCRIPTION
The language from the ARM manual previously quoted in the comment in fact only pertains to Memory Copy and Memory Set instructions. According to the section describing the behavior for "other instructions", the recorded address can be > the watchpoint address. Therefore, remove the check that the watchpoint address >= the recorded address, and update the comment for accuracy.

Fixes #3736