### PR TITLE
Introduce `rr dump --json`, dump trace in JSONL, one object per line

### DIFF
--- a/src/DumpCommand.cc
+++ b/src/DumpCommand.cc
@@ -10,6 +10,7 @@
 #include <limits>
 #include <unordered_map>
 
+#include "Event.h"
 #include "preload/preload_interface.h"
 
 #include "AddressSpace.h"
@@ -24,6 +25,27 @@
 using namespace std;
 
 namespace rr {
+
+struct JsonArrayAtKeyWriter {
+  public:
+  bool key_written = false;
+  bool write_comma = false;
+
+  void ensure_key(FILE *out, const char *key) {
+    if (!key_written) {
+      key_written = true;
+      fprintf(out, ", \"%s\": [", key);
+    }
+  };
+
+  void maybe_comma(FILE *out) {
+    if (!write_comma) {
+      write_comma = true;
+    } else {
+      fprintf(out, ", ");
+    }
+  };
+};
 
 class DumpCommand : public Command {
 public:
@@ -45,9 +67,12 @@ DumpCommand DumpCommand::singleton(
     "  -e, --task-events          dump task events\n"
     "  -m, --recorded-metadata    dump recorded data metadata\n"
     "  -p, --mmaps                dump mmap data\n"
+    "  -R, --no-regs              skip dumping register values\n"
     "  -r, --raw                  dump trace frames in a more easily\n"
     "                             machine-parseable format instead of the\n"
     "                             default human-readable format\n"
+    "  -j, --json                 dump trace frames in jsonl, i.e. one\n"
+    "                             json object per line\n"
     "  -s, --statistics           dump statistics about the trace\n"
     "  -t, --tid=<pid>            dump events only for the specified tid\n");
 
@@ -62,7 +87,9 @@ static bool parse_dump_arg(vector<string>& args, DumpFlags& flags) {
     { 'e', "task-events", NO_PARAMETER },
     { 'm', "recorded-metadata", NO_PARAMETER },
     { 'p', "mmaps", NO_PARAMETER },
+    { 'R', "no-regs", NO_PARAMETER },
     { 'r', "raw", NO_PARAMETER },
+    { 'j', "json", NO_PARAMETER },
     { 's', "statistics", NO_PARAMETER },
     { 't', "tid", HAS_PARAMETER },
   };
@@ -84,8 +111,14 @@ static bool parse_dump_arg(vector<string>& args, DumpFlags& flags) {
     case 'p':
       flags.dump_mmaps = true;
       break;
+    case 'R':
+      flags.dump_no_regs = true;
+      break;
     case 'r':
       flags.raw_dump = true;
+      break;
+    case 'j':
+      flags.json_dump = true;
       break;
     case 's':
       flags.dump_statistics = true;
@@ -122,47 +155,84 @@ static void dump_syscallbuf_data(TraceReader& trace, FILE* out,
     CLEAN_FATAL() << "Malformed trace file (bad recorded-bytes count)";
   }
   if (flags.raw_dump) {
-    fprintf(out, "  ");
-    for (unsigned long i = 0; i < sizeof(syscallbuf_hdr); ++i) {
-      fprintf(out, "%2.2x", *(buf.data.data() + (uintptr_t)i));
+    char hdr_out[sizeof(syscallbuf_hdr) * 2 + 1];
+    write_hex_string(buf.data.data(), sizeof(syscallbuf_hdr), hdr_out, sizeof(hdr_out));
+    if (flags.json_dump) {
+      fprintf(out, ", \"syscallbuf_flush_raw\": \"%s\"", hdr_out);
+    } else {
+      fprintf(out, "  %s\n", hdr_out);
     }
-    fprintf(out, "\n");
   }
   bytes_remaining = flush_hdr->num_rec_bytes;
+
+  JsonArrayAtKeyWriter key_writer = {};
 
   auto record_ptr = reinterpret_cast<const uint8_t*>(flush_hdr) + trace.syscallbuf_hdr_size();
   auto end_ptr = record_ptr + bytes_remaining;
   while (record_ptr < end_ptr) {
     auto record = reinterpret_cast<const struct syscallbuf_record*>(record_ptr);
     // Buffered syscalls always use the task arch
-    fprintf(out, "  { syscall:'%s', ret:0x%lx, size:0x%lx%s%s }\n",
-            syscall_name(record->syscallno, frame.regs().arch()).c_str(),
-            (long)record->ret, (long)record->size,
-            record->desched ? ", desched:1" : "",
-            record->replay_assist ? ", replay_assist:1" : "");
+    if (flags.json_dump) {
+      key_writer.ensure_key(out, "syscalls");
+      key_writer.maybe_comma(out);
+      fprintf(out, "{ \"syscall\":\"%s\", \"ret\":%ld, \"size\":%ld%s%s ",
+              syscall_name(record->syscallno, frame.regs().arch()).c_str(),
+              (long)record->ret, (long)record->size,
+              record->desched ? ", \"desched\":1" : "",
+              record->replay_assist ? ", \"replay_assist\":1" : "");
+    } else {
+      fprintf(out, "  { syscall:'%s', ret:0x%lx, size:0x%lx%s%s }\n",
+              syscall_name(record->syscallno, frame.regs().arch()).c_str(),
+              (long)record->ret, (long)record->size,
+              record->desched ? ", desched:1" : "",
+              record->replay_assist ? ", replay_assist:1" : "");
+    }
     if (flags.raw_dump) {
-      fprintf(out, "  ");
-      for (unsigned long i = 0; i < record->size; ++i) {
-        fprintf(out, "%2.2x", *(record_ptr + (uintptr_t)i));
+      auto record_out = std::vector<char>();
+      record_out.resize(record->size * 2 + 1);
+      write_hex_string(record_ptr, record->size, record_out.data(), record_out.size());
+      if (flags.json_dump) {
+        fprintf(out, ", \"raw\": \"%s\"", record_out.data());
+      } else {
+        fprintf(out, "  %s\n", record_out.data());
       }
-      fprintf(out, "\n");
+    }
+    if (flags.json_dump) {
+      fprintf(out, "}");
     }
     if (record->size < sizeof(*record)) {
       CLEAN_FATAL() << "Malformed trace file (bad record size)";
     }
     record_ptr += stored_record_size(record->size);
   }
+  if (key_writer.key_written) {
+    fprintf(out, "]");
+  }
   if (flags.dump_mmaps) {
+    JsonArrayAtKeyWriter mmaps_key = {};
     for (auto& record : frame.event().SyscallbufFlush().mprotect_records) {
-      fprintf(out, "  { start:%p, size:%" PRIx64 ", prot:'%s' }\n",
-              (void*)record.start, record.size, prot_flags_string(record.prot).c_str());
-      if (flags.raw_dump) {
-        fprintf(out, "  ");
-        for (unsigned long i = 0; i < sizeof(record); ++i) {
-          fprintf(out, "%2.2x", *(reinterpret_cast<const uint8_t*>(&record) + (uintptr_t)i));
-        }
-        fprintf(out, "\n");
+      if (flags.json_dump) {
+        mmaps_key.ensure_key(out, "mmaps");
+        mmaps_key.maybe_comma(out);
+        fprintf(out, "{ \"start\":%ld, \"size\":%" PRIx64 ", \"prot\":\"%s\"",
+                record.start, record.size, prot_flags_string(record.prot).c_str());
+      } else {
+        fprintf(out, "  { start:%p, size:%" PRIx64 ", prot:'%s' }\n",
+                (void*)record.start, record.size, prot_flags_string(record.prot).c_str());
       }
+      if (flags.raw_dump) {
+        char rec_out[sizeof(record) * 2 + 1];
+        write_hex_string(reinterpret_cast<const uint8_t*>(&record), sizeof(record), rec_out, sizeof(rec_out));
+        if (flags.json_dump) {
+          fprintf(out, ", \"raw\": \"%s\"", rec_out);
+        } else {
+          fprintf(out, "  %s\n", rec_out);
+        }
+      }
+      fprintf(out, "}");
+    }
+    if (mmaps_key.key_written) {
+      fprintf(out, "]");
     }
   }
 }
@@ -210,6 +280,21 @@ static void dump_socket_addrs(FILE* out, const TraceFrame& frame) {
   }
 }
 
+static void dump_frame_json(FILE *out, const TraceFrame &frame, const DumpFlags &flags) {
+  fprintf(out, "{ \"real_time\":%f, \"global_time\":%lld, \"tid\":%d, \"event\":\"%s\", \"ticks\": %ld",
+          frame.monotonic_time(), (long long)frame.time(),
+          frame.tid(), frame.event().str().c_str(),
+          frame.ticks());
+  if (frame.event().is_syscall_event()) {
+    fprintf(out, ", \"state\": \"%s\"",
+            state_name(frame.event().Syscall().state));
+  }
+  if (!flags.dump_no_regs && frame.event().record_regs()) {
+    fprintf(out, ", ");
+    frame.regs().print_register_file_json(out);
+  }
+}
+
 static void dump_task_event(FILE* out, const TraceTaskEvent& event) {
   switch (event.type()) {
     case TraceTaskEvent::CLONE:
@@ -233,6 +318,29 @@ static void dump_task_event(FILE* out, const TraceTaskEvent& event) {
   }
 }
 
+static void dump_task_event_json(FILE* out, const TraceTaskEvent& event) {
+  switch (event.type()) {
+    case TraceTaskEvent::CLONE:
+      fprintf(out, "{ \"event\":\"CLONE\", \"tid\":%d, \"parent\":%d, \"clone_flags\":%d }",
+          event.tid(), event.parent_tid(), event.clone_flags());
+      break;
+    case TraceTaskEvent::EXEC:
+      fprintf(out, "{ \"event\":\"EXEC\", \"tid\":%d, \"file\":\"%s\" }",
+          event.tid(), json_escape(event.file_name()).c_str());
+      break;
+    case TraceTaskEvent::EXIT:
+      fprintf(out, "{ \"event\":\"EXIT\", \"tid\":%d, \"status\":%d }",
+          event.tid(), event.exit_status().get());
+      break;
+    case TraceTaskEvent::DETACH:
+      fprintf(out, "{ \"event\":\"DETACH\", \"tid\":%d }",
+          event.tid());
+      break;
+    default:
+      FATAL() << "Unknown TraceTaskEvent";
+      break;
+  }
+}
 /**
  * Dump all events from the current to trace that match |spec| to
  * |out|.  |spec| has the following syntax: /\d+(-\d+)?/, expressing
@@ -273,21 +381,42 @@ static void dump_events_matching(TraceReader& trace, const DumpFlags& flags,
     if (only_end ? trace.at_end() :
          (start <= frame.time() && frame.time() <= end &&
            (!flags.only_tid || flags.only_tid == frame.tid()))) {
-      if (flags.raw_dump) {
-        frame.dump_raw(out);
+      if (flags.json_dump) {
+        JsonArrayAtKeyWriter task_event_key_writer = {};
+        dump_frame_json(out, frame, flags);
+
+        if (flags.dump_syscallbuf) {
+          dump_syscallbuf_data(trace, out, frame, flags);
+        }
+        if (flags.dump_task_events) {
+          auto range = task_events.equal_range(frame.time());
+          for (auto it = range.first; it != range.second; ++it) {
+            task_event_key_writer.ensure_key(out, "task_events");
+            task_event_key_writer.maybe_comma(out);
+            dump_task_event_json(out, it->second);
+          }
+          if (task_event_key_writer.key_written) {
+            fprintf(out, "]");
+          }
+        }
       } else {
-        frame.dump(out);
-      }
-      if (flags.dump_syscallbuf) {
-        dump_syscallbuf_data(trace, out, frame, flags);
-      }
-      if (flags.dump_task_events) {
-        auto range = task_events.equal_range(frame.time());
-        for (auto it = range.first; it != range.second; ++it) {
-          dump_task_event(out, it->second);
+        if (flags.raw_dump) {
+          frame.dump_raw(out, !flags.dump_no_regs);
+        } else {
+          frame.dump(out, !flags.dump_no_regs);
+        }
+        if (flags.dump_syscallbuf) {
+          dump_syscallbuf_data(trace, out, frame, flags);
+        }
+        if (flags.dump_task_events) {
+          auto range = task_events.equal_range(frame.time());
+          for (auto it = range.first; it != range.second; ++it) {
+            dump_task_event(out, it->second);
+          }
         }
       }
 
+      JsonArrayAtKeyWriter key_writer = {};
       while (true) {
         TraceReader::MappedData data;
         bool found;
@@ -310,48 +439,87 @@ static void dump_events_matching(TraceReader& trace, const DumpFlags& flags,
           if (km.flags() & MAP_SHARED) {
             prot_flags[3] = 's';
           }
-          const char* fsname = km.fsname().c_str();
+          std::string fsname;
           if (data.source == TraceReader::SOURCE_ZERO) {
-            static const char source_zero[] = "<ZERO>";
-            fsname = source_zero;
+            fsname = "<ZERO>";
           }
-          fprintf(out, "  { map_file:\"%s\", addr:%p, length:%p, "
-                       "prot_flags:\"%s\", file_offset:0x%llx, "
-                       "device:%lld, inode:%lld, "
-                       "data_file:\"%s\", data_offset:0x%llx, "
-                       "file_size:0x%llx }\n",
-                  fsname, (void*)km.start().as_int(), (void*)km.size(),
-                  prot_flags, (long long)km.file_offset_bytes(),
-                  (long long)km.device(), (long long)km.inode(),
-                  data.file_name.c_str(), (long long)data.data_offset_bytes,
-                  (long long)data.file_size_bytes);
+          else {
+            fsname = km.fsname();
+          }
+
+          if (flags.json_dump) {
+            key_writer.ensure_key(out, "maps");
+            key_writer.maybe_comma(out);
+            fprintf(out, "{ \"map_file\":\"%s\", \"addr\": %lu, "
+                         "\"length\": %lu, \"prot_flags\": \"%s\", "
+                         "\"file_offset\": %lld, \"device\": %lld, "
+                         "\"inode\": %lld, \"data_file\": \"%s\", "
+                         "\"data_offset\": %lld, \"file_size\": %lld }",
+                    json_escape(fsname).c_str(), km.start().as_int(), km.size(),
+                    prot_flags, (long long)km.file_offset_bytes(),
+                    (long long)km.device(), (long long)km.inode(),
+                    json_escape(data.file_name).c_str(),
+                    (long long)data.data_offset_bytes,
+                    (long long)data.file_size_bytes);
+          } else {
+            fprintf(out, "  { map_file:\"%s\", addr:%p, length:%p, "
+                         "prot_flags:\"%s\", file_offset:0x%llx, "
+                         "device:%lld, inode:%lld, "
+                         "data_file:\"%s\", data_offset:0x%llx, "
+                         "file_size:0x%llx }\n",
+                    fsname.c_str(), (void*)km.start().as_int(), (void*)km.size(),
+                    prot_flags, (long long)km.file_offset_bytes(),
+                    (long long)km.device(), (long long)km.inode(),
+                    data.file_name.c_str(), (long long)data.data_offset_bytes,
+                    (long long)data.file_size_bytes);
+          }
         }
+      }
+      if (flags.json_dump && key_writer.key_written) {
+        fprintf(out, " ]");
       }
 
       TraceReader::RawDataMetadata data;
       while (process_raw_data && trace.read_raw_data_metadata_for_frame(data)) {
         if (flags.dump_recorded_data_metadata) {
-          fprintf(out, "  { tid:%d, addr:%p, length:%p", data.rec_tid,
-                  (void*)data.addr.as_int(), (void*)data.size);
+          if (flags.json_dump) {
+            fprintf(out, ", \"metadata\": { \"tid\":%d, \"addr\":%ld, \"length\":%ld",
+                    data.rec_tid, data.addr.as_int(), data.size);
+          } else {
+            fprintf(out, " { tid:%d, addr:%p, length:%p", data.rec_tid,
+                    (void*)data.addr.as_int(), (void*)data.size);
+          }
           if (!data.holes.empty()) {
-            fputs(", holes:[", out);
+            if (flags.json_dump) {
+              fputs(", \"holes\":[", out);
+            } else {
+              fputs(", holes:[", out);
+            }
             bool first = true;
             for (auto& h : data.holes) {
               if (!first) {
                 fputs(", ", out);
               }
               first = false;
-              fprintf(out, "%p-%p", (void*)h.offset, (void*)(h.offset + h.size));
+              if (flags.json_dump) {
+                fprintf(out, "\"%p-%p\"", (void*)h.offset, (void*)(h.offset + h.size));
+              } else {
+                fprintf(out, "%p-%p", (void*)h.offset, (void*)(h.offset + h.size));
+              }
             }
             fputs("]", out);
           }
-          fputs(" }\n", out);
+          if (flags.json_dump) {
+            fputs(" }", out);
+          } else {
+            fputs(" }\n", out);
+          }
         }
       }
       if (flags.dump_socket_addrs) {
         dump_socket_addrs(out, frame);
       }
-      if (!flags.raw_dump) {
+      if (!flags.raw_dump || flags.json_dump) {
         fprintf(out, "}\n");
       }
     } else {
@@ -382,7 +550,7 @@ void dump(const string& trace_dir, const DumpFlags& flags,
           const vector<string>& specs, FILE* out) {
   TraceReader trace(trace_dir);
 
-  if (flags.raw_dump) {
+  if (flags.raw_dump && !flags.json_dump) {
     fprintf(out, "global_time tid reason ticks "
                  "hw_interrupts page_faults instructions "
                  "eax ebx ecx edx esi edi ebp orig_eax esp eip eflags\n");

--- a/src/DumpCommand.h
+++ b/src/DumpCommand.h
@@ -20,7 +20,9 @@ struct DumpFlags {
   bool dump_recorded_data_metadata;
   bool dump_mmaps;
   bool dump_task_events;
+  bool dump_no_regs;
   bool raw_dump;
+  bool json_dump;
   bool dump_statistics;
   bool dump_socket_addrs;
   int only_tid;
@@ -30,7 +32,9 @@ struct DumpFlags {
         dump_recorded_data_metadata(false),
         dump_mmaps(false),
         dump_task_events(false),
+        dump_no_regs(false),
         raw_dump(false),
+        json_dump(false),
         dump_statistics(false),
         dump_socket_addrs(false),
         only_tid(0) {}

--- a/src/GdbServerConnection.cc
+++ b/src/GdbServerConnection.cc
@@ -35,6 +35,7 @@
 #include "core.h"
 #include "kernel_supplement.h"
 #include "log.h"
+#include "util.h"
 
 using namespace std;
 
@@ -237,21 +238,6 @@ static void parser_assert(bool cond) {
     DEBUG_ASSERT(false);
     exit(2);
   }
-}
-
-/**
- * For the first |input_len| bytes in |input|, append two characters to |buf| as if
- * snprintf("%02x") would, then write a zero terminator.
- */
-static void write_hex_string(const uint8_t* input, size_t input_len,
-                             char* buf, size_t buf_len) {
-  static constexpr char hex_string_table[] = "0123456789abcdef";
-  parser_assert(buf_len >= 2 * input_len + 1);
-  for (size_t i = 0; i < input_len; ++i) {
-    buf[2 * i + 0] = hex_string_table[input[i] >> 4];
-    buf[2 * i + 1] = hex_string_table[input[i] & 0xf];
-  }
-  buf[2 * input_len] = '\0';
 }
 
 static string string_to_hex(const string& s) {

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -193,7 +193,7 @@ RegisterInfo<rr::ARM64Arch>::Table RegisterInfo<rr::ARM64Arch>::registers = {
 // 32-bit format, 64-bit format for all of these.
 // format_index in RegisterPrinting depends on the ordering here.
 static const char* hex_format_leading_0x[] = { "0x%" PRIx32, "0x%" PRIx64 };
-// static const char* decimal_format[] = { "%" PRId32, "%" PRId64 };
+static const char* decimal_format[] = { "%" PRId32, "%" PRId64 };
 
 template <size_t nbytes> struct RegisterPrinting;
 
@@ -217,6 +217,18 @@ void print_single_register(FILE* f, const char* name, const void* register_ptr,
   } else {
     fprintf(f, " ");
   }
+  fprintf(f, formats[RegisterPrinting<nbytes>::format_index], val);
+}
+
+template <size_t nbytes>
+void print_single_register_json(FILE* f, const char* name, const void* register_ptr,
+                           const char* formats[]) {
+  typename RegisterPrinting<nbytes>::type val;
+  memcpy(&val, register_ptr, nbytes);
+  if (name == 0)
+    FATAL() << "Can't dump a register to json without a name";
+
+  fprintf(f, "\"%s\":", name);
   fprintf(f, formats[RegisterPrinting<nbytes>::format_index], val);
 }
 
@@ -247,6 +259,36 @@ void Registers::print_register_file_arch(FILE* f, const char* formats[]) const {
 
 void Registers::print_register_file(FILE* f) const {
   RR_ARCH_FUNCTION(print_register_file_arch, arch(), f, hex_format_leading_0x);
+}
+
+template <typename Arch>
+void Registers::print_register_file_json_arch(FILE* f) const {
+  const void* user_regs = &u;
+  bool write_comma = false;
+  fprintf(f, "\"regs\": { ");
+  for (auto& rv : RegisterInfo<Arch>::registers) {
+    if (rv.nbytes == 0) {
+      continue;
+    }
+    if (!write_comma) {
+      write_comma = true;
+    } else {
+      fprintf(f, ", ");
+    }
+    switch (rv.nbytes) {
+      case 8:
+        print_single_register_json<8>(f, rv.name, rv.pointer_into(user_regs),
+                                 decimal_format);
+        break;
+      case 4:
+        print_single_register_json<4>(f, rv.name, rv.pointer_into(user_regs),
+                                 decimal_format);
+        break;
+      default:
+        DEBUG_ASSERT(0 && "bad register size");
+    }
+  }
+  fprintf(f, " }");
 }
 
 template <typename Arch>
@@ -281,6 +323,10 @@ void Registers::print_register_file_for_trace_arch(
 void Registers::print_register_file_compact(FILE* f) const {
   RR_ARCH_FUNCTION(print_register_file_for_trace_arch, arch(), f, Annotated,
                    hex_format_leading_0x);
+}
+
+void Registers::print_register_file_json(FILE* f) const {
+  RR_ARCH_FUNCTION(print_register_file_json_arch, arch(), f);
 }
 
 void Registers::print_register_file_for_trace_raw(FILE* f) const {

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -444,6 +444,7 @@ public:
 
   void print_register_file(FILE* f) const;
   void print_register_file_compact(FILE* f) const;
+  void print_register_file_json(FILE* f) const;
   void print_register_file_for_trace_raw(FILE* f) const;
 
   struct Mismatch {
@@ -536,6 +537,9 @@ public:
 private:
   template <typename Arch>
   void print_register_file_arch(FILE* f, const char* formats[]) const;
+
+  template <typename Arch>
+  void print_register_file_json_arch(FILE* f) const;
 
   enum TraceStyle {
     Annotated,

--- a/src/TraceFrame.cc
+++ b/src/TraceFrame.cc
@@ -17,7 +17,7 @@ TraceFrame::TraceFrame(FrameTime global_time, pid_t tid, const Event& event,
       ticks_(tick_count),
       monotonic_time_(monotonic_time ? monotonic_time : monotonic_now_sec()) {}
 
-void TraceFrame::dump(FILE* out) const {
+void TraceFrame::dump(FILE* out, bool dump_registers) const {
   out = out ? out : stdout;
 
   fprintf(out, "{\n  real_time:%f global_time:%llu, event:`%s' ",
@@ -26,7 +26,7 @@ void TraceFrame::dump(FILE* out) const {
     fprintf(out, "(state:%s) ", state_name(event().Syscall().state));
   }
   fprintf(out, "tid:%d, ticks:%" PRId64 "\n", tid(), ticks());
-  if (!event().record_regs()) {
+  if (!event().record_regs() || !dump_registers) {
     return;
   }
 
@@ -38,12 +38,12 @@ void TraceFrame::dump(FILE* out) const {
   fprintf(out, "\n");
 }
 
-void TraceFrame::dump_raw(FILE* out) const {
+void TraceFrame::dump_raw(FILE* out, bool dump_registers) const {
   out = out ? out : stdout;
 
   fprintf(out, " %lld %d %d %" PRId64, (long long)time(), tid(), event().type(),
           ticks());
-  if (!event().record_regs()) {
+  if (!event().record_regs() || !dump_registers) {
     fprintf(out, "\n");
     return;
   }

--- a/src/TraceFrame.h
+++ b/src/TraceFrame.h
@@ -49,13 +49,13 @@ public:
    * A human-friendly format is used. Does not emit a trailing '}'
    * (so the caller can add more fields to the record).
    */
-  void dump(FILE* out = nullptr) const;
+  void dump(FILE* out = nullptr, bool dump_registers = true) const;
   /**
    * Log a human-readable representation of this to |out|
    * (defaulting to stdout), including a newline character.  An
    * easily machine-parseable format is dumped.
    */
-  void dump_raw(FILE* out = nullptr) const;
+  void dump_raw(FILE* out = nullptr, bool dump_registers = true) const;
 
 private:
   friend class TraceReader;

--- a/src/util.cc
+++ b/src/util.cc
@@ -2451,6 +2451,17 @@ size_t word_size(SupportedArch arch) {
   RR_ARCH_FUNCTION(word_size_arch, arch);
 }
 
+void write_hex_string(const uint8_t* input, size_t input_len,
+                             char* buf, size_t buf_len) {
+  static constexpr char hex_string_table[] = "0123456789abcdef";
+  DEBUG_ASSERT(buf_len >= 2 * input_len + 1);
+  for (size_t i = 0; i < input_len; ++i) {
+    buf[2 * i + 0] = hex_string_table[input[i] >> 4];
+    buf[2 * i + 1] = hex_string_table[input[i] & 0xf];
+  }
+  buf[2 * input_len] = '\0';
+}
+
 string json_escape(const string& str, size_t pos) {
   string out;
   for (size_t i = pos; i < str.size(); ++i) {

--- a/src/util.h
+++ b/src/util.h
@@ -599,6 +599,13 @@ void restore_initial_resource_limits();
 size_t word_size(SupportedArch arch);
 
 /**
+ * For the first |input_len| bytes in |input|, append two characters to |buf|
+ * as snprintf("%02x") would, then write a zero terminator.
+ */
+void write_hex_string(const uint8_t* input, size_t input_len,
+                             char* buf, size_t buf_len);
+
+/**
  * Print JSON-escaped version of the string, including double-quotes.
  */
 std::string json_escape(const std::string& str, size_t pos = 0);


### PR DESCRIPTION
Combines with some of the other flags:
* `--syscallbuf` adds a `syscalls` key
* `--mmaps` adds a `maps` key
* `--task_events` adds a `task_events` key`
* `--recorded-metadata` adds a `metadata` key

Furthermore, also passing `--raw` will add extra output to some of the above:
* `syscallbuf_flush_raw` key with the header of a syscallbuf flush
* `raw` key with the syscall data for each syscall
* `raw` key with mmap record data to mmaps entries

On top of all that, a `--no-regs` flag is introduced that skips outputting
register values in the regular, the raw, or the json output.

This also moves write_hex_string from being a static function inside
GdbServerConnection to live in src/util.cc instead.

Here's some example output:

https://gist.github.com/timo/d6dd3b2762d78a9ee468b3cb554fa6b9

Open questions:

* Currently, some functions are duplicated as a _json variant, some functions check `flags.json_dump` in-line. Is there a preference?
* The current dump function ignores when `frame.event().record_extra_regs()` is true; do we care about that?
* The initial thing that caused me (well, really dzaima) to look into the code in the first place was that the header of `--raw` still has three entries in it that correspond to field that are not being output any more. Is that for a separate pull request, or fine to include here?
* The help for the command says that `--raw` outputs in a different format, and `--json` makes the same claim, so it's not obvious that they can be combined. The current behaviour of `--raw` and `--json` together may want to get a different flag and then `--raw` could conflict with `--json`
  * there could instead be a `--format=raw`/`--format=json` option instead? though a short flag for json would be nice