### PR TITLE
Errors configuring & building RR: Fixes to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,17 +76,17 @@ add_definitions(-DRR_VERSION="${rr_VERSION_MAJOR}.${rr_VERSION_MINOR}.${rr_VERSI
 
 execute_process(
   COMMAND git rev-parse HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_REVISION
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 configure_file(
-  ${CMAKE_SOURCE_DIR}/src/git_revision.h.in
-  ${CMAKE_BINARY_DIR}/git_revision.h
+  "${PROJECT_SOURCE_DIR}/src/git_revision.h.in"
+  "${PROJECT_BINARY_DIR}/git_revision.h"
 )
 configure_file(
-  ${CMAKE_SOURCE_DIR}/src/extra_version_string.h.in
-  ${CMAKE_BINARY_DIR}/extra_version_string.h
+  "${PROJECT_SOURCE_DIR}/src/extra_version_string.h.in"
+  "${PROJECT_BINARY_DIR}/extra_version_string.h"
 )
 
 set(FLAGS_COMMON "-D_FILE_OFFSET_BITS=64 -pthread")
@@ -115,7 +115,7 @@ configure_file(src/preload/rr_page.ld.in src/preload/rr_page.ld @ONLY)
 include(CheckCCompilerFlag)
 CHECK_C_COMPILER_FLAG("-fmacro-prefix-map=foo=bar" SUPPORTS_MACRO_PREFIX_MAP)
 if (SUPPORTS_MACRO_PREFIX_MAP)
-  set(FLAGS_COMMON "${FLAGS_COMMON} -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=")
+  set(FLAGS_COMMON "${FLAGS_COMMON} -fmacro-prefix-map='${PROJECT_SOURCE_DIR}/'=")
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
@@ -484,8 +484,8 @@ set(RR_PAGE_SOURCE_FILES
 )
 add_library(rrpage)
 foreach(file ${RR_PAGE_FILES})
-  target_sources(rrpage PUBLIC "${CMAKE_SOURCE_DIR}/src/preload/${file}")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/src/preload/${file}"
+  target_sources(rrpage PUBLIC "${PROJECT_SOURCE_DIR}/src/preload/${file}")
+  set_source_files_properties("${PROJECT_SOURCE_DIR}/src/preload/${file}"
                               PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
 endforeach(file)
 
@@ -493,13 +493,13 @@ endforeach(file)
 # we want it to have the same SONAME as the real vDSO to trick things
 # like AddressSanitizer into recognising it as the vDSO.
 set_target_properties(rrpage PROPERTIES NO_SONAME ON)
-set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,${CMAKE_BINARY_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostdlib ${PRELOAD_LINK_FLAGS} -Wl,-z,max-page-size=${PRELOAD_LIBRARY_PAGE_SIZE} -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
-set_target_properties(rrpage PROPERTIES LINK_DEPENDS ${CMAKE_BINARY_DIR}/src/preload/rr_page.ld)
+set_target_properties(rrpage PROPERTIES LINK_FLAGS "-Wl,-T -Wl,'${PROJECT_BINARY_DIR}/src/preload/rr_page.ld' -Wl,--hash-style=both -nostdlib ${PRELOAD_LINK_FLAGS} -Wl,-z,max-page-size=${PRELOAD_LIBRARY_PAGE_SIZE} -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
+set_target_properties(rrpage PROPERTIES LINK_DEPENDS "${PROJECT_BINARY_DIR}/src/preload/rr_page.ld")
 # CMake seems to have trouble generating the link line without this
 set_target_properties(rrpage PROPERTIES LINKER_LANGUAGE C)
 
 add_custom_command(TARGET rrpage POST_BUILD
-                   COMMAND ${CMAKE_SOURCE_DIR}/src/preload/tweak_librrpage.py $<TARGET_FILE:rrpage> ${PRELOAD_LIBRARY_PAGE_SIZE})
+                   COMMAND "${PROJECT_SOURCE_DIR}/src/preload/tweak_librrpage.py" $<TARGET_FILE:rrpage> ${PRELOAD_LIBRARY_PAGE_SIZE})
 
 # Order matters here! syscall_hook.S must be immediately before syscallbuf.c,
 # raw_syscall.S must be before overrides.c, which must be last.
@@ -523,8 +523,8 @@ set(PRELOAD_SOURCE_FILES
 )
 add_library(rrpreload)
 foreach(file ${PRELOAD_FILES})
-  target_sources(rrpreload PUBLIC "${CMAKE_SOURCE_DIR}/src/preload/${file}")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/src/preload/${file}"
+  target_sources(rrpreload PUBLIC "${PROJECT_SOURCE_DIR}/src/preload/${file}")
+  set_source_files_properties("${PROJECT_SOURCE_DIR}/src/preload/${file}"
                               PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
 endforeach(file)
 set_target_properties(rrpreload PROPERTIES LINK_FLAGS "${PRELOAD_LINK_FLAGS} ${LINKER_FLAGS}")
@@ -545,8 +545,8 @@ if(RTLD_AUDIT)
   )
   add_library(rraudit)
   foreach(file ${AUDIT_FILES})
-    target_sources(rraudit PUBLIC "${CMAKE_SOURCE_DIR}/src/audit/${file}")
-    set_source_files_properties("${CMAKE_SOURCE_DIR}/src/audit/${file}"
+    target_sources(rraudit PUBLIC "${PROJECT_SOURCE_DIR}/src/audit/${file}")
+    set_source_files_properties("${PROJECT_SOURCE_DIR}/src/audit/${file}"
                                 PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
   endforeach(file)
   set_target_properties(rraudit PROPERTIES LINK_FLAGS "${PRELOAD_LINK_FLAGS} -ldl ${LINKER_FLAGS}")
@@ -918,12 +918,12 @@ if(rr_32BIT AND rr_64BIT)
   endforeach(file)
 
   set_target_properties(rrpage_32 PROPERTIES NO_SONAME ON)
-  set_target_properties(rrpage_32 PROPERTIES LINK_FLAGS "-m32 -Wl,-T -Wl,${CMAKE_BINARY_DIR}/src/preload/rr_page.ld -Wl,--hash-style=both -nostdlib ${PRELOAD_LINK_FLAGS} -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
-  set_target_properties(rrpage_32 PROPERTIES LINK_DEPENDS ${CMAKE_BINARY_DIR}/src/preload/rr_page.ld)
+  set_target_properties(rrpage_32 PROPERTIES LINK_FLAGS "-m32 -Wl,-T -Wl,'${PROJECT_BINARY_DIR}/src/preload/rr_page.ld' -Wl,--hash-style=both -nostdlib ${PRELOAD_LINK_FLAGS} -Wl,-soname,linux-vdso.so.1 ${LINKER_FLAGS}")
+  set_target_properties(rrpage_32 PROPERTIES LINK_DEPENDS "${PROJECT_BINARY_DIR}/src/preload/rr_page.ld")
   set_target_properties(rrpage_32 PROPERTIES LINKER_LANGUAGE C)
 
   add_custom_command(TARGET rrpage_32 POST_BUILD
-                    COMMAND ${CMAKE_SOURCE_DIR}/src/preload/tweak_librrpage.py $<TARGET_FILE:rrpage_32> ${PRELOAD_LIBRARY_PAGE_SIZE})
+                    COMMAND "${PROJECT_SOURCE_DIR}/src/preload/tweak_librrpage.py" $<TARGET_FILE:rrpage_32> ${PRELOAD_LIBRARY_PAGE_SIZE})
 
 
   add_library(rrpreload_32)


### PR DESCRIPTION
Make use of PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR. If RR is to be built by a consuming application, PROJECT_SOURCE_DIR points to actual directory where sources are (so, CMAKE_SOURCE_DIR shouldn't really be used afaict).

Additionally, we also need to properly quote paths (used by both PROJECT_SOURCE_DIR and CMAKE_SOURCE_DIR). If there's a directory with spaces in it, rr will not configure or build.