### PR TITLE
safe_pwrite64() should not be infallible if the process is dying

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -855,13 +855,13 @@ int64_t AutoRemoteSyscalls::infallible_lseek_syscall(int fd, int64_t offset,
   }
 }
 
-void AutoRemoteSyscalls::check_syscall_result(long ret, int syscallno, bool allow_death) {
+bool AutoRemoteSyscalls::check_syscall_result(long ret, int syscallno, bool allow_death) {
   if (word_size(t->arch()) == 4) {
     // Sign-extend ret because it can be a 32-bit negative errno
     ret = (int)ret;
   }
   if (ret == -ESRCH && allow_death && !t->session().is_replaying()) {
-    return;
+    return true;
   }
   if (-4096 < ret && ret < 0) {
     string extra_msg;
@@ -879,6 +879,7 @@ void AutoRemoteSyscalls::check_syscall_result(long ret, int syscallno, bool allo
                      << " arg3=0x" << hex << t->regs().arg3() << " arg4=0x" << t->regs().arg4()
                      << " arg5=0x" << hex << t->regs().arg5() << " arg6=0x" << t->regs().arg6();
   }
+  return false;
 }
 
 void AutoRemoteSyscalls::finish_direct_mmap(

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -282,7 +282,8 @@ public:
                           struct stat& real_file, std::string& real_file_name);
 
   // Calling this with allow_death false is DEPRECATED.
-  void check_syscall_result(long ret, int syscallno, bool allow_death = true);
+  // Returns true iff session was not replaying and allow_death is true and process is not alive (-ESRCH)
+  bool check_syscall_result(long ret, int syscallno, bool allow_death = true);
 
 private:
   void setup_path(bool enable_singlestep_path);


### PR DESCRIPTION
During record, safe_pwrite64() should not be infallible if the process is dying, otherwise `check_syscall_result()` `ASSERT`s