### PR TITLE
Make QListThreadsInStopReply adhere to thread id syntax

### DIFF
--- a/src/GdbServerConnection.h
+++ b/src/GdbServerConnection.h
@@ -849,6 +849,8 @@ private:
    */
   bool process_packet();
   void consume_request();
+  void write_threads_if_supported(std::stringstream& stream,
+                                  const vector<ThreadInfo>& threads);
   void send_stop_reply_packet(ExtendedTaskId thread, int sig,
                               const std::vector<ThreadInfo>& threads,
                               const std::string& reason);


### PR DESCRIPTION
In future work when RR supports multi process debug session/replays, this extension must send thread info in the correct format.

If the multi process extension is enabled all threads must contain p<pid.tid>. Debuggers that opt in to multiprocess features, must honor this.