### PR TITLE
Fix PTRACE_INTERRUPT to actually work if the tracee is not already stopped.

### DIFF
--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -211,7 +211,7 @@ private:
    * the next runnable task after 't' in round-robin order.
    * Sets 'by_waitpid' to true if we determined the task was runnable by
    * calling waitpid on it and observing a state change. This task *must*
-   * be returned by get_next_thread, and is_runnable_task must not be called
+   * be returned by get_next_thread, and is_task_runnable must not be called
    * on it again until it has run.
    * Considers only tasks with priority <= priority_threshold.
    */


### PR DESCRIPTION
The current code is completely untested because it will always call syscall_state.emulate_result twice and fatally assert. The ptrace_seize test does not yield between PTRACE_CONT and PTRACE_INTERRUPT, so rr will not switch to the emulated ptracee and resume execution, and the PTRACE_INTERRUPT will always find the emulated ptracee already stopped. Additionally, the test does not wait on the emulated ptracee again after interrupting it, so the following assertion about the value of status is bogus.

Fix all of that by adding the appropriate waitpid, tweaking the status assertion, duplicating the PTRACE_CONT/PTRACE_INTERRUPT sequence but with an intervening sched_yield() to force the emulated ptracee to resume, and fixing rr's PTRACE_INTERRUPT emulation to emulate_result only once and to place an emulated stop on the emulated ptracee.