### PR TITLE
Convince compiler to use constructor MemoryRange(addr, end).

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -2337,7 +2337,9 @@ remote_ptr<void> AddressSpace::chaos_mode_find_free_memory(RecordTask* t,
   MemoryRange global_exclusion_range = get_global_exclusion_range(&t->session());
   // NB: Above RR_PAGE_ADDR is probably not free anyways, but if it somehow is
   // don't hand it out again.
-  static MemoryRange rrpage_so_range = MemoryRange(RR_PAGE_ADDR - PRELOAD_LIBRARY_PAGE_SIZE, RR_PAGE_ADDR + PRELOAD_LIBRARY_PAGE_SIZE);
+  static MemoryRange rrpage_so_range = MemoryRange(remote_ptr<void>(RR_PAGE_ADDR - PRELOAD_LIBRARY_PAGE_SIZE),
+                                                   remote_ptr<void>(RR_PAGE_ADDR + PRELOAD_LIBRARY_PAGE_SIZE));
+  assert(rrpage_so_range.size() == 2 * PRELOAD_LIBRARY_PAGE_SIZE);
 
   // Ignore the hint half the time.
   if (hint && (random() & 1)) {


### PR DESCRIPTION
A default build (no additional cmake options) in a 32-bit Debian Bookworm was observed to use the constructor MemoryRange(addr, size) instead of MemoryRange(addr, end).
This triggered a crash of the chaos_oom test, because it tried to use the last part of the address space,
which results later in following fatal message, because end_ wraps over to the value 0.

[FATAL src/MemoryRange.h:20:MemoryRange()] start_ <= end_

-----

Following is a debug session showing the end_=0xe0000000 instead of the expected end_=0x70001000.

Are there any performance concern about the additional assert?

```
$ gdb -q --args bin/rr --check-cached-mmaps record --chaos bin/chaos_oom
Reading symbols from bin/rr...
(gdb) run
Starting program: /home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr --check-cached-mmaps record --chaos bin/chaos_oom
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/i386-linux-gnu/libthread_db.so.1".
[New Thread 0xb7839b40 (LWP 6277)]
...
[New Thread 0xb0bffb40 (LWP 6288)]
rr: Saving execution to trace directory `/home/benutzer/.local/share/rr/chaos_oom-135'.
[Detaching after fork from child process 6289]
[FATAL src/MemoryRange.h:20:MemoryRange()] start_ <= end_
=== Start rr backtrace:
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr13dump_rr_stackERNS_8ScopedFdE+0x4c)[0x9e3449]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x41b771)[0x81b771]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr12FatalOstreamD1Ev+0x2f)[0x81b995]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr11MemoryRangeC1ENS_10remote_ptrIvEEj+0x95)[0x72e253]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr12AddressSpace27chaos_mode_find_free_memoryEPNS_10RecordTaskEjNS_10remote_ptrIvEE+0x5e5)[0x729869]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x48e26d)[0x88e26d]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x49c4b2)[0x89c4b2]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x48f2d5)[0x88f2d5]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x4a9214)[0x8a9214]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x48f3c5)[0x88f3c5]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr19rec_prepare_syscallEPNS_10RecordTaskE+0x77)[0x88f446]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr13RecordSession21syscall_state_changedEPNS_10RecordTaskEPNS0_9StepStateE+0x384)[0x871a7a]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr13RecordSession11record_stepEv+0x541)[0x878ded]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(+0x46b08e)[0x86b08e]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_ZN2rr13RecordCommand3runERSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE+0x400)[0x86be72]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(main+0x294)[0x82d019]
/lib/i386-linux-gnu/libc.so.6(+0x232d5)[0xb78612d5]
/lib/i386-linux-gnu/libc.so.6(__libc_start_main+0x88)[0xb7861398]
/home/bernhard/data/entwicklung/2023/rr/2022-09-11/i686/obj/bin/rr(_start+0x27)[0x71a907]
=== End rr backtrace

