### PR TITLE
Fix resolve_address to account for multiple mappings of the same file…

### DIFF
--- a/src/ElfReader.h
+++ b/src/ElfReader.h
@@ -74,6 +74,13 @@ struct SectionOffsets {
   bool compressed;
 };
 
+struct PhdrInfo {
+  uint64_t vaddr;
+  uint64_t offset;
+  uint64_t filesz;
+  uint64_t flags;
+};
+
 class ElfReader {
 public:
   ElfReader(SupportedArch arch);
@@ -102,11 +109,11 @@ public:
   Debugaltlink read_debugaltlink();
   std::string read_buildid();
   std::string read_interp();
-  // Returns true and sets file |offset| if ELF address |addr| is mapped from
-  // a section in the ELF file.  Returns false if no section maps to
-  // |addr|.  |addr| is an address indicated by the ELF file, not its
-  // relocated address in memory.
-  bool addr_to_offset(uintptr_t addr, uintptr_t& offset);
+  // Returns true if ELF address |addr| is mapped from a program header in the
+  // ELF file, and sets the fields of |phdr| to the program header fields.
+  // Returns false if no program header maps to |addr|. |addr| is an address
+  // indicated by the ELF file, not its relocated address in memory.
+  bool addr_to_phdr(uintptr_t addr, PhdrInfo& phdr);
   SectionOffsets find_section_file_offsets(const char* name);
   DwarfSpan dwarf_section(const char* name, bool known_to_be_compressed = false);
   SupportedArch arch() const { return arch_; }

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -118,7 +118,8 @@ public:
    * patch libpthread.so.
    */
   void patch_after_mmap(RecordTask* t, remote_ptr<void> start, size_t size,
-                        size_t offset_bytes, int child_fd, MmapMode mode);
+                        size_t offset_bytes, uint64_t prot, int child_fd,
+                        MmapMode mode);
 
   /**
    * The list of pages we've allocated to hold our extended jumps.
@@ -153,15 +154,14 @@ public:
 
 private:
   void patch_dl_runtime_resolve(RecordTask* t, ElfReader& reader,
-                                uintptr_t elf_addr,
-                                remote_ptr<void> map_start,
-                                size_t map_size,
-                                size_t map_offset);
+                                uintptr_t elf_addr, remote_ptr<void> map_start,
+                                size_t map_size, size_t map_offset,
+                                uint64_t prot);
   void patch_aarch64_have_lse_atomics(RecordTask* t, ElfReader& reader,
                                       uintptr_t elf_addr,
                                       remote_ptr<void> map_start,
-                                      size_t map_size,
-                                      size_t map_offset);
+                                      size_t map_size, size_t map_offset,
+                                      uint64_t prot);
 
   /**
    * `ip` is the address of the instruction that triggered the syscall or trap

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -6394,7 +6394,7 @@ static void process_mmap(RecordTask* t, size_t length, int prot, int flags,
   // at an assertion, in the worst case, we'd end up modifying the underlying
   // file.
   if (!(flags & MAP_SHARED)) {
-    t->vm()->monkeypatcher().patch_after_mmap(t, addr, size, offset, fd,
+    t->vm()->monkeypatcher().patch_after_mmap(t, addr, size, offset, prot, fd,
                                               Monkeypatcher::MMAP_SYSCALL);
   }
 


### PR DESCRIPTION
… offset

Some linkers such as lld will create program headers with multiple mappings of the same file offset. This can lead to problems when a symbol of interest to rr, such as __aarch64_ldadd4_relax, is covered by more than one mapping, as that will lead to us finding the function in multiple mappings. For that symbol in particular, we can end up misinterpreting the instructions in the wrong mapping and incorrectly computing an address to write to, which can lead to an assertion failure, or worse, silent memory corruption. Fix it by changing resolve_address to check whether the mapping is the correct one (fully covers the appropriate program header and has the same memory permissions) before returning the address.