### PR TITLE
Fix compute_cpu_microarch() for ThreadRipper 5995WX

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -111,6 +111,8 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x00f80: // Colfax, Pinnacle Ridge (Zen+) (UNTESTED)
       if (ext_family == 8) {
         return AMDZen;
+      } else if (ext_family == 0xa) {
+        return AMDZen3;
       }
       break;
     case 0x30f10: // Rome, Castle Peak (Zen 2)


### PR DESCRIPTION
Add the support of ThreadRipper 5995WX, where rr failed with the error: [FATAL src/PerfCounters_x86.h:138:compute_cpu_microarch()] AMD CPU type 0xf80 (ext family 0xa) unknown