### PR TITLE
Use the correct logic for CPUID faulting check skipping

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1052,7 +1052,7 @@ bool cpuid_faulting_works() {
   static bool did_check_cpuid_faulting = false;
   static bool cpuid_faulting_ok = false;
 
-#if defined(__i386__) || defined(__x86_64__)
+#if !(defined(__i386__) || defined(__x86_64__))
   did_check_cpuid_faulting = true;
 #endif
   if (did_check_cpuid_faulting) {


### PR DESCRIPTION
We're supposed to run this check only on x86_64/i386 (I think), but the current logic is running the check on all architectures _except_ x86_64/i386. Oops.

```
(gdb) disassemble cpuid_faulting_works
Dump of assembler code for function _ZN2rr20cpuid_faulting_worksEv:
   0x00000000005d3a60 <+0>:     xor    %eax,%eax
   0x00000000005d3a62 <+2>:     ret
End of assembler dump.
```