### PR TITLE
add support for AMD Strix Halo (Ryzen AI Max+ 395)

### DIFF
--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -169,6 +169,7 @@ static CpuMicroarch compute_cpu_microarch() {
     case 0x70f50: // Hawk Point (Zen 4)
       return AMDZen4;
     case 0x20f40: // Strix Point (Zen 5)
+    case 0x70f00: // Strix Halo (Zen 5)
       return AMDZen5;
     default:
       break;


### PR DESCRIPTION
I have a Ryzen AI Max+ 395 CPU (Zen 5), rr currently does not detect it

`FATAL ./src/PerfCounters_x86.h:153:compute_cpu_microarch()] AMD CPU type 0x70f00 (ext family 0xb) unknown`

```
cat /proc/cpuinfo|head
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 26
model		: 112
model name	: AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
stepping	: 0
microcode	: 0xb700032
```

This patch adds support to recognize this CPU.

rr seems to work, but I ran the tests and not all passed:

Some of the test failures seem unrelated to performance counters. Are test failures expected? Do some tests require elevated permissions to pass?
```
98% tests passed, 57 tests failed out of 3196

Total Test time (real) = 3777.25 sec

The following tests FAILED:
	 47 - bpf_prog_map (Failed)
	 48 - bpf_prog_map-no-syscallbuf (Failed)
	 49 - bpf_query (Failed)
	 50 - bpf_query-no-syscallbuf (Failed)
	215 - fsmount (Failed)
	216 - fsmount-no-syscallbuf (Failed)
	417 - mount_ns_exec (Failed)
	418 - mount_ns_exec-no-syscallbuf (Failed)
	419 - mount_ns_exec2 (Failed)
	420 - mount_ns_exec2-no-syscallbuf (Failed)
	421 - mount_ns_execveat (Failed)
	422 - mount_ns_execveat-no-syscallbuf (Failed)
	467 - netfilter (Failed)
	468 - netfilter-no-syscallbuf (Failed)
	469 - netfilter_ipv6 (Failed)
	470 - netfilter_ipv6-no-syscallbuf (Failed)
	509 - pid_ns_kill_threads (Failed)
	510 - pid_ns_kill_threads-no-syscallbuf (Failed)
	517 - pid_ns_shutdown (Failed)
	518 - pid_ns_shutdown-no-syscallbuf (Failed)
	537 - prctl_caps (Failed)
	538 - prctl_caps-no-syscallbuf (Failed)
	547 - privileged_net_ioctl (Failed)
	548 - privileged_net_ioctl-no-syscallbuf (Failed)
	895 - tun (Failed)
	896 - tun-no-syscallbuf (Failed)
	913 - unshare (Failed)
	914 - unshare-no-syscallbuf (Failed)
	1645 - bpf_prog_map-32 (Failed)
	1646 - bpf_prog_map-32-no-syscallbuf (Failed)
	1647 - bpf_query-32 (Failed)
	1648 - bpf_query-32-no-syscallbuf (Failed)
	1760 - exec_from_other_thread-32-no-syscallbuf (Failed)
	1813 - fsmount-32 (Failed)
	1814 - fsmount-32-no-syscallbuf (Failed)
	2015 - mount_ns_exec-32 (Failed)
	2016 - mount_ns_exec-32-no-syscallbuf (Failed)
	2017 - mount_ns_exec2-32 (Failed)
	2018 - mount_ns_exec2-32-no-syscallbuf (Failed)
	2019 - mount_ns_execveat-32 (Failed)
	2020 - mount_ns_execveat-32-no-syscallbuf (Failed)
	2065 - netfilter-32 (Failed)
	2066 - netfilter-32-no-syscallbuf (Failed)
	2067 - netfilter_ipv6-32 (Failed)
	2068 - netfilter_ipv6-32-no-syscallbuf (Failed)
	2107 - pid_ns_kill_threads-32 (Failed)
	2108 - pid_ns_kill_threads-32-no-syscallbuf (Failed)
	2115 - pid_ns_shutdown-32 (Failed)
	2116 - pid_ns_shutdown-32-no-syscallbuf (Failed)
	2135 - prctl_caps-32 (Failed)
	2136 - prctl_caps-32-no-syscallbuf (Failed)
	2145 - privileged_net_ioctl-32 (Failed)
	2146 - privileged_net_ioctl-32-no-syscallbuf (Failed)
	2493 - tun-32 (Failed)
	2494 - tun-32-no-syscallbuf (Failed)
	2511 - unshare-32 (Failed)
	2512 - unshare-32-no-syscallbuf (Failed)
```
