### PR TITLE
Add informational commands: absolute-time, when-end, info recording

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1605,6 +1605,7 @@ set(TESTS_WITH_PROGRAM
   ignored_sigsegv
   ignore_nested
   immediate_restart
+  info_recording
   x86/int3_ok
   interrupt
   intr_ptrace_decline

--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -3,7 +3,9 @@
 #include "DebuggerExtensionCommand.h"
 
 #include "ReplayTask.h"
+#include "TraceFrame.h"
 #include "log.h"
+#include "util.h"
 
 using namespace std;
 
@@ -23,6 +25,21 @@ static SimpleDebuggerExtensionCommand elapsed_time(
                             replay_t->session().get_trace_start_time();
 
       return string("Elapsed Time (s): ") + to_string(elapsed_time);
+    });
+
+static SimpleDebuggerExtensionCommand absolute_time(
+    "absolute-time",
+    "Print absolute time (in seconds) from the monotonic clock in the"
+    " 'record' timeline.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      if (!t->session().is_replaying()) {
+        return DebuggerExtensionCommandHandler::cmd_end_diversion();
+      }
+
+      ReplayTask* replay_t = static_cast<ReplayTask*>(t);
+      double elapsed_time = replay_t->session().get_trace_start_time();
+
+      return string("Absolute Time (s): ") + to_string(elapsed_time);
     });
 
 static SimpleDebuggerExtensionCommand when(
@@ -54,6 +71,41 @@ static SimpleDebuggerExtensionCommand when_tid(
         return DebuggerExtensionCommandHandler::cmd_end_diversion();
       }
       return string("Current tid: ") + to_string(t->tid);
+    });
+
+static SimpleDebuggerExtensionCommand when_end(
+    "when-end", "Print the number of the last rr event in the recording.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      if (!t->session().is_replaying()) {
+        return DebuggerExtensionCommandHandler::cmd_end_diversion();
+      }
+
+      ReplayTask* task = static_cast<ReplayTask*>(t);
+      TraceReader seek_reader(task->session().as_replay()->trace_reader());
+      FrameTime time;
+      for (;;) {
+        auto result = seek_reader.read_task_event(&time);
+        if (result.type() == TraceTaskEvent::Type::NONE) {
+          break;
+        }
+      }
+      return string("Event at end of Recording: ") + to_string(time);
+    });
+
+static SimpleDebuggerExtensionCommand info_recording(
+    "info recording",
+    "Print the path of the recording RR is"
+    " currently replaying.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      if (!t->session().is_replaying()) {
+        return DebuggerExtensionCommandHandler::cmd_end_diversion();
+      }
+
+      ReplayTask* task = static_cast<ReplayTask*>(t);
+      auto trace_dir = task->session().as_replay()->trace_reader().dir();
+
+      return string("Path of Recording: \"") + json_escape(trace_dir) +
+             string("\"");
     });
 
 static std::vector<ReplayTimeline::Mark> back_stack;

--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -89,7 +89,7 @@ static SimpleDebuggerExtensionCommand when_end(
           break;
         }
       }
-      return string("Event at end of Recording: ") + to_string(time);
+      return string("Event at end of recording: ") + to_string(time);
     });
 
 static SimpleDebuggerExtensionCommand info_recording(
@@ -104,8 +104,7 @@ static SimpleDebuggerExtensionCommand info_recording(
       auto task = static_cast<ReplayTask*>(t);
       auto trace_dir = task->session().as_replay()->trace_reader().dir();
 
-      return string("Path of Recording: \"") + json_escape(trace_dir) +
-             string("\"");
+      return string("Path of recording: \"") + json_escape(trace_dir) + string("\"");
     });
 
 static std::vector<ReplayTimeline::Mark> back_stack;

--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -36,8 +36,8 @@ static SimpleDebuggerExtensionCommand absolute_time(
         return DebuggerExtensionCommandHandler::cmd_end_diversion();
       }
 
