### PR TITLE
Add command "absolute-time" to get value of monotonic clock

### DIFF
--- a/src/DebuggerExtensionCommand.cc
+++ b/src/DebuggerExtensionCommand.cc
@@ -3,6 +3,7 @@
 #include "DebuggerExtensionCommand.h"
 
 #include "ReplayTask.h"
+#include "TraceFrame.h"
 #include "log.h"
 
 using namespace std;
@@ -23,6 +24,17 @@ static SimpleDebuggerExtensionCommand elapsed_time(
                             replay_t->session().get_trace_start_time();
 
       return string("Elapsed Time (s): ") + to_string(elapsed_time);
+    });
+
+static SimpleDebuggerExtensionCommand absolute_time(
+    "absolute-time",
+    "Print absolute time (in seconds) from the monotonic clock in the"
+    " 'record' timeline.",
+    [](GdbServer&, Task* t, const vector<string>&) {
+      auto replay_t = static_cast<ReplayTask*>(t);
+      auto elapsed_time = replay_t->current_trace_frame().monotonic_time();
+
+      return string("Absolute Time (s): ") + to_string(elapsed_time);
     });
 
 static SimpleDebuggerExtensionCommand when(

--- a/src/test/elapsed_time.py
+++ b/src/test/elapsed_time.py
@@ -1,5 +1,24 @@
+import time
+
 from util import *
 import re
+
+# Get monotonic timer value from right now
+monotonic_start = time.monotonic()
+
+send_gdb("absolute-time")
+expect_gdb(re.compile(r'(?<=Absolute Time \(s\): )[0-9.]+'))
+absolute_time_start = float(last_match().group(0))
+
+if absolute_time_start > monotonic_start:
+    failed("ERROR ... The reported monotonic time at the start was after the test script started")
+if absolute_time_start < monotonic_start - 300:
+    failed("ERROR ... The reported monotonic time at the start was over five minutes before the test script started")
+
+send_gdb('elapsed-time')
+
+expect_gdb(re.compile(r'(?<=Elapsed Time \(s\): )[0-9.]+'))
+elapsed_start = float(last_match().group(0))
 
 # Test that the elapsed-time GDB command returns a time >= 1.0 at a breakpoint
 # after sleep(1);
@@ -17,5 +36,15 @@ sleep_time = 1.0
 if elapsed_time < sleep_time:
     failed('ERROR ... The reported elapsed time after sleeping for ' +
            f'{sleep_time} (s) was {elapsed_time}')
+
+send_gdb("absolute-time")
+expect_gdb(re.compile(r'(?<=Absolute Time \(s\): )[0-9.]+'))
+absolute_time_end = float(last_match().group(0))
+
+sleep_time_absolute = absolute_time_end - absolute_time_start
+sleep_time_relative = elapsed_time - elapsed_start
+
+if abs(sleep_time_absolute - sleep_time_relative) > 0.0001:
+    failed(f"ERROR ... The sleep time reported by absolute-time vs elapsed-time was too far apart (should be as equal as double allows): {sleep_time_absolute} - {sleep_time_relative} = {sleep_time_absolute - sleep_time_relative}" )
 
 ok()


### PR DESCRIPTION
absolute-time gives the absolute monotonic clock time from the current event.

This is useful when you want to align events with a perf recording that also uses the monotonic clock (you still have to scale by 1000000000 of course.)