### PR TITLE
Add support for Intel N100 (4 x Gracemont E-cores only).

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -116,6 +116,8 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelMeteorLake;
     case 0xb06d0:
       return IntelLunarLake;
+    case 0xb06e0:
+      return IntelGracemont;
     case 0xc0660:
       return IntelArrowLake;
     case 0xf20:  // Piledriver


### PR DESCRIPTION
Reference: https://github.com/rr-debugger/rr/issues/3338#issuecomment-3290057790

make check:

```
99% tests passed, 35 tests failed out of 3192

Total Test time (real) = 4246.12 sec

The following tests FAILED:
        381 - mmap_huge (Failed)
        382 - mmap_huge-no-syscallbuf (Failed)
        406 - mmap_shared_write-no-syscallbuf (Failed)
        408 - mmap_shared_write_fork-no-syscallbuf (Failed)
        409 - mmap_short_file (Failed)
        965 - alternate_thread_diversion (Failed)
        966 - alternate_thread_diversion-no-syscallbuf (Failed)
        1005 - breakpoint (Failed)
        1006 - breakpoint-no-syscallbuf (Failed)
        1349 - x86/watchpoint_error (Failed)
        1350 - x86/watchpoint_error-no-syscallbuf (Failed)
        1357 - watchpoint_unaligned (Failed)
        1358 - watchpoint_unaligned-no-syscallbuf (Failed)
        1359 - when_threads (Failed)
        1360 - when_threads-no-syscallbuf (Failed)
        1393 - breakpoint_print (Failed)
        1394 - breakpoint_print-no-syscallbuf (Failed)
        1595 - when (Failed)
        1596 - when-no-syscallbuf (Failed)
        1893 - ioctl_blk-32 (Failed)
        1894 - ioctl_blk-32-no-syscallbuf (Failed)
        2561 - alternate_thread_diversion-32 (Failed)
        2562 - alternate_thread_diversion-32-no-syscallbuf (Failed)
        2601 - breakpoint-32 (Failed)
        2602 - breakpoint-32-no-syscallbuf (Failed)
        2945 - x86/watchpoint_error-32 (Failed)
        2946 - x86/watchpoint_error-32-no-syscallbuf (Failed)
        2953 - watchpoint_unaligned-32 (Failed)
        2954 - watchpoint_unaligned-32-no-syscallbuf (Failed)
        2955 - when_threads-32 (Failed)
        2956 - when_threads-32-no-syscallbuf (Failed)
        2989 - breakpoint_print-32 (Failed)
        2990 - breakpoint_print-32-no-syscallbuf (Failed)
        3191 - when-32 (Failed)
        3192 - when-32-no-syscallbuf (Failed)
```
