### PR TITLE
Support TCSETSW2 and TCSETSF2

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1984,6 +1984,8 @@ static Switchable prepare_ioctl(RecordTask* t,
       case IOCTL_MASK_SIZE(TUNSETVNETLE):
       case IOCTL_MASK_SIZE(TUNSETVNETBE):
       case IOCTL_MASK_SIZE(TCSETS2):
+      case IOCTL_MASK_SIZE(TCSETSW2):
+      case IOCTL_MASK_SIZE(TCSETSF2):
         return PREVENT_SWITCH;
       case IOCTL_MASK_SIZE(USBDEVFS_GETDRIVER):
         // Reads and writes its parameter despite not having the _IOC_READ bit.

--- a/src/test/ioctl_tty.c
+++ b/src/test/ioctl_tty.c
@@ -132,6 +132,8 @@ int main(void) {
                 tc2->c_iflag, tc2->c_oflag, tc2->c_cflag, tc2->c_lflag,
                 tc2->c_ispeed, tc2->c_ospeed);
   test_assert(0 == ioctl(fd, TCSETS2, tc2));
+  test_assert(0 == ioctl(fd, TCSETSW2, tc2));
+  test_assert(0 == ioctl(fd, TCSETSF2, tc2));
 
   // NB: leaving the TCSETS2 as the last word seems to mess up the terminal,
   // so fix it.


### PR DESCRIPTION
Recording seems to be broken on Fedora 43:

    [FATAL src/record_syscall.cc:6754:rec_process_syscall_arch()] 
     (task 35371 (rec:35371) at time 11696)
     -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result 0 (errno SUCCESS); Unknown ioctl(0x402c542c): type:0x54 nr:0x2c dir:0x1 size:44 addr:0x7ffcf79be4c0

I haven't tried pinpointing which component triggers this specifically, but `0x402c542c` is `TCSETSW2`.

[`man TCSETSW2`](https://manpages.opensuse.org/Tumbleweed/man-pages/TCSETSW2.2const.en.html) says:

    TCSETS Equivalent to tcsetattr(fd, TCSANOW, argp).

           Set the current serial port settings.

    TCSETSW
           Equivalent to tcsetattr(fd, TCSADRAIN, argp).

           Allow the output buffer to drain, and set the current serial port settings.

    TCSETSF
           Equivalent to tcsetattr(fd, TCSAFLUSH, argp).

           Allow the output buffer to drain, discard pending input, and set the current serial port settings.

    The  following  four ioctls are just like TCGETS, TCSETS, TCSETSW, TCSETSF, except that they take a struct termios2 * instead of a struct termios *. (...)

           TCGETS2
           TCSETS2
           TCSETSW2
           TCSETSF2

Given that `TCSETS2` is already supported by rr, listing `TCSETSW2` and `TCSETSF2` next to it seems to do the trick.
