### PR TITLE
Add "b" prefix when using DREQ_GET_MEM_BINARY

### DIFF
--- a/src/GdbServerConnection.cc
+++ b/src/GdbServerConnection.cc
@@ -1921,7 +1921,7 @@ void GdbServerConnection::reply_get_mem(const vector<uint8_t>& mem) {
     } else if (!mem.size()) {
       write_packet("E01");
     } else {
-      write_binary_packet("", mem.data(), mem.size());
+      write_binary_packet("b", mem.data(), mem.size());
     }
   }
 


### PR DESCRIPTION
Fixes #3901.

GDB errors out if the response doesn't start with "b" (see https://github.com/bminor/binutils-gdb/blob/master/gdb/remote.c#L9739). This works on GDB 16.1 and LLDB 19.1.7, but I haven't tested anything else.