### PR TITLE
pack: Restore behavior with no passed trace dirs

### DIFF
--- a/src/PackCommand.cc
+++ b/src/PackCommand.cc
@@ -754,6 +754,11 @@ int PackCommand::run(vector<string>& args) {
     trace_dirs.push_back(trace_dir);
   }
 
+  // If no trace dirs were supplied, default to packing "", i.e. the latest trace.
+  if (trace_dirs.empty()) {
+    trace_dirs.push_back("");
+  }
+
   return pack(trace_dirs, flags);
 }
 

--- a/src/test/pack.run
+++ b/src/test/pack.run
@@ -12,6 +12,11 @@ pack || failed "'rr pack' failed"
 if [[ `ls latest-trace/*_pack$bitness-* | wc -l` != "1" ]]; then
     failed "Failed to coalesce all instances of 'pack'"
 fi
+
+if [[ `ls latest-trace/mmap_pack_* | wc -l` == "0" ]]; then
+    failed "Packing produced no files."
+fi
+
 # If there are no copies of _mapped_file it was probably copied
 # into the trace data, for one of various reasons, so don't fail
 # the test in that case.


### PR DESCRIPTION
This is a bit of an embarassing bug-fix, but as pointed out in https://github.com/rr-debugger/rr/pull/3834#issuecomment-2380622819, I accidentally broke `rr pack` without trace dir specified (which is supposed to pack the latest dir). We do actually have a test for it, which does fail for me locally (which I didn't notice - sorry), but not on CI. I'm not entirely sure why it doesn't fail on CI, but I imagine we might be copying more things in the CI environment, rather than cloning/linking them. To try to catch similar regressions in the future, this also adds an extra check to the test to make sure that there is some `mmap_pack_*` file in the trace after packing. I think we should always be packing at least libc or ld-linux, so hopefully there shouldn't be any false positives there.