### PR TITLE
Add "when-end" command to get the number of the last event

### DIFF
--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -80,6 +80,21 @@ static SimpleDebuggerExtensionCommand info_recording(
       return string("Path of recording: \"") + json_escape(trace_dir) + string("\"");
     });
 
+static SimpleDebuggerExtensionCommand when_end(
+    "when-end", "Print the number of the last rr event in the recording.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      auto task = static_cast<ReplayTask*>(t);
+      auto seek_reader(task->session().as_replay()->trace_reader());
+      FrameTime time;
+      for (;;) {
+        auto result = seek_reader.read_task_event(&time);
+        if (result.type() == TraceTaskEvent::Type::NONE) {
+          break;
+        }
+      }
+      return string("Event at end of recording: ") + to_string(time);
+    });
+
 static std::vector<ReplayTimeline::Mark> back_stack;
 static ReplayTimeline::Mark current_history_cp;
 static std::vector<ReplayTimeline::Mark> forward_stack;

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -1,6 +1,11 @@
 from util import *
 import re
 
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
+first_when_end_result = int(last_match().group(1))
+# Check this value after running the program for a bit.
+
 send_custom_command('when')
 expect_debugger(re.compile(r'Completed event: (\d+)'))
 t = int(last_match().group(1))
@@ -43,6 +48,10 @@ tid2 = int(last_match().group(1))
 if tid2 != tid:
     failed('ERROR ... tid changed')
 
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
+second_when_end_result = int(last_match().group(1))
+
 # Ensure 'when' terminates a diversion
 expect_expression('(int)strlen("abcd")', 4)
 send_custom_command('when')
@@ -64,5 +73,23 @@ expect_debugger(re.compile(r'Current tid: (\d+)'))
 tid3 = int(last_match().group(1))
 if tid3 != tid2:
     failed('ERROR ... diversion changed tid')
+
+stepi()
+
+send_custom_command('when-end')
+expect_debugger(re.compile(r'Event at end of recording: (\d+)'))
+final_when_end_result = int(last_match().group(1))
+
+if first_when_end_result != second_when_end_result:
+    failed("ERROR ... first when-end result differs from second when-end result")
+if second_when_end_result != final_when_end_result:
+    failed("ERROR ... second when-end result differs from final when-end result")
+
+if t >= first_when_end_result:
+    failed("ERROR ... First when result was after when-end")
+if t3 >= first_when_end_result:
+    failed("ERROR ... Second when result was after when-end")
+if t3 >= first_when_end_result:
+    failed("ERROR ... Third when result was after when-end")
 
 ok()


### PR DESCRIPTION
when-end gives the event number of the last event in the whole recording.

This is useful when running a replay with non-stopping breakpoints and displaying the "progress" of the replay to the user.

I'm not actually sure if `result.type() == TraceTaskEvent::Type::NONE` is an idiomatic way to see if the `read_task_event` call returned the "default value" of that type. But it does at least seem to work in the cases I've tested.