### PR TITLE
Don't assert on ticks overshoot during record on AMD

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -1066,7 +1066,7 @@ Ticks PerfCounters::read_ticks(Task* t, Error* error) {
       ret = measure_val;
     }
   }
-  if (ret > adjusted_counting_period) {
+  if (!t->session().is_recording() && ret > adjusted_counting_period) {
     if (error && (perf_attrs[pmu_index].pmu_flags & PMU_SKID_UNBOUNDED)) {
       *error = Error::Transient;
     } else {


### PR DESCRIPTION
On AMD, we regularly overshoot the programmed ticks counter. We print this as a warning earlier in the function. However, the warning is ineffective, because we have an assert with the same condition later in the function. Adjust the check for that error condition to only fire during replay, not record (where it is supposed to be non-fatal).