### PR TITLE
Buffer epoll_ctl.

### DIFF
--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -4177,6 +4177,7 @@ static long syscall_hook_internal(struct syscall_info* call) {
     CASE(creat);
 #endif
     CASE_GENERIC_NONBLOCKING_FD(dup);
+    CASE_GENERIC_NONBLOCKING_FD(epoll_ctl);
 #if defined(SYS_epoll_wait)
 case SYS_epoll_wait:
 #endif


### PR DESCRIPTION
I don't see any reason we can't do this, and it's worth a 6x improvement on a customer-provided testcase.