### PR TITLE
Fix a deadlock in syscallbuf unmapping after vfork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1493,6 +1493,8 @@ set(TESTS_WITH_PROGRAM
   clone_interruption
   # Disabled because it fails
   # clone_share_vm
+  clone_syscallbuf_cleanup_blocked
+  clone_syscallbuf_cleanup_cpu
   clone_vfork
   concurrent_signals
   conditional_breakpoint_calls

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -914,6 +914,14 @@ public:
   // Returns true if the range is completely covered by private mappings
   bool range_is_private_mapping(const MemoryRange& range) const;
 
+  /**
+   * When two processes share an address space (e.g. with vfork(2) or
+   * clone(2) CLONE_VM), and one process calls execve(2), we need to unmap
+   * that process's syscallbuf. This list is checked the next time a task
+   * in that address space runs to perform the unmapping
+   */
+  std::vector<MemoryRange> regions_pending_unmap;
+
 private:
   struct Breakpoint;
   typedef std::map<remote_code_ptr, Breakpoint> BreakpointMap;

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -329,6 +329,7 @@ private:
   sig_set_t sigmask_to_restore;
 
   bool need_sigpending_renable;
+  bool need_desched_event_reenable;
 
   AutoRemoteSyscalls& operator=(const AutoRemoteSyscalls&) = delete;
   AutoRemoteSyscalls(const AutoRemoteSyscalls&) = delete;

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -936,6 +936,7 @@ void RecordSession::task_continue(const StepState& step_state) {
       }
     }
   }
+  t->unmap_dead_syscallbufs_if_required();
   t->resume_execution(resume, RESUME_NONBLOCKING, ticks_request);
 }
 

--- a/src/Task.h
+++ b/src/Task.h
@@ -1142,6 +1142,13 @@ public:
   // (used to avoid double recording on unexpected exit)
   bool last_syscall_entry_recorded;
 
+  /*
+   * Called before the scheduler resumes a task to check if the task's address
+   * space has any leftover syscallbufs from dead processes which shared the
+   * address space
+   */
+  void unmap_dead_syscallbufs_if_required();
+
 protected:
   Task(Session& session, pid_t tid, pid_t rec_tid, uint32_t serial,
        SupportedArch a);

--- a/src/record_signal.h
+++ b/src/record_signal.h
@@ -15,6 +15,7 @@ const int SIGCHLD_SYNTHETIC = 0xbeadf00d;
 
 void disarm_desched_event(RecordTask* t);
 void arm_desched_event(RecordTask* t);
+bool desched_event_armed(RecordTask *t);
 bool handle_syscallbuf_breakpoint(RecordTask* t);
 
 enum SignalBlocked { SIG_UNBLOCKED = 0, SIG_BLOCKED = 1 };

