### PR TITLE
Added PmuConfig for Intel Arrow Lake

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -114,7 +114,8 @@ enum CpuMicroarch {
   IntelSapphireRapid,
   IntelEmeraldRapid,
   IntelMeteorLake,
-  LastIntel = IntelMeteorLake,
+  IntelArrowLake,
+  LastIntel = IntelArrowLake,
   FirstAMD,
   AMDF15 = FirstAMD,
   AMDZen,
@@ -202,6 +203,7 @@ struct PmuConfig {
 static const PmuConfig pmu_configs[] = {
   { IntelEmeraldRapid, "Intel EmeraldRapid", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelSapphireRapid, "Intel SapphireRapid", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
+  { IntelArrowLake, "Intel Arrowlake", 0x100005111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelMeteorLake, "Intel Meteorlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelRaptorlake, "Intel Raptorlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },
   { IntelAlderlake, "Intel Alderlake", 0x5111c4, 0, 0, 125, PMU_TICKS_RCB },

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -96,6 +96,8 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelEmeraldRapid;
     case 0xa06a0:
       return IntelMeteorLake;
+    case 0xc0660:
+      return IntelArrowLake;
     case 0xf20:  // Piledriver
     case 0x30f00:  // Steamroller
       return AMDF15;


### PR DESCRIPTION
This commit adds `0xc0660` as Intel Arrow Lake.