### PR TITLE
check for EPERM in syscall perf_event_open

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -337,6 +337,7 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
   if (fd < 0) {
     switch (errno) {
       case EACCES:
+      case EPERM:
         CLEAN_FATAL() << "Permission denied to use 'perf_event_open'; are hardware perf events "
                    "available? See https://github.com/rr-debugger/rr/wiki/Will-rr-work-on-my-system";
         break;


### PR DESCRIPTION
EPERM is one of the explicit noted entries in man _syscall and is returned in docker environments without permissions (where /proc/sys/kernel is read-only)