### PR TITLE
Fix FATAL message for PERF_EVENT_IOC_DISABLE.

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -802,7 +802,7 @@ static void infallible_perf_event_enable_if_open(ScopedFd& fd) {
 static void infallible_perf_event_disable_if_open(ScopedFd& fd) {
   if (fd.is_open()) {
     if (ioctl(fd, PERF_EVENT_IOC_DISABLE, 0)) {
-      FATAL() << "ioctl(PERF_EVENT_IOC_ENABLE) failed";
+      FATAL() << "ioctl(PERF_EVENT_IOC_DISABLE) failed";
     }
   }
 }


### PR DESCRIPTION
infallible_perf_event_disable_if_open() reported ioctl(PERF_EVENT_IOC_ENABLE) on failure; the ioctl call is PERF_EVENT_IOC_DISABLE.