Thread 1 "rr" received signal SIGABRT, Aborted.
0xb7fc9559 in __kernel_vsyscall ()
(gdb) bt
#0  0xb7fc9559 in __kernel_vsyscall ()
#1  0xb78c82f7 in ?? () from /lib/i386-linux-gnu/libc.so.6
#2  0xb7877111 in raise () from /lib/i386-linux-gnu/libc.so.6
#3  0xb786026a in abort () from /lib/i386-linux-gnu/libc.so.6
#4  0x009e33fd in rr::notifying_abort () at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/util.cc:1770
#5  0x0081b809 in rr::dump_stack_and_abort () at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/log.cc:427
#6  0x0081b995 in rr::FatalOstream::~FatalOstream (this=0xbfffd4cf, __in_chrg=<optimized out>) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/log.cc:460
#7  0x0072e253 in rr::MemoryRange::MemoryRange (this=0xbfffd524, addr=..., num_bytes=536870912) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/MemoryRange.h:20
#8  0x00729869 in rr::AddressSpace::chaos_mode_find_free_memory (this=0xc290d0, t=0xc2e9d0, len=536870912, hint=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/AddressSpace.cc:2398
#9  0x0088e26d in rr::prepare_mmap_register_params (t=0xc2e9d0) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/record_syscall.cc:3344
#10 0x0089c4b2 in rr::rec_prepare_syscall_arch<rr::X86Arch> (t=0xc2e9d0, syscall_state=..., regs=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/record_syscall.cc:5203
#11 0x0088f2d5 in operator() (__closure=0xbfffe7c8, regs=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/record_syscall.cc:5420
#12 0x008a9214 in rr::with_converted_registers<rr::Switchable, rr::rec_prepare_syscall_internal(RecordTask*, TaskSyscallState&)::<lambda(const rr::Registers&)> >(const rr::Registers &, rr::SupportedArch, struct {...}) ( regs=..., arch=rr::x86, f=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/Registers.h:630
#13 0x0088f3c5 in rr::rec_prepare_syscall_internal (t=0xc2e9d0, syscall_state=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/record_syscall.cc:5418
#14 0x0088f446 in rr::rec_prepare_syscall (t=0xc2e9d0) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/record_syscall.cc:5430
#15 0x00871a7a in rr::RecordSession::syscall_state_changed (this=0xc2c120, t=0xc2e9d0, step_state=0xbffff0ec) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/RecordSession.cc:1178
#16 0x00878ded in rr::RecordSession::record_step (this=0xc2c120) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/RecordSession.cc:2670
#17 0x0086b08e in rr::record (args=std::vector of length 1, capacity 4 = {...}, flags=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/RecordCommand.cc:711
#18 0x0086be72 in rr::RecordCommand::run (this=0xc21048 <rr::RecordCommand::singleton>, args=std::vector of length 1, capacity 4 = {...}) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/RecordCommand.cc:874
#19 0x0082d019 in main (argc=5, argv=0xbffff474) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/main.cc:278
(gdb) frame 7
#7  0x0072e253 in rr::MemoryRange::MemoryRange (this=0xbfffd524, addr=..., num_bytes=536870912) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/MemoryRange.h:20
20          DEBUG_ASSERT(start_ <= end_);
(gdb) print/x *this
$1 = {start_ = {ptr = 0xe0000000}, end_ = {ptr = 0x0}}
(gdb) up
#8  0x00729869 in rr::AddressSpace::chaos_mode_find_free_memory (this=0xc290d0, t=0xc2e9d0, len=536870912, hint=...) at /home/bernhard/data/entwicklung/2023/rr/2022-09-11/rr/src/AddressSpace.cc:2398
2398            MemoryRange r(addr, ceil_page_size(len));
(gdb) print/x addr
$2 = {ptr = 0xe0000000}
(gdb) print/x len
$3 = 0x20000000
(gdb) print/x rrpage_so_range
$4 = {start_ = {ptr = 0x6ffff000}, end_ = {ptr = 0xe0000000}}
(gdb) print/x 0x70000000 - 4096 + 0x70000000 + 4096
$5 = 0xe0000000
(gdb)
```