### PR TITLE
Make arm64 register accessors take a register number

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -338,7 +338,7 @@ static void note_entering_syscall(RecordTask* t) {
       // value will be wrong due to the aarch64 kernel bug.
       // Get it from the syscall event.
       Registers r = t->regs();
-      r.set_x7(t->ev().Syscall().regs.x7());
+      r.set_x(7, t->ev().Syscall().regs.x(7));
       t->set_regs(r);
     }
   }
@@ -1464,7 +1464,7 @@ static void setup_sigframe_siginfo_arch(RecordTask* t,
       dest = t->regs().si();
       break;
     case aarch64:
-      dest = t->regs().x1();
+      dest = t->regs().x(1);
       break;
     default:
       DEBUG_ASSERT(0 && "Unknown architecture");

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1626,7 +1626,7 @@ bool RecordTask::is_in_syscallbuf() {
     bool ok = true;
     uint64_t addr;
     if (arch() == aarch64) {
-      addr = regs().xlr();
+      addr = regs().x(30);
     }
     else {
       ASSERT(this, is_x86ish(arch())) << "Unknown architecture";

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -404,34 +404,14 @@ public:
     u.arm64regs.pstate = pstate;
   }
 
-  void set_x7(uintptr_t x7) {
-    DEBUG_ASSERT(arch() == aarch64);
-    u.arm64regs.x[7] = x7;
+  void set_x(unsigned regno, uintptr_t val) {
+    DEBUG_ASSERT(arch() == aarch64 && regno < 31);
+    u.arm64regs.x[regno] = val;
   }
 
-  void set_x15(uintptr_t x15) {
-    DEBUG_ASSERT(arch() == aarch64);
-    u.arm64regs.x[15] = x15;
-  }
-
-  void set_xlr(uintptr_t xlr) {
-    DEBUG_ASSERT(arch() == aarch64);
-    u.arm64regs.x[30] = xlr;
-  }
-
-  uintptr_t x1() const {
-    DEBUG_ASSERT(arch() == aarch64);
-    return u.arm64regs.x[1];
-  }
-
-  uintptr_t x7() const {
-    DEBUG_ASSERT(arch() == aarch64);
-    return u.arm64regs.x[7];
-  }
-
-  uintptr_t xlr() const {
-    DEBUG_ASSERT(arch() == aarch64);
-    return u.arm64regs.x[30];
+  uintptr_t x(unsigned regno) const {
+    DEBUG_ASSERT(arch() == aarch64 && regno < 31);
+    return u.arm64regs.x[regno];
   }
   // End of aarch64 specific accessors
 

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -238,8 +238,8 @@ bool handle_syscallbuf_breakpoint(RecordTask* t) {
       uint64_t x15_x30[2];
       get_stub_scratch_2(t, x15_x30, 16);
       Registers r = t->regs();
-      r.set_x15(x15_x30[0]);
-      r.set_xlr(x15_x30[1]);
+      r.set_x(15, x15_x30[0]);
+      r.set_x(30, x15_x30[1]);
       t->set_regs(r);
       t->count_direct_jump();
     }

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5376,7 +5376,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           regs),x);
         auto x7 = t->read_mem(x_regs_arr.field((uintptr_t*)nullptr,
           7 * sizeof(uintptr_t)));
-        syscall_state.syscall_entry_registers.set_x7(x7);
+        syscall_state.syscall_entry_registers.set_x(7, x7);
       }
       t->invalidate_sigmask();
       return PREVENT_SWITCH;
@@ -5471,7 +5471,7 @@ static void aarch64_kernel_bug_workaround(RecordTask *t,
     // un-recorded divergence). I'm really hoping to get this fixed
     // in the kernel.
     Registers r = t->regs();
-    r.set_x7(syscall_state.syscall_entry_registers.x7());
+    r.set_x(7, syscall_state.syscall_entry_registers.x(7));
     t->set_regs(r);
   }
 }


### PR DESCRIPTION
In order to emulate timer access instructions we will need to be able to store a value to a register by number. The existing x-register accessors are not suitable for this because the register number is fixed. Therefore, replace these accessors with ones that take a register number.