### PR TITLE
Modifications for old lldb version.

### DIFF
--- a/src/test/util.py
+++ b/src/test/util.py
@@ -1,4 +1,4 @@
-import pexpect, re, signal, sys, time
+import pexpect, re, signal, sys, time, os
 
 __all__ = [ 'expect_rr', 'expect_list', 'expect_debugger',
             'restart_replay', 'interrupt_gdb', 'expect_gdb', 'send_gdb',
@@ -236,6 +236,9 @@ def set_up():
             timeout=TIMEOUT_SEC, encoding='utf-8', logfile=open(log_file, 'w'))
         child.delaybeforesend = 0
         expect_debugger(r'\(rr\)')
+        if debugger_type == 'LLDB':
+            script = os.environ["TESTDIR"] + "/test_setup.lldb"
+            send_lldb(f'command source -s 0 {script}')
     except Exception as e:
         failed('initializing rr and debugger', e)
 

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -137,11 +137,8 @@ def set_breakpoint_commands(number, commands):
         expect_debugger('(rr)')
 
 def expect_expression(expression, value):
-    send_debugger(f'print {expression}', f'print {expression}')
-    if debugger_type == 'GDB':
-        expect_debugger(f' = {value}')
-    else:
-        expect_debugger(fr'\) {value}')
+    send_debugger(f'print {expression}', f'expression -- {expression}')
+    expect_debugger(f' = {value}')
 
 def expect_threads(num_threads, selected_thread):
     send_debugger('info threads', 'thread list')

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -152,7 +152,7 @@ test_passed=y
 nonce=
 
 # Set up the environment and working directory.
-TESTDIR="${SRCDIR}/src/test"
+export TESTDIR="${SRCDIR}/src/test"
 
 # Make rr treat temp files as durable. This saves copying all test
 # binaries into the trace.
@@ -350,7 +350,7 @@ function debug {
 function debug_lldb_only { expectscript=$1; replayargs=$2
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT debug.err \
         python3 $TESTDIR/$expectscript.py --lldb \
-        $RR_EXE $GLOBAL_OPTIONS replay -o-S -o$TESTDIR/test_setup.lldb $replayargs
+        $RR_EXE $GLOBAL_OPTIONS replay $replayargs
     if [[ $? == 0 ]]; then
         passed_msg lldb
     else


### PR DESCRIPTION
I received a failure with the new test `alternate_thread_diversion` when running below my Debian Bookworm system.
This not overly elegant modifications would make the test work with this old lldb version.

Another option would be to define a minimum lldb version and check this before running the tests?