### PR TITLE
Tiny changes needed for building with c++23 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,23 @@
 cmake_minimum_required(VERSION 3.12)
 project(rr C CXX ASM)
 
+# Require c++17 as minimum
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Configure so that we use -std=c++17 (as previously done) not -std=gnu++17
+if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Because `CMAKE_CXX_STANDARD_REQUIRED ON` does not enforce this for us.
+if(CMAKE_CXX_STANDARD LESS 17)
+  message(FATAL_ERROR "C++ standard too low: CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}. Minimum required is C++17.")
+endif()
+
 # "Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property."
 # This avoids linking executables with -rdynamic. -rdynamic has been observed
 # to cause rr_exec_stub to be linked with the dynamic linker with some
@@ -104,7 +121,7 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS")
 
 # We support three build types:
 # DEBUG: suitable for debugging rr

--- a/src/ContextSwitchEvent.cc
+++ b/src/ContextSwitchEvent.cc
@@ -23,7 +23,7 @@ namespace rr {
 static volatile int sigio_count;
 
 static void sigio_handler(int, siginfo_t*, void*) {
-  ++sigio_count;
+  sigio_count += 1;
 }
 
 static bool can_use_switch_records() {

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -125,7 +125,7 @@ public:
                       size_t size);
 
 #define ARCH_SWITCH_CASE(rettype, x86case, x64case, arm64case)                 \
-(([=](void) -> rettype {                                                       \
+(([&](void) -> rettype {                                                       \
   switch (arch()) {                                                            \
     default:                                                                   \
       DEBUG_ASSERT(0 && "unknown architecture");                               \

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -131,11 +131,11 @@ void ReplayTask::validate_regs(uint32_t flags) {
       << comparison;
 }
 
-const TraceFrame& ReplayTask::current_trace_frame() {
+const TraceFrame& ReplayTask::current_trace_frame() const {
   return session().current_trace_frame();
 }
 
-FrameTime ReplayTask::current_frame_time() {
+FrameTime ReplayTask::current_frame_time() const {
   return current_trace_frame().time();
 }
 

--- a/src/ReplayTask.h
+++ b/src/ReplayTask.h
@@ -58,8 +58,8 @@ public:
    *  current trace record.
    */
   void validate_regs(uint32_t flags = 0);
-  const TraceFrame& current_trace_frame();
-  FrameTime current_frame_time();
+  const TraceFrame& current_trace_frame() const;
+  FrameTime current_frame_time() const;
 
   /** Restore the next chunk of this frame's saved data from the trace to this. */
   void apply_data_record_from_trace();

--- a/src/Session.h
+++ b/src/Session.h
@@ -135,7 +135,7 @@ struct BreakStatus {
     return result;
   }
 
-  bool any_break() {
+  bool any_break() const {
     return !watchpoints_hit.empty() || signal || breakpoint_hit ||
            singlestep_complete || approaching_ticks_target;
   }

--- a/src/Task.h
+++ b/src/Task.h
@@ -201,7 +201,7 @@ public:
    * Updates tick count from the current performance counter values if
    * necessary.
    */
-  Ticks tick_count() { return ticks; }
+  Ticks tick_count() const { return ticks; }
 
   /**
    * Return the path of this fd as /proc/<pid>/fd/<fd>

--- a/src/WaitManager.cc
+++ b/src/WaitManager.cc
@@ -47,7 +47,7 @@ pid_t WaitState::do_wait(pid_t tid, bool consume, int type, double block_seconds
   memset(&siginfo, 0, sizeof(siginfo));
   if (block_seconds <= 0.0) {
     options |= WNOHANG;
-  } else if (block_seconds < WAIT_BLOCK_MAX) {
+  } else if (block_seconds < static_cast<double>(WAIT_BLOCK_MAX)) {
     struct itimerval timer = { { 0, 0 }, to_timeval(block_seconds) };
     if (setitimer(ITIMER_REAL, &timer, nullptr) < 0) {
       FATAL() << "Failed to set itimer";
@@ -60,7 +60,7 @@ pid_t WaitState::do_wait(pid_t tid, bool consume, int type, double block_seconds
     CLEAN_FATAL() << "waitid(options=" << options
       << ") returned EINVAL; rr requires Linux kernel 4.7 or greater";
   }
-  if (!(block_seconds <= 0.0) && block_seconds < WAIT_BLOCK_MAX) {
+  if (!(block_seconds <= 0.0) && block_seconds < static_cast<double>(WAIT_BLOCK_MAX)) {
     int err = errno;
     struct itimerval timer = { { 0, 0 }, { 0, 0 } };
     if (setitimer(ITIMER_REAL, &timer, nullptr) < 0) {


### PR DESCRIPTION
I know > c++17 is not officially supported by rr, but these changes do not change behavior in any way, so I figured it'd be nice to make it possible to just drop rr into a c++23 setting and it building with no issues.

Also added some minor const thing.