### PR TITLE
"info recording" command that gives the path to the recording

### DIFF
--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -4,6 +4,7 @@
 
 #include "ReplayTask.h"
 #include "log.h"
+#include "util.h"
 
 using namespace std;
 
@@ -54,6 +55,17 @@ static SimpleDebuggerExtensionCommand when_tid(
         return DebuggerExtensionCommandHandler::cmd_end_diversion();
       }
       return string("Current tid: ") + to_string(t->tid);
+    });
+
+static SimpleDebuggerExtensionCommand info_recording(
+    "info recording",
+    "Print the path of the recording RR is"
+    " currently replaying.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      auto task = static_cast<ReplayTask*>(t);
+      auto trace_dir = task->session().as_replay()->trace_reader().dir();
+
+      return string("Path of recording: \"") + json_escape(trace_dir) + string("\"");
     });
 
 static std::vector<ReplayTimeline::Mark> back_stack;

--- a/src/test/info_recording.py
+++ b/src/test/info_recording.py
@@ -1,0 +1,19 @@
+from util import *
+
+import re
+import json
+
+send_gdb('info recording')
+expect_gdb(re.compile(r'(?<=Path of recording: ).*'))
+path_jsonstr = last_match().group(0)
+path_pystr   = json.loads(path_jsonstr)
+
+if len(path_pystr) < 6:
+    failed("ERROR ... Unreasonably short path for recording file found in output")
+
+# Inferior command also has the name of the binary at the end,
+# so the pattern matches opening but not closing paren.
+send_gdb("inferior")
+expect_gdb(f"\\({path_pystr}")
+
+ok()

--- a/src/test/info_recording.run
+++ b/src/test/info_recording.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record simple$bitness
+debug info_recording


### PR DESCRIPTION
info recording prints out the path of the recording folder.

This is useful for running additional rr replay sessions from an existing one, or for calling rr dump to get data that is not otherwise surfaced by any gdb commands.