### PR TITLE
Skip hold detection on broken ZFS filesystems

### DIFF
--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -615,6 +615,10 @@ struct dma_buf_export_sync_file {
 #define RENAME_NOREPLACE 1
 #endif
 
+#ifndef ZFS_SUPER_MAGIC
+#define ZFS_SUPER_MAGIC 0x2fc12fc1
+#endif
+
 } // namespace rr
 
 // We can't include libc's ptrace.h, so declare this here.


### PR DESCRIPTION
As discussed in https://github.com/rr-debugger/rr/issues/3717, ZFS has known bugs around SEEK_HOLE/SEEK_DATA causing it to indicate spurious holes. We detect the case where it (inconsistently) ends up indicating the hole to be zero sized, but depending on the sequencing of events, the related upstream issues indicate that the file system could indicate a non-zero-sized spurious hole on these versions. To avoid trace corruption on such file systems, we must skip our SEEK_HOLE/SEEK_DATA optimizations.