### PR TITLE
suppress environment warnings in nested_detach tests

### DIFF
--- a/src/test/nested_detach.run
+++ b/src/test/nested_detach.run
@@ -2,7 +2,7 @@ source `dirname $0`/util.sh
 RECORD_ARGS="--env=_RR_TRACE_DIR=$workdir/inner"
 save_exe simple$bitness
 export RR_TEST_DELAY_SEIZE=1
-just_record $(which rr) "record --nested=detach $PWD/simple$bitness-$nonce"
+just_record $(which rr) "record --suppress-environment-warnings --nested=detach $PWD/simple$bitness-$nonce"
 # Replay outer
 replay
 check_record

--- a/src/test/nested_detach_wait.run
+++ b/src/test/nested_detach_wait.run
@@ -2,7 +2,7 @@ source `dirname $0`/util.sh
 
 mkdir $workdir/inner
 RECORD_ARGS="--env=_RR_TRACE_DIR=$workdir/inner"
-record $TESTNAME "$(which rr) record --nested=detach $PWD/$TESTNAME-$nonce --inner"
+record $TESTNAME "$(which rr) record --suppress-environment-warnings --nested=detach $PWD/$TESTNAME-$nonce --inner"
 # Replay outer
 replay
 check_record EXIT-WAITED


### PR DESCRIPTION
fixing test runs on some environmments that stumble over those