### PR TITLE
Check for zen microarch bug on all Zen microarches

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -395,7 +395,7 @@ static void check_for_arch_bugs(perf_event_attrs &perf_attr) {
   if (uarch >= IntelCometlake && uarch <= LastIntel) {
     check_for_freeze_on_smi();
   }
-  if (uarch == AMDZen) {
+  if (uarch >= AMDZen && uarch <= LastAMD) {
     check_for_zen_speclockmap();
   }
 }


### PR DESCRIPTION
Commit ca5c4d9 split out the Zen microarches by generation, but did not update the check for the presence of the Zen SpecLockMap workaround. The issue is applicable to all Zen generations, so adjust the check accordingly.