### PR TITLE
Mimic kernel signal coalescing behavior for synthetic SIGCHLDs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1100,6 +1100,7 @@ set(BASIC_TESTS
   grandchild_threads_main_running
   grandchild_threads_thread_running
   grandchild_threads_parent_alive
+  group_stop_thundering_herd
   x86/hle
   x86/hlt
   inotify

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -997,9 +997,10 @@ void RecordTask::set_siginfo_for_synthetic_SIGCHLD(siginfo_t* si) {
   RecordTask* from_task = nullptr;
   for (RecordTask* tracee : emulated_ptrace_tracees) {
     if (tracee->emulated_ptrace_SIGCHLD_pending) {
-      from_task = tracee;
-      from_task->emulated_ptrace_SIGCHLD_pending = false;
-      break;
+      if (!from_task) {
+        from_task = tracee;
+      }
+      tracee->emulated_ptrace_SIGCHLD_pending = false;
     }
   }
 
@@ -1008,13 +1009,11 @@ void RecordTask::set_siginfo_for_synthetic_SIGCHLD(siginfo_t* si) {
       for (Task* child : child_tg->task_set()) {
         auto rchild = static_cast<RecordTask*>(child);
         if (rchild->emulated_SIGCHLD_pending) {
-          from_task = rchild;
-          from_task->emulated_SIGCHLD_pending = false;
-          break;
+          if (!from_task) {
+            from_task = rchild;
+          }
+          rchild->emulated_SIGCHLD_pending = false;
         }
-      }
-      if (from_task) {
-        break;
       }
     }
 

--- a/src/test/group_stop_thundering_herd.c
+++ b/src/test/group_stop_thundering_herd.c
@@ -1,0 +1,63 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+#include "ptrace_util.h"
+
+static void* do_thread(void* arg) {
+  int pipe_fd = *(int*)arg;
+  uint32_t tid = gettid();
+
+  write(pipe_fd, &tid, 4);
+  /* Sleep long enough that it will be noticed if it's not interrupted. */
+  sleep(1000);
+
+  return NULL;
+}
+
+int main(void) {
+  pid_t child, grandchild;
+  int sock_fds[2];
+
+  test_assert(0 == socketpair(AF_LOCAL, SOCK_STREAM, 0, sock_fds));
+
+  if (0 == (child = fork())) {
+    uint32_t tid;
+    int pipe_fds[2];
+    test_assert(0 == pipe(pipe_fds));
+
+    if (0 == (grandchild = fork())) {
+      pthread_t t;
+
+      pthread_create(&t, NULL, do_thread, &pipe_fds[1]);
+      pthread_join(t, NULL);
+
+      return 77;
+    }
+
+    test_assert(4 == read(pipe_fds[0], &tid, 4));
+
+    close(pipe_fds[0]);
+    sched_yield();
+
+    test_assert(sizeof(grandchild) == send(sock_fds[1], &grandchild, sizeof(grandchild), 0));
+    /* Nothing is ever sent the other way so this just blocks. */
+    recv(sock_fds[1], &grandchild, sizeof(grandchild), 0);
+
+    return 66;
+  }
+
+  /* Get the grandchild pid. */
+  recv(sock_fds[0], &grandchild, sizeof(grandchild), 0);
+
+  /* Hit the entire process group with a SIGSTOP. */
+  tgkill(grandchild, grandchild, SIGSTOP);
+
+  /* Force the rr scheduler to run. */
+  sched_yield();
+
+  kill(SIGKILL, grandchild);
+  kill(SIGKILL, child);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
On the real kernel multiple SIGCHLDs (and all non-rt signals, of course) are coalesced and only a single SIGCHLD is delivered. It's important for us to copy this behavior here because RecordTask::has_other_actionable signals does not know about the signals that effectively exist in emulated_[ptrace_]SIGCHLD_pending. If we allow multiple emulated SIGCHLDs and those SIGCHLDs happen to interrupt e.g. a recv(2) the EV_SIGNAL_DELIVERY case in RecordSession::signal_state_changed will set up the syscall restart after the first signal only to immediately take a second one, and when we go to replay the second signal we will find the registers have diverged.