### PR TITLE
Fix out-of-bounds access in AVX register handling on some CPUs

### DIFF
--- a/src/ExtraRegisters.cc
+++ b/src/ExtraRegisters.cc
@@ -101,6 +101,10 @@ struct RegisterDescriptor {
   }
 
   bool describes_register(GdbServerRegister gdb_register) const {
+    const auto& layout = xsave_native_layout();
+    if (!(layout.supported_feature_bits & (1ULL << feature))) {
+      return false;
+    }
     // compare end first because we search table linerarly.
     return gdb_register <= end_inclusive && gdb_register >= base;
   }


### PR DESCRIPTION
For cpu like intel N5095, `supported_feature_bits ` is 0b11, it doesn't support any AVX.
https://github.com/rr-debugger/rr/blob/18077ca9e95eea3e4aeac0af059d147ed027f0ba/src/ExtraRegisters.cc#L139-L154
https://github.com/rr-debugger/rr/blob/18077ca9e95eea3e4aeac0af059d147ed027f0ba/src/ExtraRegisters.cc#L96-L101

So `layout.feature_layouts[feature]` above will make out-of-bounds access if `feature` is 2.

Any better solutions to fix this?