### PR TITLE
Avoid warning about format string in 32-bit build.

### DIFF
--- a/src/StdioMonitor.cc
+++ b/src/StdioMonitor.cc
@@ -13,7 +13,7 @@ namespace rr {
 Switchable StdioMonitor::will_write(Task* t) {
   if (t->session().mark_stdio()) {
     char buf[256];
-    snprintf(buf, sizeof(buf) - 1, "[rr %d %ld]", t->tgid(), t->trace_time());
+    snprintf(buf, sizeof(buf) - 1, "[rr %d %" PRId64 "]", t->tgid(), t->trace_time());
     ssize_t len = strlen(buf);
     if (write(original_fd, buf, len) != len) {
       ASSERT(t, false) << "Couldn't write to " << original_fd;


### PR DESCRIPTION
```
src/StdioMonitor.cc:16:46: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘rr::FrameTime’ {aka ‘long long int’} [-Wformat=]
   16 |     snprintf(buf, sizeof(buf) - 1, "[rr %d %ld]", t->tgid(), t->trace_time());
      |                                            ~~^               ~~~~~~~~~~~~~~~
      |                                              |                            |
      |                                              long int                     rr::FrameTime {aka long long int}
      |                                            %lld
```