### PR TITLE
provide loff_t as typedef

### DIFF
--- a/src/EmuFs.cc
+++ b/src/EmuFs.cc
@@ -10,6 +10,13 @@
 #include <sstream>
 #include <string>
 
+// muslc defines those, but we want a typedef instead
+#if defined(loff_t)
+typedef loff_t __musl_loff_t;
+#undef loff_t
+typedef __musl_loff_t loff_t;
+#endif
+
 #include "AddressSpace.h"
 #include "ReplaySession.h"
 #include "core.h"

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -102,6 +102,13 @@
 #include "log.h"
 #include "util.h"
 
+// muslc defines those, but we want a typedef instead
+#if defined(loff_t)
+typedef loff_t __musl_loff_t;
+#undef loff_t
+typedef __musl_loff_t loff_t;
+#endif
+
 using namespace std;
 
 #ifndef HAVE_TERMIOS2


### PR DESCRIPTION
muslc defines those, but we want a typedef instead

solution copied from libgo
https://gcc.gnu.org/pipermail/gcc-patches/2022-April/593527.html

Note: instead of EmuFS.cc this may go to ScopedFd.h, just drop a note and I'll adjust that.

Also note: clangd warns on this file:
>Included header fstream is not used directly (fixes available)
Included header ReplaySession.h is not used directly (fixes available)
Included header core.h is not used directly (fixes available)
Included header kernel_abi.h is not used directly (fixes available)
Included header kernel_metadata.h is not used directly (fixes available)
