### PR TITLE
test/util.h: include limits.h

### DIFF
--- a/src/test/util.h
+++ b/src/test/util.h
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <linux/aio_abi.h>
 #include <linux/audit.h>
 #include <linux/capability.h>


### PR DESCRIPTION
This is needed for _MAX constants; it used to be included through the kernel UAPI (linux/ethtool.h) but the latter has been fixed to no longer rely on the C library's limits.h. See
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e8c6888e177c5ae0e09e184f51bf60d28bb49a34 for details.