### PR TITLE
should_retry_patch must be initialized

### DIFF
--- a/src/Event.h
+++ b/src/Event.h
@@ -233,7 +233,8 @@ struct SyscallEvent {
         switchable(PREVENT_SWITCH),
         is_restart(false),
         failed_during_preparation(false),
-        in_sysemu(false) {}
+        in_sysemu(false),
+        should_retry_patch(false) {}
 
   std::string syscall_name() const { return rr::syscall_name(number, arch()); }
 


### PR DESCRIPTION
`should_retry_patch` must be initialized otherwise random syscall patch retrying errors happen even on aarch64