### PR TITLE
Avoid leak in check_outside_mappings.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -6326,6 +6326,7 @@ static void check_outside_mappings(const KernelMapping& tracee_km, const RecordS
           printf("rr: Warning: Mapping of file %s could cause diversion when replaying, "
                  "because pid=%d has mapped it outside of the recording.\n",
                  km.fsname().c_str(), pid);
+          closedir(proc);
           return;
         }
       }


### PR DESCRIPTION
When I tried to update my ASan branch I received this report in the mmap_shared_extern test, unfortunately missing the important lines, but with this patch the report disappears:
```
==460704==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32816 byte(s) in 1 object(s) allocated from:
    #0 0x7f8d926f4c57 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f8d91ff89c4 in __alloc_dir ../sysdeps/unix/sysv/linux/opendir.c:115

SUMMARY: AddressSanitizer: 32816 byte(s) leaked in 1 allocation(s).
```