### PR TITLE
Set len in the ethtool_gstrings struct in sioc test.

### DIFF
--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -341,6 +341,7 @@ static void ethtool(int sockfd, struct ifreq* req) {
         struct ethtool_gstrings* et_gstrings = (struct ethtool_gstrings*)buf;
         et_gstrings->cmd = ETHTOOL_GSTRINGS;
         et_gstrings->string_set = i;
+        et_gstrings->len = len;
         req->ifr_data = buf;
         ret = ioctl(sockfd, SIOCETHTOOL, req);
         VERIFY_GUARD(req);
@@ -353,8 +354,8 @@ static void ethtool(int sockfd, struct ifreq* req) {
         } else {
           uint32_t j;
           for (j = 0; j < len; ++j) {
-            atomic_printf("Group %d string %d: %s\n",
-                          i, j, buf + sizeof(struct ethtool_gstrings) + j*ETH_GSTRING_LEN);
+            atomic_printf("Group %d string %d: %.*s\n",
+                          i, j, ETH_GSTRING_LEN, buf + sizeof(struct ethtool_gstrings) + j*ETH_GSTRING_LEN);
           }
         }
       }


### PR DESCRIPTION
I finally ran the tests again, and found the sioc test fail. They crash already without running in rr.
It looks like currently `et_gstrings->len` stays at 0x6f6f6f6f when calling the ioctl, and it returns with it set to zero.
The seems to happen because atomic_printf wants to read beyond the mapped memory, because no string
termination is found.

This may be a change from kernel side as I recently switched to `6.19.6-2~bpo13+1`, but I seem to never have
run the tests with the 6.12 default kernel in debian-13-trixie.
With the 6.1.129-1 from debian-12-bookworm it did not crash.

This patch only sets the len to the amount of elements for which we reserved memory.
And limits the atomic_printf to only read a maximum of ETH_GSTRING_LEN for each element.

