### PR TITLE
Add at least the first two feature_layouts in xsave_layout_from_trace.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1635,6 +1635,10 @@ XSaveLayout xsave_layout_from_trace(const std::vector<CPUIDRecord> records) {
   layout.supported_feature_bits =
       cpuid_data.out.eax | (uint64_t(cpuid_data.out.edx) << 32);
 
+  // Add at least the first two entries in case there are no feature_bits set above 2
+  while (layout.feature_layouts.size() < 2) {
+    layout.feature_layouts.push_back({ 0, 0 });
+  }
   for (size_t i = 2; i < 64; ++i) {
     if (layout.supported_feature_bits & (uint64_t(1) << i)) {
       do {


### PR DESCRIPTION
This fixes a regression introduced by 2c1d0b2377,
which gets only visible if no supported_feature_bits are set above the first two bits,
which is the case for a Intel Pentium B950 from 2011. There it surfaces in the tcp_sockets test, with the dump crashing.

Backtrace of the SIGSEGV and some notes I took are in attached file:
[debugging.txt](https://github.com/user-attachments/files/27140033/debugging.txt)

CC: @theIDinside 