### PR TITLE
Print a useful error message for perf_event_paranoid == 4

### DIFF
--- a/src/ContextSwitchEvent.cc
+++ b/src/ContextSwitchEvent.cc
@@ -20,19 +20,6 @@ using namespace std;
 
 namespace rr {
 
-static optional<int> read_perf_event_paranoid() {
-  ScopedFd fd("/proc/sys/kernel/perf_event_paranoid", O_RDONLY);
-  if (fd.is_open()) {
-    char buf[100];
-    ssize_t size = read(fd, buf, sizeof(buf) - 1);
-    if (size >= 0) {
-      buf[size] = 0;
-      return atoi(buf);
-    }
-  }
-  return nullopt;
-}
-
 static volatile int sigio_count;
 
 static void sigio_handler(int, siginfo_t*, void*) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -2600,4 +2600,23 @@ void base_name(string& s) {
   }
 }
 
+static optional<int> init_read_perf_event_paranoid() {
+  ScopedFd fd("/proc/sys/kernel/perf_event_paranoid", O_RDONLY);
+  if (fd.is_open()) {
+    char buf[100];
+    ssize_t size = read(fd, buf, sizeof(buf) - 1);
+    if (size >= 0) {
+      buf[size] = 0;
+      return atoi(buf);
+    }
+  }
+
+  return nullopt;
+}
+
+optional<int> read_perf_event_paranoid() {
+  static optional<int> value = init_read_perf_event_paranoid();
+  return value;
+}
+
 } // namespace rr

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -665,6 +666,8 @@ void replace_in_buffer(MemoryRange src, const uint8_t* src_data,
 
 // Strip any directory part from the filename `s`
 void base_name(std::string& s);
+
+std::optional<int> read_perf_event_paranoid();
 
 } // namespace rr
 


### PR DESCRIPTION
This came up with a Mozilla user today.