### PR TITLE
Support Intel ArrowLake of 0xc0650

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -118,6 +118,7 @@ static CpuMicroarch compute_cpu_microarch() {
       return IntelLunarLake;
     case 0xb06e0:
       return IntelGracemont;
+    case 0xc0650:
     case 0xc0660:
       return IntelArrowLake;
     case 0xf20:  // Piledriver


### PR DESCRIPTION
Enable rr work on Intel® Core™ Ultra 5 Processor 225H, which code is `0xc0650`.

The code name is Arrow Lake, which could be found at [Ultra 5 Processor 225H ](https://www.intel.cn/content/www/cn/zh/products/sku/241749/intel-core-ultra-5-processor-225h-18m-cache-up-to-4-90-ghz/specifications.html)