### PR TITLE
muslc compat: support system without termios2

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -104,7 +104,7 @@
 
 using namespace std;
 
-#ifndef HAVE_TERMIOS2
+#if defined (TCGETS2) && ! defined (HAVE_TERMIOS2)
 // The kernel header that defines this conflicts badly with glibc headers
 // (but not bionic, which does define this) so we define it ourselves.
 // NB: We need this struct defined so that the preprocessor macro for
@@ -1972,7 +1972,9 @@ static Switchable prepare_ioctl(RecordTask* t,
       case IOCTL_MASK_SIZE(TUNSETIFINDEX):
       case IOCTL_MASK_SIZE(TUNSETVNETLE):
       case IOCTL_MASK_SIZE(TUNSETVNETBE):
+      #ifdef TCSETS2
       case IOCTL_MASK_SIZE(TCSETS2):
+      #endif
         return PREVENT_SWITCH;
       case IOCTL_MASK_SIZE(USBDEVFS_GETDRIVER):
         // Reads and writes its parameter despite not having the _IOC_READ bit.
@@ -2108,7 +2110,10 @@ static Switchable prepare_ioctl(RecordTask* t,
     case IOCTL_MASK_SIZE(OTPGETREGIONINFO):
     case IOCTL_MASK_SIZE(ECCGETLAYOUT):
     case IOCTL_MASK_SIZE(ECCGETSTATS):
+    #ifndef TCGETS2
     case IOCTL_MASK_SIZE(TCGETS2):
+    #endif
+
       syscall_state.reg_parameter(3, size);
       return PREVENT_SWITCH;
 

--- a/src/test/ioctl_tty.c
+++ b/src/test/ioctl_tty.c
@@ -124,6 +124,7 @@ int main(void) {
   VERIFY_GUARD(nread);
   atomic_printf("FIONREAD returned nread=%d\n", *nread);
 
+#ifdef TCGETS2
   ALLOCATE_GUARD(tc2, 'i');
   test_assert(0 == ioctl(fd, TCGETS2, tc));
   VERIFY_GUARD(tc2);
@@ -136,6 +137,7 @@ int main(void) {
   // NB: leaving the TCSETS2 as the last word seems to mess up the terminal,
   // so fix it.
   test_assert(0 == ioctl(fd, TCSETS, tc));
+#endif
 
   atomic_puts("EXIT-SUCCESS");
   return 0;


### PR DESCRIPTION
see removal in https://github.com/bminor/musl/commit/6fce6ca129c34d8975f777216d32cf92e77c18f2

Fixing the related parts seen in the build log for #4009.