### PR TITLE
Avoid warning about variable getting used uninitialized.

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1931,6 +1931,9 @@ template <> bool set_debug_regs_arch<X64Arch>(Task* t,
 static void query_max_bp_wp(Task* t, ssize_t* max_bp, ssize_t* max_wp) {
   ARM64Arch::user_hwdebug_state bps;
   ARM64Arch::user_hwdebug_state wps;
+  memset(&bps, 0, sizeof(bps));
+  memset(&wps, 0, sizeof(wps));
+
   bool ok = t->get_aarch64_debug_regs(NT_ARM_HW_BREAK, &bps) &&
             t->get_aarch64_debug_regs(NT_ARM_HW_WATCH, &wps);
   ASSERT(t, ok);


### PR DESCRIPTION
```
src/Task.cc:1938:17: warning: ‘wps.rr::ARM64Arch::user_hwdebug_state::dbg_info’ may be used uninitialized [-Wmaybe-uninitialized]
 1938 |   *max_wp = wps.dbg_info & 0xff;
      |             ~~~~^~~~~~~~
```