### PR TITLE
Add support for capturing blkzone IOCTL system calls in rr

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <linux/auxvec.h>
+#include <linux/blkzoned.h>
 #include <linux/capability.h>
 #include <linux/cdrom.h>
 #include <linux/elf.h>
@@ -1800,6 +1801,16 @@ static Switchable prepare_ioctl(RecordTask* t,
     case BLKSECTGET:
     case BLKROTATIONAL:
       syscall_state.reg_parameter<typename Arch::unsigned_short>(3);
+      return PREVENT_SWITCH;
+
+    case BLKGETNRZONES:
+    case BLKGETZONESZ:
+    case BLKREPORTZONE:
+    case BLKCLOSEZONE:
+    case BLKOPENZONE:
+    case BLKRESETZONE:
+    case BLKFINISHZONE:
+      syscall_state.reg_parameter<typename Arch::signed_long>(3);
       return PREVENT_SWITCH;
 
     case TIOCGWINSZ:


### PR DESCRIPTION
While using `rr` to debug a program that uses the libzbd library, I found that `rr` could not successfully capture the ioctl system calls related to blkzone devices. Therefore, I modified `record_syscall.cc` and submitted this PR. 
I will try to add related test programs in `src/test` later.