### PR TITLE
Add missing #include <sched.h>

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -34,6 +34,7 @@
 #include <linux/vt.h>
 #include <linux/wireless.h>
 #include <poll.h>
+#include <sched.h>
 #include <scsi/sg.h>
 #include <signal.h>
 #include <sound/asound.h>


### PR DESCRIPTION
This is needed to verify the sched_param type.

The header is no longer transitively included via libc++ after https://github.com/llvm/llvm-project/commit/699f19605579f25083152a9ad21e14c2751d5d66