### PR TITLE
Add an IS_SCRATCH flag to mark scratch memory with.

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -315,6 +315,8 @@ public:
       IS_RR_PAGE = 0x8,
       // This mapping is the rr vdso page
       IS_RR_VDSO_PAGE = 0x10,
+      // This mapping is the per-thread scratch space.
+      IS_SCRATCH = 0x20,
     };
     uint32_t flags;
   };

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3375,6 +3375,7 @@ static void init_scratch_memory(RecordTask* t,
 
   KernelMapping km =
       t->vm()->map(t, t->scratch_ptr, sz, prot, flags, 0, string());
+  t->vm()->mapping_flags_of(t->scratch_ptr) |= AddressSpace::Mapping::IS_SCRATCH;
   struct stat stat;
   memset(&stat, 0, sizeof(stat));
   auto record_in_trace = t->trace_writer().write_mapped_region(t,


### PR DESCRIPTION
Fixes #3779