### PR TITLE
Don't save the exe twice in pack_dir test

### DIFF
--- a/src/test/pack_dir.run
+++ b/src/test/pack_dir.run
@@ -1,7 +1,8 @@
 source `dirname $0`/util.sh
 
-record simple$bitness
-record simple$bitness
+save_exe simple$bitness
+just_record simple$bitness-$nonce
+just_record simple$bitness-$nonce
 
 mkdir the_pack_dir
 


### PR DESCRIPTION
Otherwise the test may fail because the file attributes (mtime in particular) changed.