### PR TITLE
Add support for MTD ioctls

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -33,6 +33,7 @@
 #include <linux/videodev2.h>
 #include <linux/vt.h>
 #include <linux/wireless.h>
+#include <mtd/mtd-user.h>
 #include <poll.h>
 #include <sched.h>
 #include <scsi/sg.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2006,6 +2006,24 @@ struct BaseArch : public wordsize,
   };
   RR_VERIFY_TYPE(cdrom_tocentry);
 
+  struct mtd_read_req_ecc_stats {
+    uint32_t uncorrectable_errors;
+    uint32_t corrected_bitflips;
+    uint32_t max_bitflips;
+  };
+
+  struct mtd_read_req {
+    uint64_t start;
+    uint64_t len;
+    uint64_t ooblen;
+    uint64_t usr_data;
+    uint64_t usr_oob;
+    uint8_t mode;
+    uint8_t padding[7];
+    struct mtd_read_req_ecc_stats ecc_stats;
+  };
+  RR_VERIFY_TYPE(mtd_read_req);
+
   struct ptrace_syscall_info {
     uint8_t op;
     uint32_t arch;


### PR DESCRIPTION
Reference: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/mtd/mtdchar.c?h=v6.13#n822

A limited subset of these ioctls can be tested without a physical MTD device by running:

    sudo modprobe nandsim
    sudo chown "${USER}" /dev/mtd1
    git clone --depth 1 --recurse-submodules https://github.com/kempniu/yafut.git
    cd yafut/
    cmake -Bbuild && cmake --build build
    dd if=/dev/urandom bs=32k count=1 | tee garbage-in | rr record build/yafut -d /dev/mtd1 -v -v -w -i - -o /garbage   
    rr replay -a -M
    rr record build/yafut -d /dev/mtd1 -v -v -r -i /garbage -o garbage-out
    rr replay -a -M
    sha256sum garbage-in garbage-out
