### PR TITLE
Set dependency against only object

### DIFF
--- a/third-party/zen-pmu-workaround/Makefile
+++ b/third-party/zen-pmu-workaround/Makefile
@@ -4,7 +4,7 @@ all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
 signed: $(obj-m)
-	sudo /lib/modules/$(shell uname -r)/build/scripts/sign-file sha512 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der $(obj-m)
+	sudo /lib/modules/$(shell uname -r)/build/scripts/sign-file sha512 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der zen_workaround.ko
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/third-party/zen-pmu-workaround/Makefile
+++ b/third-party/zen-pmu-workaround/Makefile
@@ -3,8 +3,8 @@ obj-m = zen_workaround.o
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
-signed: all
-	sudo /lib/modules/$(shell uname -r)/build/scripts/sign-file sha512 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der zen_workaround.ko
+signed: $(obj-m)
+	sudo /lib/modules/$(shell uname -r)/build/scripts/sign-file sha512 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der $(obj-m)
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean


### PR DESCRIPTION
Not doing so may result in build failure:
```
$ sudo make signed
make -C /lib/modules/6.14.0-28-generic/build M= modules
make[1] : on entre dans le répertoire « /usr/src/linux-headers-6.14.0-28-generic »

make[3]: ***  Aucune règle pour fabriquer la cible « arch/x86/entry/syscalls/syscall_32.tbl », nécessaire pour « arch/x86/include/generated/uapi/asm/unistd_32.h ». Arrêt.
make[2]: *** [arch/x86/Makefile:277: archheaders] Error 2
make[1]: *** [Makefile:251: __sub-make] Error 2
make[1] : on quitte le répertoire « /usr/src/linux-headers-6.14.0-28-generic »
make: *** [Makefile:4: all] Error 2