```gdb
$ gdb -q --args bin/sioc
Reading symbols from bin/sioc...
(gdb) b 345
Breakpoint 1 at 0x2e3c: file src/test/sioc.c, line 345.
(gdb) run
Starting program: obj/bin/sioc 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
SIOCGIFCONF(ret 0): 2 ifaces (80 bytes of ifreq)
  iface 0: name:lo addr:127.0.0.1
  iface 1: name:enp7s0 addr:**************
SIOCGIFINDEX(ret:0): enp7s0 index is 2
SIOCGIFNAME(ret:0): index 2(enp7s0) name is enp7s0
SIOCGIFFLAGS(ret:0): enp7s0 flags are 0x1043
SIOCGIFADDR(ret:0): enp7s0 addr is **************
SIOCGIFDSTADDR(ret:0): enp7s0 addr is **************
SIOCGIFBRDADDR(ret:0): enp7s0 addr is **************
SIOCGIFNETMASK(ret:0): enp7s0 netmask is 255.255.255.0
SIOCGIFMETRIC(ret:0): enp7s0 metric is 0
SIOCGIFMAP(ret:0): enp7s0 map is 0,0,0,0,0,0
SIOCGIFMTU(ret:0): enp7s0 MTU is 1500
SIOCGIFHWADDR(ret:0): enp7s0 hwaddr *****************
SIOCGIFTXQLEN(ret:0): enp7s0 qlen is 1000
SIOCETHTOOL(ret:0) ETHTOOL_GSET: enp7s0 ethtool data: speed:0x3e8 duplex:0x1 port:0 physaddr:0, maxtxpkt:0 maxrxpkt:0 ...
SIOCETHTOOL(ret:0) ETHTOOL_GDRVINFO: enp7s0 ethtool data: driver:r8169 version:6.19.6+deb13-amd64 fw_version:rtl8168h-2_0.0.2 02/26/15 bus_info:0000:07:00.0 erom_version:
SIOCETHTOOL(ret:-1) ETHTOOL_GWOL: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GWOL
SIOCETHTOOL(ret:-1) ETHTOOL_GREGS: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GREGS
SIOCETHTOOL(ret:-1) ETHTOOL_GEEPROM: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GEEPROM
SIOCETHTOOL(ret:-1) ETHTOOL_GMODULEEEPROM: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GMODULEEEPROM
SIOCETHTOOL(ret:0) ETHTOOL_GEEE: enp7s0 ethtool data: tx_lpi_timer:12 enabled:1
SIOCETHTOOL(ret:-1) ETHTOOL_GMODULEINFO: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GMODULEINFO
SIOCETHTOOL(ret:0) ETHTOOL_GCOALESCE: enp7s0 ethtool data: rx_coalesce_usecs:0 tx_coalesce_usecs:0
SIOCETHTOOL(ret:0) ETHTOOL_GRINGPARAM: enp7s0 ethtool data: rx_max_pending:256 rx_pending:256 tx_max_pending:256 tx_pending:256
SIOCETHTOOL(ret:-1) ETHTOOL_GCHANNELS: enp7s0 ethtool data: WARNING: enp7s0 doesn't appear to support SIOCETHTOOL ETHTOOL_GCHANNELS
SIOCETHTOOL(ret:0) ETHTOOL_GPAUSEPARAM: enp7s0 ethtool data: rx_pause:0 tx_pause:0
SIOCETHTOOL(ret:0) ETHTOOL_GSSET_INFO: enp7s0 ethtool data: 

Breakpoint 1, ethtool (sockfd=3, req=0x7ffff7fb9fd8) at src/test/sioc.c:345
345             ret = ioctl(sockfd, SIOCETHTOOL, req);
(gdb) print et_gstrings
$1 = (struct ethtool_gstrings *) 0x7ffff7f99e54
(gdb) print/x *et_gstrings
$2 = {cmd = 0x1b, string_set = 0x1, len = 0x6f6f6f6f, data = 0x7ffff7f99e60}
(gdb) cont
Continuing.
SIOCETHTOOL(ret:0) ETHTOOL_GSTRINGS: enp7s0 ethtool data: 
Program received signal SIGSEGV, Segmentation fault.
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:292
warning: 292    ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory
(gdb) display/i $pc
1: x/i $pc
=> 0x7ffff7ef18c0 <__strlen_avx2+192>:  vmovdqa 0x1(%rdi),%ymm1
(gdb) print/x $rdi
$3 = 0x7ffff7f99fff
(gdb) up
#1  0x00007ffff7df0300 in __printf_buffer (buf=buf@entry=0x7fffffffbe80, format=0x555555558b94 "Group %d string %d: %s\n", ap=0x7fffffffc350, mode_flags=mode_flags@entry=0) at ./stdio-common/vfprintf-process-arg.c:435
warning: 435    ./stdio-common/vfprintf-process-arg.c: No such file or directory
(gdb) up
#2  0x00007ffff7e13e5e in __vsnprintf_internal (string=<optimized out>, maxlen=<optimized out>, format=<optimized out>, args=<optimized out>, mode_flags=0) at ./libio/vsnprintf.c:96
warning: 96     ./libio/vsnprintf.c: No such file or directory
(gdb) up
#3  ___vsnprintf (string=<optimized out>, maxlen=<optimized out>, format=<optimized out>, args=<optimized out>) at ./libio/vsnprintf.c:103
103     in ./libio/vsnprintf.c
(gdb) up
#4  0x00005555555552f1 in atomic_printf (fmt=0x555555558b94 "Group %d string %d: %s\n") at src/test/util.h:159
159       len = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
(gdb) up
#5  0x0000555555556f4c in ethtool (sockfd=3, req=0x7ffff7fb9fd8) at src/test/sioc.c:356
356                 atomic_printf("Group %d string %d: %s\n",
(gdb) list
351               atomic_printf("WARNING: %s doesn't appear to support SIOCETHTOOL ETHTOOL_GSTRINGS\n", req->ifr_name);
352               test_assert(EOPNOTSUPP == err || EPERM == err);
353             } else {
354               uint32_t j;
355               for (j = 0; j < len; ++j) {
356                 atomic_printf("Group %d string %d: %s\n",
357                               i, j, buf + sizeof(struct ethtool_gstrings) + j*ETH_GSTRING_LEN);
358               }
359             }
360           }
(gdb) print size
$4 = 428
(gdb) x/428xc buf
0x7ffff7f99e54: 27 '\033'       0 '\000'        0 '\000'        0 '\000'        1 '\001'        0 '\000'        0 '\000'        0 '\000'
0x7ffff7f99e5c: 0 '\000'        0 '\000'        0 '\000'        0 '\000'        111 'o' 111 'o' 111 'o' 111 'o'
0x7ffff7f99e64: 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o'
0x7ffff7f99e6c: 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o'
...
0x7ffff7f99ff4: 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o' 111 'o'
0x7ffff7f99ffc: 111 'o' 111 'o' 111 'o' 111 'o'
(gdb) print/x *et_gstrings
$5 = {cmd = 0x1b, string_set = 0x1, len = 0x0, data = 0x7ffff7f99e60}
(gdb) 
```