### PR TITLE
Fix 32-bit readv/writev tests.

### DIFF
--- a/src/test/readv.c
+++ b/src/test/readv.c
@@ -29,9 +29,9 @@ static void test(int mode) {
   iovs[1].iov_len = sizeof(*part2);
   if (mode == 1) {
     /* Work around busted preadv prototype in older libcs */
-    nread = syscall(SYS_preadv, fd, iovs, 2, (off_t)0, 0);
+    nread = syscall(SYS_preadv, fd, iovs, 2, 0, 0);
   } else if (mode == 2) {
-    nread = syscall(SYS_preadv2, fd, iovs, 2, (off_t)0, 0, 0);
+    nread = syscall(SYS_preadv2, fd, iovs, 2, 0, 0, 0);
   } else {
     test_assert(0 == lseek(fd, 0, SEEK_SET));
     nread = readv(fd, iovs, 2);
@@ -65,7 +65,7 @@ int main(void) {
     test_assert(0 == unlink("temp2"));
     iov.iov_base = &buf;
     iov.iov_len = 1;
-    ret = syscall(SYS_preadv2, fd, &iov, 1, (off_t)0, 0, 0x40000000);
+    ret = syscall(SYS_preadv2, fd, &iov, 1, 0, 0, 0x40000000);
     test_assert(ret == -1 && errno == EINVAL);
     close(fd);
   }

--- a/src/test/writev.c
+++ b/src/test/writev.c
@@ -23,9 +23,9 @@ static void test(int mode) {
   iovs[1].iov_len = sizeof(data) - iovs[0].iov_len;
   if (mode == 1) {
     /* Work around busted pwritev prototype in older libcs */
-    nwritten = syscall(SYS_pwritev, fd, iovs, 2, (off_t)0, 0);
+    nwritten = syscall(SYS_pwritev, fd, iovs, 2, 0, 0);
   } else if (mode == 2) {
-    nwritten = syscall(SYS_pwritev2, fd, iovs, 2, (off_t)0, 0, 0);
+    nwritten = syscall(SYS_pwritev2, fd, iovs, 2, 0, 0, 0);
   } else {
     nwritten = writev(fd, iovs, 2);
   }
@@ -58,9 +58,9 @@ int main(void) {
     test_assert(0 == unlink("temp2"));
     iov.iov_base = &buf;
     iov.iov_len = 1;
-    ret = syscall(SYS_pwritev2, fd, &iov, 1, (off_t)0, 0, 0x10 /*RWF_APPEND*/);
+    ret = syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, 0x10 /*RWF_APPEND*/);
     test_assert(ret == -1 && errno == EINVAL);
-    ret = syscall(SYS_pwritev2, fd, &iov, 1, (off_t)0, 0, 0x40000000);
+    ret = syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, 0x40000000);
     test_assert(ret == -1 && errno == EINVAL);
     close(fd);
   }


### PR DESCRIPTION
In the tests the type off_t is 8 bytes in 32-bit and 64-bit. Therefore in 32-bit in rec_prepare_syscall_arch the regs.arg6 contains not the invalid parameter, therefore the "return reject_preadv2_pwritev2" is not reached.

Followup of 95b6860724.

CC: @azat 