-      ReplayTask* replay_t = static_cast<ReplayTask*>(t);
-      double elapsed_time = replay_t->session().get_trace_start_time();
+      auto replay_t = static_cast<ReplayTask*>(t);
+      auto elapsed_time = replay_t->current_trace_frame().monotonic_time();
 
       return string("Absolute Time (s): ") + to_string(elapsed_time);
     });
@@ -80,8 +80,8 @@ static SimpleDebuggerExtensionCommand when_end(
         return DebuggerExtensionCommandHandler::cmd_end_diversion();
       }
 
-      ReplayTask* task = static_cast<ReplayTask*>(t);
-      TraceReader seek_reader(task->session().as_replay()->trace_reader());
+      auto task = static_cast<ReplayTask*>(t);
+      auto seek_reader(task->session().as_replay()->trace_reader());
       FrameTime time;
       for (;;) {
         auto result = seek_reader.read_task_event(&time);
@@ -101,7 +101,7 @@ static SimpleDebuggerExtensionCommand info_recording(
         return DebuggerExtensionCommandHandler::cmd_end_diversion();
       }
 
-      ReplayTask* task = static_cast<ReplayTask*>(t);
+      auto task = static_cast<ReplayTask*>(t);
       auto trace_dir = task->session().as_replay()->trace_reader().dir();
 
       return string("Path of Recording: \"") + json_escape(trace_dir) +

--- a/src/test/elapsed_time.py
+++ b/src/test/elapsed_time.py
@@ -1,5 +1,24 @@
+import time
+
 from util import *
 import re
+
+# Get monotonic timer value from right now
+monotonic_start = time.monotonic()
+
+send_gdb("absolute-time")
+expect_gdb(re.compile(r'(?<=Absolute Time \(s\): )[0-9.]+'))
+absolute_time_start = float(last_match().group(0))
+
+if absolute_time_start > monotonic_start:
+    failed("ERROR ... The reported monotonic time at the start was after the test script started")
+if absolute_time_start < monotonic_start - 300:
+    failed("ERROR ... The reported monotonic time at the start was over five minutes before the test script started")
+
+send_gdb('elapsed-time')
+
+expect_gdb(re.compile(r'(?<=Elapsed Time \(s\): )[0-9.]+'))
+elapsed_start = float(last_match().group(0))
 
 # Test that the elapsed-time GDB command returns a time >= 1.0 at a breakpoint
 # after sleep(1);
@@ -17,5 +36,15 @@ sleep_time = 1.0
 if elapsed_time < sleep_time:
     failed('ERROR ... The reported elapsed time after sleeping for ' +
            f'{sleep_time} (s) was {elapsed_time}')
+
+send_gdb("absolute-time")
+expect_gdb(re.compile(r'(?<=Absolute Time \(s\): )[0-9.]+'))
+absolute_time_end = float(last_match().group(0))
+
+sleep_time_absolute = absolute_time_end - absolute_time_start
+sleep_time_relative = elapsed_time - elapsed_start
+
+if abs(sleep_time_absolute - sleep_time_relative) > 0.0001:
+    failed(f"ERROR ... The sleep time reported by absolute-time vs elapsed-time was too far apart (should be as equal as double allows): {sleep_time_absolute} - {sleep_time_relative} = {sleep_time_absolute - sleep_time_relative}" )
 
 ok()

--- a/src/test/info_recording.c
+++ b/src/test/info_recording.c
@@ -1,0 +1,12 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(int argc, char *argv[]) {
+  if (argc <= 1) {
+    atomic_puts("Hi");
+  } else {
+    atomic_puts(argv[1]);
+  }
+  return 0;
+}

--- a/src/test/info_recording.py
+++ b/src/test/info_recording.py
@@ -1,0 +1,19 @@
+from util import *
+
+import re
+import json
+
+send_gdb('info recording')
+expect_gdb(re.compile(r'(?<=Path of Recording: ).*'))
+path_jsonstr = last_match().group(0)
+path_pystr   = json.loads(path_jsonstr)
+
+if len(path_pystr) < 6:
+    failed("ERROR ... Unreasonably short path for recording file found in output")
+
+# Inferior command also has the name of the binary at the end,
+# so the pattern matches opening but not closing paren.
+send_gdb("inferior")
+expect_gdb(f"\\({path_pystr}")
+
+ok()

--- a/src/test/info_recording.py
+++ b/src/test/info_recording.py
@@ -4,7 +4,7 @@ import re
 import json
 
 send_gdb('info recording')
-expect_gdb(re.compile(r'(?<=Path of Recording: ).*'))
+expect_gdb(re.compile(r'(?<=Path of recording: ).*'))
 path_jsonstr = last_match().group(0)
 path_pystr   = json.loads(path_jsonstr)
 

--- a/src/test/info_recording.run
+++ b/src/test/info_recording.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh
+debug_test_gdb_only

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -1,6 +1,11 @@
 from util import *
 import re
 
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+first_when_end_result = int(last_match().group(1))
+# Check this value after running the program for a bit.
+
 send_custom_command('when')
 expect_debugger(re.compile(r'Completed event: (\d+)'))
 t = int(last_match().group(1))
@@ -43,6 +48,10 @@ tid2 = int(last_match().group(1))
 if tid2 != tid:
     failed('ERROR ... tid changed')
 
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+second_when_end_result = int(last_match().group(1))
+
 # Ensure 'when' terminates a diversion
 expect_expression('(int)strlen("abcd")', 4)
 send_custom_command('when')
@@ -64,5 +73,22 @@ expect_debugger(re.compile(r'Current tid: (\d+)'))
 tid3 = int(last_match().group(1))
 if tid3 != tid2:
     failed('ERROR ... diversion changed tid')
+
+send_custom_command("c")
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+final_when_end_result = int(last_match().group(1))
+
+if first_when_end_result != second_when_end_result:
+    failed("ERROR ... first when-end result differs from second when-end result")
+if second_when_end_result != final_when_end_result:
+    failed("ERROR ... second when-end result differs from final when-end result")
+
+if t >= first_when_end_result:
+    failed("ERROR ... First when result was after when-end")
+if t3 >= first_when_end_result:
+    failed("ERROR ... Second when result was after when-end")
+if t3 >= first_when_end_result:
+    failed("ERROR ... Third when result was after when-end")
 
 ok()

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -2,7 +2,7 @@ from util import *
 import re
 
 send_custom_command('when-end')
-expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
 first_when_end_result = int(last_match().group(1))
 # Check this value after running the program for a bit.
 
@@ -49,7 +49,7 @@ if tid2 != tid:
     failed('ERROR ... tid changed')
 
 send_custom_command('when-end')
-expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
 second_when_end_result = int(last_match().group(1))
 
 # Ensure 'when' terminates a diversion
@@ -76,7 +76,7 @@ if tid3 != tid2:
 
 send_custom_command("c")
 send_custom_command('when-end')
-expect_debugger(re.compile(r'Event at end of Recording: (\d+)'))
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
 final_when_end_result = int(last_match().group(1))
 
 if first_when_end_result != second_when_end_result:


### PR DESCRIPTION
absolute-time gives the absolute monotonic clock time from the current event.

This is useful when you want to align events with a perf recording that also uses the monotonic clock (you still have to scale by 1000000000 of course.)

when-end gives the event number of the last event in the whole recording.

This is useful when running a replay with non-stopping breakpoints and displaying the "progress" of the replay to the user.

info recording prints out the path of the recording folder.

This is useful for running additional `rr replay` sessions from an existing one, or for calling `rr dump` to get data that is not otherwise surfaced by any gdb commands.

The next thing I am going to do is write tests for these commands, but I'd like to already PR the changes to get feedback on whether the implementation and the names of the commands are OK.

Thanks!