### PR TITLE
Update comments relating to CPUIDs

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -69,9 +69,24 @@ static uint32_t pmu_semantics_flags;
 
 /*
  * Find out the cpu model using the cpuid instruction.
- * Full list of CPUIDs at http://sandpile.org/x86/cpuid.htm
- * Another list at
- * http://software.intel.com/en-us/articles/intel-architecture-and-processor-identification-with-cpuid-model-and-family-numbers
+ *
+ * A 3rd party list of CPUIDs at https://sandpile.org/x86/cpuid.htm
+ *
+ * Intel's up-to-date and complete list is in
+ * "Volume 4: Model-Specific Registers", Chapter 2.
+ * See "Intel 64 and IA-32 Architectures Software Developer Manual"
+ * https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
+ *
+ * Alternatively you can find the recently added CPUIDs in the lighter document
+ * called "Documentation Changes", navigate in table of contents to
+ * "27. Updates to Chapter 2, Volume 4"
+ * and then "Chapter 2 Model-Specific Registers (MSRs)"
+ *
+ * AMD: your best bet is https://www.amd.com/en/search/documentation/hub.html
+ * Search for "revision guide Family 17h" and "Model 31h" or "Models 00h-0Fh"
+ * For example "Revision Guide for AMD Family 19h Models 00h-0Fh Processors"
+ * has a "Table 2" with "CPUID Values for AMD" showing the specific model and
+ * revisions.
  */
 enum CpuMicroarch {
   UnknownCpu,

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -117,7 +117,7 @@ static CpuMicroarch compute_cpu_microarch() {
       break;
     case 0x10f10: // Raven Ridge, Great Horned Owl (Zen) (UNTESTED)
     case 0x10f80: // Banded Kestrel (Zen), Picasso (Zen+), 7975WX (Zen2)
-    case 0x20f00: // Dali (Zen) (UNTESTED)
+    case 0x20f00: // Dali (Zen)
       if (ext_family == 8) {
         return AMDZen;
       } else if (ext_family == 0xa) {
@@ -125,8 +125,8 @@ static CpuMicroarch compute_cpu_microarch() {
       }
       break;
     case 0x30f10: // Rome, Castle Peak (Zen 2)
-    case 0x60f00: // Renoir (Zen 2) (UNTESTED)
-    case 0x70f10: // Matisse (Zen 2) (UNTESTED)
+    case 0x60f00: // Renoir (Zen 2)
+    case 0x70f10: // Matisse (Zen 2)
     case 0x60f80: // Lucienne (Zen 2)
     case 0x90f00: // Van Gogh (Zen 2)
       if (ext_family == 8) {


### PR DESCRIPTION
> Remove "untested" CPUID family comments for Zen
> I cleaned up the list on the wiki and added the generations and their codenames.
> It turned out a couple were claimed as working there; lets update the code comments too.
> Ref: https://github.com/rr-debugger/rr/wiki/Zen/bca014d54c29480750ff63899c648ac2906710bd

----

> Add CPUID lists links to PerfCounters.cc
> Due to the apparent and constant churn when adding "confirmed working" CPUIDs, I 
decided to clean up the comments here. Take a hint, this means many CPUs aren't 
explicitly added to the list of known processors.

> Updated Intel's link and gave directions where exactly to find CPUIDs.

> AMD doesn't appear to have a single source of truth for those, as they are 
scattered in individual revision guides and are hard to find.
