### PR TITLE
Only check for PROT_{READ,WRITE,EXEC} in assert_segments_match()

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1646,7 +1646,7 @@ static void assert_segments_match(Task* t, const KernelMapping& input_m,
     err = "starts differ";
   } else if (m.end() != km.end()) {
     err = "ends differ";
-  } else if (m.prot() != km.prot()) {
+  } else if ((m.prot() ^ km.prot()) & KernelMapping::checkable_prot_mask) {
     err = "prots differ";
   } else if ((m.flags() ^ km.flags()) & KernelMapping::checkable_flags_mask) {
     err = "flags differ";

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -56,6 +56,7 @@ public:
                                     MAP_PRIVATE | MAP_SHARED | MAP_STACK |
                                     MAP_GROWSDOWN;
   static const int checkable_flags_mask = MAP_PRIVATE | MAP_SHARED;
+  static const int checkable_prot_mask = PROT_READ | PROT_WRITE | PROT_EXEC;
   static const dev_t NO_DEVICE = 0;
   static const ino_t NO_INODE = 0;
 


### PR DESCRIPTION
On arm64, mapping protection flags can include PROT_BTI and PROT_MTE, but they are not shown in /proc/pid/maps, so if a mapping has one of these the assert_segments_match() check will fail. Fix it by masking out flags that are not shown in /proc/pid/maps when doing the check.