### PR TITLE
When using `PERF_RECORD_SWITCH`, allow ContextSwitchEvent initialization to fail

### DIFF
--- a/src/ContextSwitchEvent.cc
+++ b/src/ContextSwitchEvent.cc
@@ -144,12 +144,15 @@ ContextSwitchEventStrategy ContextSwitchEvent::strategy() {
   return strat;
 }
 
-void ContextSwitchEvent::init(ScopedFd tracee_fd) {
+bool ContextSwitchEvent::init(ScopedFd tracee_fd) {
   tracee_fd_ = std::move(tracee_fd);
   if (strategy() == ContextSwitchEventStrategy::STRATEGY_RECORD_SWITCH) {
     mmap_buffer = make_unique<PerfCounterBuffers>();
-    mmap_buffer->allocate(tracee_fd_, page_size(), 0);
+    bool ok = false;
+    mmap_buffer->allocate(tracee_fd_, page_size(), 0, &ok);
+    return ok;
   }
+  return true;
 }
 
 void ContextSwitchEvent::drain_events() {

--- a/src/ContextSwitchEvent.h
+++ b/src/ContextSwitchEvent.h
@@ -47,7 +47,7 @@ namespace rr {
  */
 class ContextSwitchEvent {
 public:
-  void init(ScopedFd tracee_fd);
+  bool init(ScopedFd tracee_fd);
 
   ScopedFd& tracee_fd() { return tracee_fd_; }
 

--- a/src/PerfCounterBuffers.h
+++ b/src/PerfCounterBuffers.h
@@ -32,7 +32,7 @@ public:
       buffer_size(0), packet_in_use(false) {}
   ~PerfCounterBuffers() { destroy(); }
 
-  void allocate(ScopedFd& perf_event_fd, uint64_t buffer_size, uint64_t aux_size);
+  void allocate(ScopedFd& perf_event_fd, uint64_t buffer_size, uint64_t aux_size, bool *ok = nullptr);
   void destroy();
 
   bool allocated() const { return mmap_header != nullptr; }

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -526,7 +526,11 @@ template <typename Arch> void RecordTask::init_buffers_arch() {
     desched_fd_child = args.desched_counter_fd;
     // Prevent the child from closing this fd
     fds->add_monitor(this, desched_fd_child, new PreserveFileMonitor());
-    desched_fd.init(remote.retrieve_fd(desched_fd_child));
+    if (!desched_fd.init(remote.retrieve_fd(desched_fd_child))) {
+      LOG(warn)
+          << "ContextSwitchEvent initialization with strategy "
+             "STRATEGY_RECORD_SWITCH failed. tracee died unexpectedly or killed ??";
+    }
 
     if (trace_writer().supports_file_data_cloning() &&
         session().use_read_cloning()) {


### PR DESCRIPTION
The tracee may have died unexpectedly or been killed.

This commit allows the `cont_race` test to consistently pass when the test is run under all the following conditions:
(a) kernel.perf_event_paranoid = 2
(b) kernel supports PERF_RECORD_SWITCH (Linux kernel >= 6.10) 
(c) syscallbuf is enabled (so here we're talking only about `cont_race`
    and NOT `cont_race-no-syscallbuf` which doesn't need switch events anyways)

Without this commit, I noticed the occasional failure in (syscallbuf enabled) `cont_race`:
```
[FATAL src/PerfCounterBuffers.cc:32:allocate() errno: EBADF] Can't allocate memory for PT DATA area
```