### PR TITLE
test adjustment: priority working under "nice"

### DIFF
--- a/src/test/priority.run
+++ b/src/test/priority.run
@@ -1,4 +1,6 @@
 source `dirname $0`/util.sh
-renice -n 1 $$ && record $TESTNAME
-renice -n 2 $$ && replay
+# note: we use a value that is below the regular "nice" value
+#       of 10, allowing to run `nice ctest` as well
+renice -n 11 $$ && record $TESTNAME
+renice -n 22 $$ && replay
 check 'EXIT-SUCCESS'


### PR DESCRIPTION
fixes #3963

`nice ctest` will run as 10, so only root could run a "nice ctest" and pass this test before - fixed by "using higher than 10".
Obviously would still fail with `nice -n 15 ctest`, but that's at least much rarer than running tests next to something else by "nice". If wanted I could also use something like 16+17...

Edit: please manually add the reference to the issue before merging.