### PR TITLE
Follow up addition of --pack-dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1719,6 +1719,7 @@ set(TESTS_WITHOUT_PROGRAM
   nested_detach_kill
   nested_detach_stop
   nested_release
+  pack_dir
   parent_no_break_child_bkpt
   parent_no_stop_child_crash
   post_exec_fpu_regs

--- a/src/test/pack_dir.run
+++ b/src/test/pack_dir.run
@@ -1,0 +1,31 @@
+source `dirname $0`/util.sh
+
+record simple$bitness
+record simple$bitness
+
+mkdir the_pack_dir
+
+# Pack both directories with a common pack directory
+pack --pack-dir the_pack_dir simple$bitness-$nonce-0 simple$bitness-$nonce-1
+
+# Test that we can still replay both traces
+replay simple$bitness-$nonce-0
+check EXIT-SUCCESS
+rm replay.err replay.out
+
+replay simple$bitness-$nonce-1
+check EXIT-SUCCESS
+rm replay.err replay.out
+
+# Check that we can move all three directories somewhere else and replay
+# still works.
+mkdir a_subdirectory
+mv the_pack_dir simple$bitness-$nonce-0 simple$bitness-$nonce-1 a_subdirectory
+
+replay a_subdirectory/simple$bitness-$nonce-0
+check EXIT-SUCCESS
+rm replay.err replay.out
+
+replay a_subdirectory/simple$bitness-$nonce-1
+check EXIT-SUCCESS
+rm replay.err replay.out

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -327,9 +327,9 @@ function rerun { rerunflags=$1
         $RR_EXE $GLOBAL_OPTIONS rerun $rerunflags 1> rerun.out 2> rerun.err
 }
 
-function pack { packflags=$1
+function pack {
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT pack.err \
-        $RR_EXE $GLOBAL_OPTIONS pack $packflags 1> pack.out 2> pack.err
+        $RR_EXE $GLOBAL_OPTIONS pack $@ 1> pack.out 2> pack.err
 }
 
 function do_ps { psflags=$1


### PR DESCRIPTION
This follows up the recently merged #3735 by:

1. Adding --pack-dir to the help
2. Allowing `pack` to take multiple directories to pack to make the argument useful.
3. Adding a test for the option.