### PR TITLE
Make trapped_instruction_at() explicitly x86-specific

### DIFF
--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -227,9 +227,9 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
         result.break_status.signal = unique_ptr<siginfo_t>(new siginfo_t(t->get_siginfo()));
         result.break_status.signal->si_signo = t->stop_sig();
       } else if (t->stop_sig() == SIGSEGV) {
-        auto trapped_instruction = trapped_instruction_at(t, t->ip());
-        if (trapped_instruction == TrappedInstruction::RDTSC) {
-          size_t len = trapped_instruction_len(trapped_instruction);
+        auto special_instruction = special_instruction_at(t, t->ip());
+        if (special_instruction.opcode == SpecialInstOpcode::X86_RDTSC) {
+          size_t len = special_instruction_len(special_instruction.opcode);
           uint64_t rdtsc_value = next_rdtsc_value();
           LOG(debug) << "Faking RDTSC instruction with value " << rdtsc_value;
           Registers r = t->regs();

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -497,7 +497,7 @@ bool ReplaySession::handle_unrecorded_cpuid_fault(
     ReplayTask* t, const StepConstraints& constraints) {
   if (t->stop_sig() != SIGSEGV || !has_cpuid_faulting() ||
       trace_in.uses_cpuid_faulting() ||
-      trapped_instruction_at(t, t->ip()) != TrappedInstruction::CPUID) {
+      special_instruction_at(t, t->ip()).opcode != SpecialInstOpcode::X86_CPUID) {
     return false;
   }
   // OK, this is a case where we did not record using CPUID faulting but we are
@@ -522,7 +522,7 @@ bool ReplaySession::handle_unrecorded_cpuid_fault(
               << " CX=" << HEX(r.cx()) << "; defaulting to 0/0/0/0";
     r.set_cpuid_output(0, 0, 0, 0);
   }
-  r.set_ip(r.ip() + trapped_instruction_len(TrappedInstruction::CPUID));
+  r.set_ip(r.ip() + special_instruction_len(SpecialInstOpcode::X86_CPUID));
   t->set_regs(r);
   // Clear SIGSEGV status since we're handling it
   t->set_status(constraints.is_singlestep() ? WaitStatus::for_stop_sig(SIGTRAP)

--- a/src/Task.h
+++ b/src/Task.h
@@ -1317,7 +1317,7 @@ protected:
   // Task.cc
   uint64_t last_resume_orig_cx;
   // The instruction type we're singlestepping through.
-  TrappedInstruction singlestepping_instruction;
+  SpecialInst singlestepping_instruction;
   // True if we set a breakpoint after a singlestepped CPUID instruction.
   // We need this in addition to `singlestepping_instruction` because that
   // might be CPUID but we failed to set the breakpoint.

--- a/src/util.h
+++ b/src/util.h
@@ -486,23 +486,27 @@ std::vector<std::string> current_env();
  */
 int get_num_cpus();
 
-enum class TrappedInstruction {
-  NONE = 0,
-  RDTSC = 1,
-  RDTSCP = 2,
-  CPUID = 3,
-  INT3 = 4,
-  PUSHF = 5,
-  PUSHF16 = 6,
+enum class SpecialInstOpcode {
+  NONE,
+  X86_RDTSC,
+  X86_RDTSCP,
+  X86_CPUID,
+  X86_INT3,
+  X86_PUSHF,
+  X86_PUSHF16,
+};
+
+struct SpecialInst {
+  SpecialInstOpcode opcode;
 };
 
 /* If |t->ip()| points at a decoded instruction, return the instruction */
-TrappedInstruction trapped_instruction_at(Task* t, remote_code_ptr ip);
+SpecialInst special_instruction_at(Task* t, remote_code_ptr ip);
 
 extern const uint8_t rdtsc_insn[2];
 
 /* Return the length of the TrappedInstruction */
-size_t trapped_instruction_len(TrappedInstruction insn);
+size_t special_instruction_len(SpecialInstOpcode insn);
 
 /**
  * Certain instructions generate deterministic signals but also advance pc.


### PR DESCRIPTION
There were some code paths where trapped_instruction_at() was callable on non-x86 platforms; as a result it may have been possible to reach x86-specific handling of trapped instructions in cases where the instruction bytes happened to match. Fix it by adding an architecture check to said code paths, renaming the function to x86_trapped_instruction_at() (likewise for trapped_instruction_len() and TrappedInstruction) and adding an assertion that checks the architecture.