--- a/src/test/clone_syscallbuf_cleanup_blocked.c
+++ b/src/test/clone_syscallbuf_cleanup_blocked.c
@@ -1,0 +1,106 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static int pipefds[2];
+static const char *CHILD_PROCESS_NAME = "clone_syscallbuf_cleanup_child";
+
+void assert_syscallbuf_count(int expected) {
+  FILE *f = fopen("/proc/self/maps", "r");
+  test_assert(!!f);
+
+  int actual = 0;
+  for (;;) {
+      size_t len = 0;
+      char *line = NULL;
+      int ret = getline(&line, &len, f);
+      if (ret == -1) {
+        break;
+      }
+      if (strstr(line, "rr-shared-syscallbuf")) {
+        actual++;
+      }
+      free(line);
+  }
+  test_assert(expected == actual);
+}
+
+static int exec_proc(__attribute__((unused)) void* arg) {
+  // Close the reading end of the pipe in this process
+  close(pipefds[0]);
+
+  // Wait for the parent to be blocked in a read(2) syscall waiting on the pipe
+  char wchan_path[PATH_MAX];
+  snprintf(wchan_path, PATH_MAX, "/proc/%d/wchan", getppid());
+  char wchan[1024] = {0};
+  do {
+    FILE *f = fopen(wchan_path, "r");
+    fread(wchan, 1, 1024, f);
+    fclose(f);
+  } while (strncmp(wchan, "pipe_read", 1024) != 0);
+
+  sleep(1);
+
+  assert_syscallbuf_count(2);
+  // Now exec our child. The child will un-freeze the parent.
+  char wpipe_name[PATH_MAX];
+  snprintf(wpipe_name, sizeof(wpipe_name), "/proc/self/fd/%d", pipefds[1]);
+  execl("/proc/self/exe", CHILD_PROCESS_NAME, wpipe_name, NULL);
+
+  test_assert("Not reached" && 0);
+  return 0;
+}
+
+static void execd_child_proc(char *pipe_file) {
+  // Unblock the parent by writing a . to the shared pipe
+  pipefds[1] = open(pipe_file, O_WRONLY);
+  test_assert(pipefds[1] != -1);
+
+  char dummy[1] = { '.' };
+  int ret = write(pipefds[1], dummy, 1);
+  test_assert(ret == 1);
+
+  close(pipefds[1]);
+}
+
+int main(int argc, char **argv) {
+  // This is what get exec'd from exec_proc
+  if (argc == 2 && strcmp(argv[0], CHILD_PROCESS_NAME) == 0) {
+    execd_child_proc(argv[1]);
+    return 0;
+  }
+
+  int ret;
+
+  // Before forking, there should only be one syscallbuf
+  assert_syscallbuf_count(1);
+
+  ret = pipe2(pipefds, 0);
+  test_assert(ret != -1);
+
+  // Spawn a process which shares our address space, and will execve(2)
+  const size_t stack_size = 1 << 20;
+  void* exec_proc_stack = mmap(NULL, stack_size, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  pid_t exec_proc_pid = clone(exec_proc, exec_proc_stack + stack_size, CLONE_VM | SIGCHLD,
+                              NULL, NULL, NULL, NULL);
+
+  // This proces needs the read end of the pipe, close the write end
+  close(pipefds[1]);
+
+  // Block ourselves attempting to read from the pipe.
+  char dummy[1] = { 0 };
+  ret = read(pipefds[0], dummy, 1);
+  // When we are woken up, we should have read a byte
+  test_assert(ret == 1);
+  test_assert(dummy[0] == '.');
+
+  // This means the child exec'd so we should have cleaned up the syscallbuf
+  assert_syscallbuf_count(1);
+
+  // Reap the exec'd child
+  test_assert(exec_proc_pid == waitpid(exec_proc_pid, NULL, 0));
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}
+

--- a/src/test/clone_syscallbuf_cleanup_blocked.run
+++ b/src/test/clone_syscallbuf_cleanup_blocked.run
@@ -1,0 +1,4 @@
+source `dirname $0`/util.sh
+skip_if_no_syscall_buf
+record $TESTNAME
+replay

--- a/src/test/clone_syscallbuf_cleanup_cpu.c
+++ b/src/test/clone_syscallbuf_cleanup_cpu.c
@@ -1,0 +1,95 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static const size_t SHARED_MEMFD_SIZE = 4096;
+static int shared_memfd;
+static volatile char *shared_memfd_mapping;
+static const char *CHILD_PROCESS_NAME = "clone_syscallbuf_cleanup_child";
+
+void assert_syscallbuf_count(int expected) {
+  FILE *f = fopen("/proc/self/maps", "r");
+  test_assert(!!f);
+
+  int actual = 0;
+  for (;;) {
+      size_t len = 0;
+      char *line = NULL;
+      int ret = getline(&line, &len, f);
+      if (ret == -1) {
+        break;
+      }
+      if (strstr(line, "rr-shared-syscallbuf")) {
+        actual++;
+      }
+      free(line);
+  }
+  test_assert(expected == actual);
+}
+
+static int exec_proc(__attribute__((unused)) void* arg) {
+  assert_syscallbuf_count(2);
+
+  char memfd_name[PATH_MAX];
+  snprintf(memfd_name, sizeof(memfd_name), "/proc/self/fd/%d", shared_memfd);
+  execl("/proc/self/exe", CHILD_PROCESS_NAME, memfd_name, NULL);
+
+  test_assert("Not reached" && 0);
+  return 0;
+}
+
+static void execd_child_proc(char *shared_memfd_mapping_path) {
+  // Need to re-map the shared memory we're going to use to poke the parent process
+  shared_memfd = open(shared_memfd_mapping_path, O_RDWR);
+  test_assert(shared_memfd != -1);
+  shared_memfd_mapping = mmap(NULL, SHARED_MEMFD_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              shared_memfd, 0);
+  test_assert(shared_memfd_mapping != MAP_FAILED);
+
+  // And do said poking
+  shared_memfd_mapping[0] = 1;
+}
+
+
+int main(int argc, char **argv) {
+  // This is what get exec'd from exec_proc
+  if (argc == 2 && strcmp(argv[0], CHILD_PROCESS_NAME) == 0) {
+    execd_child_proc(argv[1]);
+    return 0;
+  }
+
+  int ret;
+
+  // Before forking, there should only be one syscallbuf
+  assert_syscallbuf_count(1);
+
+  // mmap some memory that can be shared across execve(2)
+  shared_memfd = memfd_create("shared_page", 0);
+  test_assert(shared_memfd != -1);
+  ret = ftruncate(shared_memfd, SHARED_MEMFD_SIZE);
+  test_assert(ret != -1);
+  shared_memfd_mapping = mmap(NULL, SHARED_MEMFD_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              shared_memfd, 0);
+  test_assert(shared_memfd_mapping != MAP_FAILED);
+  shared_memfd_mapping[0] = 0;
+
+  // Spawn a process which shares our address space, and will execve(2)
+  const size_t stack_size = 1 << 20;
+  void* exec_proc_stack = mmap(NULL, stack_size, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  test_assert(exec_proc_stack != MAP_FAILED);
+  pid_t exec_proc_pid = clone(exec_proc, exec_proc_stack + stack_size, CLONE_VM | SIGCHLD,
+                              NULL, NULL, NULL, NULL);
+  test_assert(exec_proc_pid != -1);
+
+  // Now spin waiting for the exec'd process to set a bit in the shard mapping
+  while (shared_memfd_mapping[0] != 1) { ; }
+
+  // This means the child exec'd so we should have cleaned up the syscallbuf
+  assert_syscallbuf_count(1);
+
+  // Reap the exec'd child
+  test_assert(exec_proc_pid == waitpid(exec_proc_pid, NULL, 0));
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/clone_syscallbuf_cleanup_cpu.run
+++ b/src/test/clone_syscallbuf_cleanup_cpu.run
@@ -1,0 +1,4 @@
+source `dirname $0`/util.sh
+skip_if_no_syscall_buf
+record $TESTNAME
+replay


### PR DESCRIPTION
This should be :crossed_fingers: a fix for https://github.com/rr-debugger/rr/issues/3807

It does two things to address that issue:

Firstly, moves the code for doing syscallbuf unmap after `vfork`/`exec` out of `Task::post_exec`, and instead defers doing that until we next run a task in that address space. This means we should never leak address space just because there were no available threads to perform the unmapping. This doesn't actually do anything to technically fix the issue, but it means we can write some reliable tests around the syscallbuf unmapping stuff, so it seemed worthwhile.

Secondly, we now look at the desched signal state in AutoRemoteSyscalls. If the desched signal is armed, we temporarily disarm it (and mask it too, in case the signal was pending but unprocessed). This is what should fix our issue, I think

It's hard to prove that this really has fixed the issue, but I left my reproduction script running for 12 hours last night and it didn't hang, and that had always been long enough to trigger the hang before. So I guess either this fixes the issue, or I got (un)lucky.

I'm sure my C++ isn't going to win any beauty contests here but hopefully this demonstrates the outlines of a fix.