### PR TITLE
Add support for SIOCGMIIPHY and SIOCGMIIREG ioctls.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1712,6 +1712,7 @@ static Switchable prepare_ioctl(RecordTask* t,
     case SIOCGIFNETMASK:
     case SIOCGIFMETRIC:
     case SIOCGIFMAP:
+    case SIOCGMIIPHY:
       syscall_state.reg_parameter<typename Arch::ifreq>(3);
       syscall_state.after_syscall_action(record_page_below_stack_ptr);
       return PREVENT_SWITCH;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1713,6 +1713,7 @@ static Switchable prepare_ioctl(RecordTask* t,
     case SIOCGIFMETRIC:
     case SIOCGIFMAP:
     case SIOCGMIIPHY:
+    case SIOCGMIIREG:
       syscall_state.reg_parameter<typename Arch::ifreq>(3);
       syscall_state.after_syscall_action(record_page_below_stack_ptr);
       return PREVENT_SWITCH;

--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -533,6 +533,10 @@ int main(void) {
     atomic_printf("flags is %d\n", req->ifr_ifru.ifru_flags);
   }
 
+  if (GENERIC_REQUEST_BY_NAME(SIOCGMIIREG)) {
+    atomic_printf("flags is %d\n", req->ifr_ifru.ifru_flags);
+  }
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }

--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -118,6 +118,10 @@ static int generic_request_by_name(int sockfd, struct ifreq* req, int nr,
       atomic_printf("(errno:%d/%s)\n", errno, strerror(errno));
       return 0;
     }
+    if (errno == EPERM) {
+      atomic_printf("(errno:%d/%s)\n", errno, strerror(errno));
+      return 0;
+    }
   }
 
   test_assert(0 == ret);
@@ -523,6 +527,10 @@ int main(void) {
     test_assert(EOPNOTSUPP == err || EPERM == err || EINVAL == err || ENODEV == err || ENOTTY == err);
   } else {
     atomic_printf("wireless ESSID:%s\n", buf);
+  }
+
+  if (GENERIC_REQUEST_BY_NAME(SIOCGMIIPHY)) {
+    atomic_printf("flags is %d\n", req->ifr_ifru.ifru_flags);
   }
 
   atomic_puts("EXIT-SUCCESS");


### PR DESCRIPTION
When recording `gnome-nettool` or `mii-tool` rr throws assertions like these:
```
$ bin/rr record /sbin/mii-tool enp7s0
rr: Saving execution to trace directory `/home/bernhard/data/entwicklung/2023/rr/rr-recordings/mii-tool-1'.
[FATAL src/record_syscall.cc:6564:rec_process_syscall_arch()] 
 (task 537273 (rec:537273) at time 139)
 -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result -1 (errno EPERM); Unknown ioctl(0x8947): type:0x89 nr:0x47 dir:0 size:0 addr:0x5607c41203e0
```
```
[FATAL src/record_syscall.cc:6565:rec_process_syscall_arch()] 
 (task 596577 (rec:596577) at time 742)
 -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result -1 (errno EPERM); Unknown ioctl(0x8948): type:0x89 nr:0x48 dir:0 size:0 addr:0x7f11cf5defd8
```

https://github.com/torvalds/linux/blob/0106679839f7c69632b3b9833c3268c316c0a9fc/include/uapi/linux/sockios.h#L104-L106

This two patches are just enough to make rr no longer fail.