### PR TITLE
Support `syslog` syscall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1403,6 +1403,7 @@ set(BASIC_TESTS
   sysemu_singlestep
   x86/sysfs
   sysinfo
+  syslog
   tgkill
   thread_yield
   timer

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5459,6 +5459,17 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       return ALLOW_SWITCH;
     }
 
+    case Arch::syslog: {
+      int type = regs.arg1();
+      if (type < 0 || type > 10) {
+        syscall_state.expect_errno = EINVAL;
+      } else if (type == 2 || type == 3 || type == 4) {
+        syscall_state.reg_parameter(
+            2, ParamSize::from_syscall_result<int>((size_t)regs.arg3()));
+      }
+      return PREVENT_SWITCH;
+    }
+
     default:
       // Invalid syscalls return -ENOSYS. Assume any such
       // result means the syscall was completely ignored by the

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -568,7 +568,7 @@ ioperm = EmulatedSyscall(x86=101, x64=173)
 # through to the appropriate call.
 socketcall = IrregularEmulatedSyscall(x86=102)
 
-syslog = UnsupportedSyscall(x86=103, x64=103, generic=116)
+syslog = IrregularEmulatedSyscall(x86=103, x64=103, generic=116)
 
 #  int setitimer(int which, const struct itimerval *new_value, struct itimerval
 #*old_value);

--- a/src/test/syslog.c
+++ b/src/test/syslog.c
@@ -1,0 +1,35 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+#include <sys/klog.h>
+
+#define BUF1_SIZE 500
+
+int main(void) {
+  int log_buf_size = klogctl(10 /* SYSLOG_ACTION_SIZE_BUFFER */, NULL, 42);
+  if (log_buf_size == -1 && errno == EPERM) {
+    atomic_puts("Skipping test because it requires CAP_SYSLOG");
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
+  test_assert(log_buf_size >= 0);
+
+  char* buf1 = allocate_guard(BUF1_SIZE, '1');
+  int buf2_size = log_buf_size + 10;
+  char* buf2 = allocate_guard(buf2_size, '2');
+
+  int size1 = klogctl(3 /* SYSLOG_ACTION_READ_ALL */, buf1, BUF1_SIZE);
+  test_assert(size1 >= 0);
+  verify_guard(BUF1_SIZE, buf1);
+
+  int size2 = klogctl(3 /* SYSLOG_ACTION_READ_ALL */, buf2, buf2_size);
+  test_assert(size2 >= 0);
+  verify_guard(buf2_size, buf2);
+
+  test_assert(size2 >= size1);
+  test_assert(0 == memcmp(buf1, buf2 + (size2 - size1), size1));
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
I have run the test suite on AMD Ryzen 7 4700U and all tests passed except `x86/morestack_unwind`. However, `x86/morestack_unwind` was failing even before my change.

The new test for this syscall requires either the `CAP_SYSLOG` capability or setting the sysctl `kernel.dmesg_restrict` to 0.