### PR TITLE
log: Clear log_modules after changing log spec

### DIFF
--- a/src/log.cc
+++ b/src/log.cc
@@ -182,6 +182,7 @@ void apply_log_spec(const char *spec) {
     }
   }
   free(env);
+  log_modules->clear();
 }
 
 void apply_log_spec_from_env() {


### PR DESCRIPTION
I was expecting to be able to change the logging of a running rr process by running `rr::apply_log_spec` at runtime under gdb, but this did not quite work, because unlike `set_all_logging`, it does not clear the log_modules cache. I think it would be useful for this to work, so clear log_modules at the end of this function.