### PR TITLE
Fix build with recent GCC

### DIFF
--- a/src/test/readv.c
+++ b/src/test/readv.c
@@ -2,7 +2,7 @@
 
 #include "util.h"
 
-static char data[10] = "0123456789";
+static char data[11] = "0123456789";
 
 static void test(int use_preadv) {
   static const char name[] = "temp";

--- a/src/test/writev.c
+++ b/src/test/writev.c
@@ -2,7 +2,7 @@
 
 #include "util.h"
 
-static char data[10] = "0123456789";
+static char data[11] = "0123456789";
 
 static void test(int use_pwritev) {
   static const char name[] = "temp";


### PR DESCRIPTION
Recent versions of GCC complain about the string
buffers in some tests being too short to fit a NULL terminator. This causes the build to fail due to -Werror.

Observed on Fedora 42 with GCC 15, probably also affects others.