### PR TITLE
Fix test watchpoint_error when run with a 32-bit build of rr.

### DIFF
--- a/src/test/x86/watchpoint_error.py
+++ b/src/test/x86/watchpoint_error.py
@@ -1,3 +1,4 @@
+import os
 from util import *
 
 breakpoint = breakpoint_at_function('main')
@@ -5,8 +6,9 @@ cont()
 expect_breakpoint_stop(breakpoint)
 
 watchpoint_at_address("&buffer[0]", 8)
-watchpoint_at_address("&buffer[8]", 8)
-watchpoint_at_address("&buffer[16]", 8)
+if os.environ['IS_32BIT_RR'] != '1':
+    watchpoint_at_address("&buffer[8]", 8)
+    watchpoint_at_address("&buffer[16]", 8)
 wp4 = watchpoint_at_address("&buffer[24]", 8)
 watchpoint_at_address_fail("&buffer[32]", 8)
 

--- a/src/test/x86/watchpoint_error.run
+++ b/src/test/x86/watchpoint_error.run
@@ -1,2 +1,3 @@
 source `dirname $0`/util.sh
+export IS_32BIT_RR=$(file $RESOURCE_PATH/lib/rr/librrpage.so | grep 32-bit -c)
 debug_test watchpoint_error


### PR DESCRIPTION
Looks like a 32-bit rr can provide even less hardware breakpionts.

Another option to "fix" would be just skipping it with `skip_if_rr_32_bit`?

What do you think?

Example output of a failed test:
```
(rr) break main
break main
Breakpoint 1 at 0x5656328b: file /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/test/x86/watchpoint_error.c, line 8.
(rr) continue
continue
Continuing.

Breakpoint 1, main ()
    at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/test/x86/watchpoint_error.c:8
8         atomic_puts("EXIT-SUCCESS");
watch -l *(long long*)(&buffer[0])
(rr) watch -l *(long long*)(&buffer[0])
Hardware watchpoint 2: -location *(long long*)(&buffer[0])
watch -l *(long long*)(&buffer[8])
(rr) watch -l *(long long*)(&buffer[8])
Hardware watchpoint 3: -location *(long long*)(&buffer[8])
(rr) watch -l *(long long*)(&buffer[16])
watch -l *(long long*)(&buffer[16])
Hardware watchpoint 4: -location *(long long*)(&buffer[16])
watch -l *(long long*)(&buffer[24])
(rr) watch -l *(long long*)(&buffer[24])
Hardware watchpoint 5: -location *(long long*)(&buffer[24])
watch -l *(long long*)(&buffer[32])
(rr) watch -l *(long long*)(&buffer[32])
Hardware watchpoint 6: -location *(long long*)(&buffer[32])
stepi
(rr) stepi
Warning:
Could not insert hardware watchpoint 4.
Could not insert hardware watchpoint 5.
Could not insert hardware watchpoint 6.
Could not insert hardware breakpoints:
You may have requested too many hardware breakpoints/watchpoints.

delete 6
delete 5
watch -l *(long long*)(&buffer[24])
break atomic_puts
Command aborted.
(rr) delete 6
delete 5
(rr) delete 5
watch -l *(long long*)(&buffer[24])
(rr) watch -l *(long long*)(&buffer[24])
Hardware watchpoint 7: -location *(long long*)(&buffer[24])
(rr) break atomic_puts
Breakpoint 8 at 0x56563213: file /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/test/x86/../util.h, line 178.
(rr) continue
continue
Continuing.
Warning:
Could not insert hardware watchpoint 4.
Could not insert hardware watchpoint 7.
Could not insert hardware breakpoints:
You may have requested too many hardware breakpoints/watchpoints.

Command aborted.
(rr)
```