### PR TITLE
Add missing copyright headers

### DIFF
--- a/third-party/gdb/32bit-avx512.xml
+++ b/third-party/gdb/32bit-avx512.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
+<!-- Copyright (C) 2014-2024 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
 <!DOCTYPE feature SYSTEM "gdb-target.dtd">
 <feature name="org.gnu.gdb.i386.avx512">
     <vector id="v2ui128" type="uint128" count="2"/>

--- a/third-party/gdb/64bit-avx512.xml
+++ b/third-party/gdb/64bit-avx512.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
+<!-- Copyright (C) 2014-2024 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
 <!DOCTYPE feature SYSTEM "gdb-target.dtd">
 <feature name="org.gnu.gdb.i386.avx512">
     <vector id="v8bf16" type="bfloat16" count="8"/>


### PR DESCRIPTION
Add copyright headers that were missing from target description xml files.